### PR TITLE
Declare support for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
 language: python
 python: 2.7
 env:
+  - TOX_ENV=py36
   - TOX_ENV=py35
   - TOX_ENV=py34
   - TOX_ENV=py27

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = py35,py34,py27,pep8
+envlist = py36,py35,py34,py27,pep8
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}


### PR DESCRIPTION
Add Python 3.6 environments to `tox.ini` and `.travis.yml`.