### PR TITLE
introduce a way to get all user's projects

### DIFF
--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -181,6 +181,12 @@ class UserProject(RESTObject):
     pass
 
 
+class UserProjectsManager(GetFromListMixin, RESTManager):
+    _path = '/users/%(user_id)s/projects'
+    _obj_cls = UserProject
+    _from_parent_attrs = {'user_id': 'id'}
+
+
 class UserProjectManager(CreateMixin, RESTManager):
     _path = '/projects/user/%(user_id)s'
     _obj_cls = UserProject
@@ -202,7 +208,8 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
         ('gpgkeys', 'UserGPGKeyManager'),
         ('impersonationtokens', 'UserImpersonationTokenManager'),
         ('keys', 'UserKeyManager'),
-        ('projects', 'UserProjectManager'),
+        ('project', 'UserProjectManager'),
+        ('projects', 'UserProjectsManager'),
     )
 
     @cli.register_custom_action('User')


### PR DESCRIPTION
This is a proposal for accessing `GET /users/:id/projects`. Note that it isn't strictly backwards compatible because I renamed `gitlab.user.projects` into `gitlab.user.project` and used `gitlab.user.projects` for the new endpoint.

Closes #403 