### PR TITLE
make trigger_pipeline return the pipeline

### DIFF
--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -2624,7 +2624,8 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
         """
         path = '/projects/%s/trigger/pipeline' % self.get_id()
         post_data = {'ref': ref, 'token': token, 'variables': variables}
-        self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
+        attrs = self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
+        return ProjectPipeline(project.pipelines, attrs)
 
     @cli.register_custom_action('Project')
     @exc.on_http_error(exc.GitlabHousekeepingError)

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -2624,8 +2624,9 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
         """
         path = '/projects/%s/trigger/pipeline' % self.get_id()
         post_data = {'ref': ref, 'token': token, 'variables': variables}
-        attrs = self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
-        return ProjectPipeline(project.pipelines, attrs)
+        attrs = self.manager.gitlab.http_post(
+            path, post_data=post_data, **kwargs)
+        return ProjectPipeline(self.pipelines, attrs)
 
     @cli.register_custom_action('Project')
     @exc.on_http_error(exc.GitlabHousekeepingError)


### PR DESCRIPTION
Trigger_pipeline returns nothing, which makes it difficult to track the pipeline being trigger.

Next PR will be about updating a pipeline object to get latest status (not sure yet the best way to do it)