### PR TITLE
Add SSH key for user

### DIFF
--- a/gitlab.py
+++ b/gitlab.py
@@ -549,6 +549,15 @@ class User(GitlabObject):
                            'extern_uid', 'provider', 'bio']
 
 
+class UserKey(GitlabObject):
+    _url = '/users/%(user_id)s/keys'
+    canGet = False
+    canList = False
+    canUpdate = False
+    canDelete = False
+    requiredCreateAttrs = ['user_id', 'title', 'key']
+
+
 class CurrentUserKey(GitlabObject):
     _url = '/user/keys'
     canUpdate = False


### PR DESCRIPTION
This allows an admin to create a new key owned by specified user. See [GitLab users API](https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/users.md).
