### PR TITLE
import urlencode() from six.moves.urllib.parse instead of from urllib

### DIFF
--- a/gitlab/v3/objects.py
+++ b/gitlab/v3/objects.py
@@ -23,7 +23,7 @@ import json
 import warnings
 
 import six
-from six.moves.urllib.parse import urlencode
+from six.moves import urllib
 
 import gitlab
 from gitlab.base import *  # noqa
@@ -1841,7 +1841,7 @@ class Project(GitlabObject):
         url = "/projects/%s/repository/tree" % (self.id)
         params = []
         if path:
-            params.append(urlencode({'path': path}))
+            params.append(urllib.parse.urlencode({'path': path}))
         if ref_name:
             params.append("ref_name=%s" % ref_name)
         if params:
@@ -1872,7 +1872,7 @@ class Project(GitlabObject):
             GitlabGetError: If the server fails to perform the request.
         """
         url = "/projects/%s/repository/blobs/%s" % (self.id, sha)
-        url += '?%s' % (urlencode({'filepath': filepath}))
+        url += '?%s' % (urllib.parse.urlencode({'filepath': filepath}))
         r = self.gitlab._raw_get(url, streamed=streamed, **kwargs)
         raise_error_from_response(r, GitlabGetError)
         return utils.response_content(r, streamed, action, chunk_size)

--- a/gitlab/v3/objects.py
+++ b/gitlab/v3/objects.py
@@ -20,10 +20,10 @@ from __future__ import division
 from __future__ import absolute_import
 import base64
 import json
-import urllib
 import warnings
 
 import six
+from six.moves.urllib.parse import urlencode
 
 import gitlab
 from gitlab.base import *  # noqa
@@ -1841,7 +1841,7 @@ class Project(GitlabObject):
         url = "/projects/%s/repository/tree" % (self.id)
         params = []
         if path:
-            params.append(urllib.urlencode({'path': path}))
+            params.append(urlencode({'path': path}))
         if ref_name:
             params.append("ref_name=%s" % ref_name)
         if params:
@@ -1872,7 +1872,7 @@ class Project(GitlabObject):
             GitlabGetError: If the server fails to perform the request.
         """
         url = "/projects/%s/repository/blobs/%s" % (self.id, sha)
-        url += '?%s' % (urllib.urlencode({'filepath': filepath}))
+        url += '?%s' % (urlencode({'filepath': filepath}))
         r = self.gitlab._raw_get(url, streamed=streamed, **kwargs)
         raise_error_from_response(r, GitlabGetError)
         return utils.response_content(r, streamed, action, chunk_size)

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -22,7 +22,7 @@ import base64
 import json
 
 import six
-from six.moves.urllib.parse import urlencode
+from six.moves import urllib
 
 import gitlab
 from gitlab.base import *  # noqa
@@ -1846,7 +1846,7 @@ class Project(GitlabObject):
         url = "/projects/%s/repository/tree" % (self.id)
         params = []
         if path:
-            params.append(urlencode({'path': path}))
+            params.append(urllib.parse.urlencode({'path': path}))
         if ref:
             params.append("ref=%s" % ref)
         if params:

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -20,9 +20,9 @@ from __future__ import division
 from __future__ import absolute_import
 import base64
 import json
-import urllib
 
 import six
+from six.moves.urllib.parse import urlencode
 
 import gitlab
 from gitlab.base import *  # noqa
@@ -1846,7 +1846,7 @@ class Project(GitlabObject):
         url = "/projects/%s/repository/tree" % (self.id)
         params = []
         if path:
-            params.append(urllib.urlencode({'path': path}))
+            params.append(urlencode({'path': path}))
         if ref:
             params.append("ref=%s" % ref)
         if params:


### PR DESCRIPTION
Fixes AttributeError on Python 3, as `urlencode` function has been moved from `urllib` to `urllib.parse` module.

`six.moves.urllib.parse.urlencode()` is an py2.py3 compatible alias of `urllib.parse.urlencode()` on Python 3, and of `urllib.urlencode()` on Python 2.