### PR TITLE
mixins.py: Avoid sending empty update data to issue.save

### DIFF
--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -299,7 +299,7 @@ class SaveMixin(object):
         """
         updated_data = self._get_updated_data()
         # Nothing to update. Server fails if sent an empty dict.
-        if len(updated_data.keys()) == 0:
+        if not updated_data.keys():
             return
 
         # call the manager

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -298,8 +298,8 @@ class SaveMixin(object):
             GitlabUpdateError: If the server cannot perform the request
         """
         updated_data = self._get_updated_data()
-        # Nothing to update. Servers fails if sent an empty dict.
-        if len(updated_data.keys()) == 9:
+        # Nothing to update. Server fails if sent an empty dict.
+        if len(updated_data.keys()) == 0:
             return
 
         # call the manager

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -299,7 +299,7 @@ class SaveMixin(object):
         """
         updated_data = self._get_updated_data()
         # Nothing to update. Server fails if sent an empty dict.
-        if not updated_data.keys():
+        if not updated_data:
             return
 
         # call the manager

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -298,6 +298,9 @@ class SaveMixin(object):
             GitlabUpdateError: If the server cannot perform the request
         """
         updated_data = self._get_updated_data()
+        # Nothing to update. Servers fails if sent an empty dict.
+        if len(updated_data.keys()) == 9:
+            return
 
         # call the manager
         obj_id = self.get_id()


### PR DESCRIPTION
When saving an issue we send the updated data only. 

However the server expect at least one parameter to be provided,
otherwise it fails with an exception.

Check whether we have some update to send, otherwise skip
the update altogether.