### PR TITLE
Expected HTTP response for subscribe is 201

### DIFF
--- a/gitlab/v3/objects.py
+++ b/gitlab/v3/objects.py
@@ -934,7 +934,7 @@ class ProjectIssue(GitlabObject):
                {'project_id': self.project_id, 'issue_id': self.id})
 
         r = self.gitlab._raw_post(url, **kwargs)
-        raise_error_from_response(r, GitlabSubscribeError)
+        raise_error_from_response(r, GitlabSubscribeError, 201)
         self._set_from_dict(r.json())
 
     def unsubscribe(self, **kwargs):


### PR DESCRIPTION
It seems that the GitLab API gives HTTP response code 201 ("created") when
successfully subscribing to an object, not 200.