### PR TITLE
Allow blank token in config

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -168,9 +168,12 @@ class Gitlab(object):
     def credentials_auth(self):
         """Performs an authentication using email/password."""
         if not self.email or not self.password:
-            raise GitlabAuthenticationError("Missing email/password")
+            # raise GitlabAuthenticationError("Missing email/password")
+            data = json.dumps({'email':self.http_username,
+                'password':self.http_password})
+        else:
+            data = json.dumps({'email': self.email, 'password': self.password})
 
-        data = json.dumps({'email': self.email, 'password': self.password})
         r = self._raw_post('/session', data, content_type='application/json')
         raise_error_from_response(r, GitlabAuthenticationError, 201)
         self.user = CurrentUser(self, r.json())

--- a/gitlab/config.py
+++ b/gitlab/config.py
@@ -53,7 +53,6 @@ class GitlabConfigParser(object):
 
         try:
             self.url = self._config.get(self.gitlab_id, 'url')
-            self.token = self._config.get(self.gitlab_id, 'private_token')
         except Exception:
             raise GitlabDataError("Impossible to get gitlab informations from "
                                   "configuration (%s)" % self.gitlab_id)
@@ -76,6 +75,12 @@ class GitlabConfigParser(object):
             pass
         try:
             self.timeout = self._config.getint(self.gitlab_id, 'timeout')
+        except Exception:
+            pass
+
+        self.token = None
+        try:
+            self.token = self._config.get(self.gitlab_id, 'private_token')
         except Exception:
             pass
 


### PR DESCRIPTION
Using a config with `http_username/http_password` only (*no token*) did not work...

The changes in this pull request allow usage of gitlab-cli with the following config:
```
[global]
default = example
ssl_verify = true
timeout = 5

[example]
url = https://gitlab.example.com
http_username = root
http_password = mypassword
```