### PR TITLE
Simplify the example for streamed artifacts

### DIFF
--- a/docs/gl_objects/builds.py
+++ b/docs/gl_objects/builds.py
@@ -72,7 +72,7 @@ project.jobs.get(job_id)  # v4
 build_or_job.artifacts()
 # end artifacts
 
-# stream artifacts
+# stream artifacts with class
 class Foo(object):
     def __init__(self):
         self._fd = open('artifacts.zip', 'wb')
@@ -83,7 +83,15 @@ class Foo(object):
 target = Foo()
 build_or_job.artifacts(streamed=True, action=target)
 del(target)  # flushes data on disk
-# end stream artifacts
+# end stream artifacts with class
+
+# stream artifacts with unzip
+zipfn = "___artifacts.zip"
+with open(zipfn, "wb") as f:
+    build_or_job.artifacts(streamed=True, action=f.write)
+subprocess.run(["unzip", "-bo", zipfn])
+os.unlink(zipfn)
+# end stream artifacts with unzip
 
 # keep artifacts
 build_or_job.keep_artifacts()

--- a/docs/gl_objects/builds.rst
+++ b/docs/gl_objects/builds.rst
@@ -201,8 +201,14 @@ You can download artifacts as a stream. Provide a callable to handle the
 stream:
 
 .. literalinclude:: builds.py
-   :start-after: # stream artifacts
-   :end-before: # end stream artifacts
+   :start-after: # stream artifacts with class
+   :end-before: # end stream artifacts with class
+
+In this second example, you can directly stream the output into a file, and unzip it afterwards:
+
+.. literalinclude:: builds.py
+   :start-after: # stream artifacts with unzip
+   :end-before: # end stream artifacts with unzip
 
 Mark a job artifact as kept when expiration is set:
 


### PR DESCRIPTION
Going through an object adds a lot of complication.
Adding example for unzipping on the fly