### PR TITLE
Missing expires_at in GroupMembers update

### DIFF
--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -362,7 +362,7 @@ class GroupMember(GitlabObject):
     requiredCreateAttrs = ['access_level', 'user_id']
     optionalCreateAttrs = ['expires_at']
     requiredUpdateAttrs = ['access_level']
-    optionalCreateAttrs = ['expires_at']
+    optionalUpdateAttrs = ['expires_at']
     shortPrintAttr = 'username'
 
     def _update(self, **kwargs):


### PR DESCRIPTION
optionalCreateAttrs was set twice in GroupMember due to possible copy-paste error. This corrects the second call from optionalCreateAttrs to optionUpdateAttrs.