### PR TITLE
Add manager for jobs within a pipeline.

### DIFF
--- a/docs/gl_objects/builds.py
+++ b/docs/gl_objects/builds.py
@@ -55,10 +55,18 @@ commit = gl.project_commits.get(commit_sha, project_id=1)
 builds = commit.builds()
 # end commit list
 
-# get
+# pipeline list get
+# v4 only
+project = gl.projects.get(project_id)
+pipeline = project.pipelines.get(pipeline_id)
+jobs = pipeline.jobs.list()  # gets all jobs in pipeline
+job = pipeline.jobs.get(job_id)  # gets one job from pipeline
+# end pipeline list get
+
+# get job
 project.builds.get(build_id)  # v3
 project.jobs.get(job_id)  # v4
-# end get
+# end get job
 
 # artifacts
 build_or_job.artifacts()

--- a/docs/gl_objects/builds.rst
+++ b/docs/gl_objects/builds.rst
@@ -122,8 +122,9 @@ Remove a variable:
 Builds/Jobs
 ===========
 
-Builds/Jobs are associated to projects and commits. They provide information on
-the builds/jobs that have been run, and methods to manipulate them.
+Builds/Jobs are associated to projects, pipelines and commits. They provide
+information on the builds/jobs that have been run, and methods to manipulate
+them.
 
 Reference
 ---------
@@ -169,11 +170,20 @@ To list builds for a specific commit, create a
    :start-after: # commit list
    :end-before: # end commit list
 
+To list builds for a specific pipeline or get a single job within a specific
+pipeline, create a
+:class:`~gitlab.v4.objects.ProjectPipeline` object and use its
+:attr:`~gitlab.v4.objects.ProjectPipeline.jobs` method (v4 only):
+
+.. literalinclude:: builds.py
+    :start-after: # pipeline list get
+    :end-before: # end pipeline list get
+
 Get a job:
 
 .. literalinclude:: builds.py
-   :start-after: # get
-   :end-before: # end get
+   :start-after: # get job
+   :end-before: # end get job
 
 Get a job artifact:
 

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -1942,9 +1942,13 @@ class ProjectPipelineManager(RetrieveMixin, CreateMixin, RESTManager):
         return CreateMixin.create(self, data, path=path, **kwargs)
 
 
-class ProjectPipelineJobManager(RetrieveMixin, RESTManager):
+class ProjectPipelineJob(ProjectJob):
+    pass
+
+
+class ProjectPipelineJobManager(GetFromListMixin, RESTManager):
     _path = '/projects/%(project_id)s/pipelines/%(pipeline_id)s/jobs'
-    _obj_cls = ProjectJob
+    _obj_cls = ProjectPipelineJob
     _from_parent_attrs = {'project_id': 'project_id', 'pipeline_id': 'id'}
 
 

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -1883,6 +1883,8 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin,
 
 
 class ProjectPipeline(RESTObject):
+    _managers = (('jobs', 'ProjectPipelineJobManager'), )
+
     @cli.register_custom_action('ProjectPipeline')
     @exc.on_http_error(exc.GitlabPipelineCancelError)
     def cancel(self, **kwargs):
@@ -1938,6 +1940,12 @@ class ProjectPipelineManager(RetrieveMixin, CreateMixin, RESTManager):
         """
         path = self.path[:-1]  # drop the 's'
         return CreateMixin.create(self, data, path=path, **kwargs)
+
+
+class ProjectPipelineJobManager(RetrieveMixin, RESTManager):
+    _path = '/projects/%(project_id)s/pipelines/%(pipeline_id)s/jobs'
+    _obj_cls = ProjectJob
+    _from_parent_attrs = {'project_id': 'project_id', 'pipeline_id': 'id'}
 
 
 class ProjectSnippetNoteAwardEmoji(ObjectDeleteMixin, RESTObject):


### PR DESCRIPTION
This PR adds a manager for jobs within a pipeline, so you can say `gl.projects.get(prid).pipelines.get(plid).jobs.list()` to list all of the jobs within a single pipeline (in GitLab v4).

Please let me know if there are any tests I should add. The existing UTs still pass.