### PR TITLE
Add initial support for manipulation of LDAP links

### DIFF
--- a/docs/gl_objects/groups.py
+++ b/docs/gl_objects/groups.py
@@ -64,3 +64,24 @@ group.members.delete(member_id)
 # or
 member.delete()
 # end member delete
+
+# ldap sync list
+group.ldap_group_links
+# end ldap sync list
+
+# ldap sync create
+gl.group_ldap_links.create({'cn': 'some_ldap_group_name',
+                             'provider': 'ldapmain', 'group_access': 50},
+                            group_id=1)
+# or
+group.ldaplinks.create({'cn': 'some_ldap_group_name',
+                             'provider': 'ldapmain', 'group_access': 50})
+# end ldap sync create
+
+# ldap sync delete
+gl.group_ldap_links.delete('some_ldap_group_name', group_id=1)
+# or
+group.ldaplinks.delete('some_ldap_group_name')
+# or
+ldaplink.delete()
+# end ldap sync delete

--- a/docs/gl_objects/groups.rst
+++ b/docs/gl_objects/groups.rst
@@ -109,3 +109,15 @@ Remove a member from the group:
 .. literalinclude:: groups.py
    :start-after: # member delete
    :end-before: # end member delete
+
+Add an LDAP group for synchronization:
+
+.. literalinclude:: groups.py
+   :start-after: # ldap sync create
+   :end-before: # end ldap sync create
+
+Remove an LDAP group for synchronization:
+
+.. literalinclude:: groups.py
+   :start-after: # ldap sync delete
+   :end-before: # end ldap sync delete

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -528,7 +528,7 @@ class Gitlab(object):
             if k not in params:
                 try:
                     params[k] = getattr(obj, k)
-                except KeyError:
+                except AttributeError:
                     missing.append(k)
         if missing:
             raise GitlabDeleteError('Missing attribute(s): %s' %

--- a/gitlab/objects.py
+++ b/gitlab/objects.py
@@ -737,6 +737,20 @@ class GroupIssueManager(BaseManager):
     obj_cls = GroupIssue
 
 
+class GroupLdapSyncLink(GitlabObject):
+    _url = '/groups/%(group_id)s/ldap_group_links'
+    idAttr = 'cn'
+    canGet = False
+    canList = False
+    canUpdate = False
+    requiredUrlAttrs = ['group_id']
+    requiredCreateAttrs = ['cn', 'group_access', 'provider']
+
+
+class GroupLdapSyncLinkManager(BaseManager):
+    obj_cls = GroupLdapSyncLink
+
+
 class GroupMember(GitlabObject):
     _url = '/groups/%(group_id)s/members'
     canGet = 'from_list'
@@ -807,7 +821,8 @@ class Group(GitlabObject):
         ('accessrequests', GroupAccessRequestManager, [('group_id', 'id')]),
         ('members', GroupMemberManager, [('group_id', 'id')]),
         ('projects', GroupProjectManager, [('group_id', 'id')]),
-        ('issues', GroupIssueManager, [('group_id', 'id')])
+        ('issues', GroupIssueManager, [('group_id', 'id')]),
+        ('ldaplinks', GroupLdapSyncLinkManager, [('group_id', 'id')]),
     ]
 
     GUEST_ACCESS = gitlab.GUEST_ACCESS

--- a/tools/build_test_env.sh
+++ b/tools/build_test_env.sh
@@ -75,7 +75,7 @@ cleanup() {
 }
 
 try docker run --name gitlab-test --detach --publish 8080:80 \
-    --publish 2222:22 gpocentek/test-python-gitlab:latest >/dev/null
+    --publish 2222:22 costela/test-python-gitlab:latest >/dev/null
 
 LOGIN='root'
 PASSWORD='5iveL!fe'
@@ -100,7 +100,7 @@ while :; do
     curl -s http://localhost:8080/users/sign_in 2>/dev/null \
         | grep -q "GitLab Community Edition" && break
     I=$((I+5))
-    [ "$I" -lt 120 ] || fatal "timed out"
+    [ "$I" -lt 300 ] || fatal "timed out"
 done
 sleep 5
 


### PR DESCRIPTION
This PR add support for group.ldaplinks.create() and group.ldaplinks.delete().

It's unclear to me what the best way to implement .list() would be. Since the API returns the LDAP information embedded in the group, I see two options (maybe I'm missing something obvious):
- hide the ldap_group_links attribute behind a manager and add a list() method that fetches the group again, ignoring all info but the LDAP links
- keep the .ldap_group_links and the .ldaplinks manager separate, but somehow update the .ldap_group_links list when we perform changes (currently the list remains out-dated whenever we perform changes, which obviously sucks)

Not sure how any of these could be implemented... :)
