### PR TITLE
Support api-objects which don't have id in api response.

### DIFF
--- a/gitlab.py
+++ b/gitlab.py
@@ -222,12 +222,13 @@ class Gitlab(object):
             if obj_class._returnClass:
                 cls = obj_class._returnClass
 
+            cls_kwargs = kwargs.copy()
+
             # Add _created manually, because we are not creating objects
             # through normal path
             cls_kwargs['_created'] = True
 
             # Remove parameters from kwargs before passing it to constructor
-            cls_kwargs = kwargs.copy()
             for key in ['page', 'per_page']:
                 if key in cls_kwargs:
                     del cls_kwargs[key]


### PR DESCRIPTION
In gitlab api Repository File and Label objects don't use **id** on get, post, put or delete. File uses url ending with /files for all operations and Label uses /label.
**_created** boolean is used to distinguish between create and update instead of presense of id.

In addition to that Label returns list with get and File returns object. **getListWhenNoId** boolean is used to distinguish between them.
