### PR TITLE
refactor "_sanitize" for Python < 2.7

### DIFF
--- a/gitlab.py
+++ b/gitlab.py
@@ -468,7 +468,7 @@ def _sanitize(value):
 
 
 def _sanitize_dict(src):
-    return {k: _sanitize(v) for k, v in src.items()}
+    return dict((k, _sanitize(v)) for k, v in src.items())
 
 
 class GitlabObject(object):


### PR DESCRIPTION
I have a python2.6 project which I'd like to use this on, so it does not handle dictionary comprehensions. I believe this patch would make it compatible for Python 2.6+. 
