### PR TITLE
Fixed encoding error while piped output

### DIFF
--- a/gitlab.py
+++ b/gitlab.py
@@ -574,7 +574,11 @@ class GitlabObject(object):
             s = ", ".join([GitlabObject._obj_to_str(x) for x in obj])
             return "[ %s ]" % s
         elif isinstance(obj, unicode):
-            return obj.encode(sys.stdout.encoding, "replace")
+            if sys.stdout.encoding is None:
+                return obj.encode(sys.getdefaultencoding(), "replace")
+            else:
+                return obj.encode(sys.stdout.encoding, "replace")
+
         else:
             return str(obj)
 
@@ -585,8 +589,14 @@ class GitlabObject(object):
             if k == self.idAttr:
                 continue
             v = self.__dict__[k]
-            pretty_k = k.replace('_', '-').encode(sys.stdout.encoding,
-                                                  "replace")
+           
+            if sys.stdout.encoding is None:
+                pretty_k = k.replace('_','-').encode(sys.getdefaultencoding(),
+                                                     "replace")
+            else:
+                pretty_k = k.replace('_', '-').encode(sys.stdout.encoding,
+                                                      "replace")
+
             if isinstance(v, GitlabObject):
                 if depth == 0:
                     print("%s:" % pretty_k)


### PR DESCRIPTION
If a ran python-gitlab with the -v option piping to another process
was not possible. This was due to the fact that sys.stdout.encoding
was set to None.
The problem is solved if the default encoding is used instead of 
sys.stdout.encoding if it is set to None.

Here the Traceback:
    Traceback (most recent call last):
      File "/usr/bin/gitlab", line 5, in <module>
        pkg_resources.run_script('python-gitlab==0.6', 'gitlab')
      File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 528, in run_script
        self.require(requires)[0].run_script(script_name, ns)
      File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 1401, in run_script
        exec(script_code, namespace, namespace)
      File "/usr/lib/python2.7/site-packages/python_gitlab-0.6-py2.7.egg/EGG-INFO/scripts/gitlab", line 337, in <module>

```
  File "build/bdist.linux-x86_64/egg/gitlab.py", line 554, in display
  File "build/bdist.linux-x86_64/egg/gitlab.py", line 589, in pretty_print
TypeError: encode() argument 1 must be string, not None
```
