### PR TITLE
Docs 📖: Add link to gitlab docs on obtaining a token

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -80,12 +80,15 @@ section.
      - URL for the GitLab server
    * - ``private_token``
      - Your user token. Login/password is not supported.
+       Refer `the official documentation`__ to learn how to obtain a token.
    * - ``api_version``
      - API version to use (``3`` or ``4``), defaults to ``3``
    * - ``http_username``
      - Username for optional HTTP authentication
    * - ``http_password``
      - Password for optional HTTP authentication
+
+__ https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html
 
 CLI
 ===


### PR DESCRIPTION
I find these sort of links very user friendly 😅