### PR TITLE
introduce RefreshMixin

### DIFF
--- a/docs/gl_objects/builds.py
+++ b/docs/gl_objects/builds.py
@@ -44,6 +44,22 @@ project.triggers.delete(trigger_token)
 trigger.delete()
 # end trigger delete
 
+# pipeline trigger
+def get_or_create_trigger(project):
+    trigger_decription = 'my_trigger_id'
+    for t in project.triggers.list():
+        if t.description == trigger_decription:
+            return t
+    return project.triggers.create({'description': trigger_decription})
+
+trigger = get_or_create_trigger(project)
+pipeline = project.trigger_pipeline('master', trigger.token, variables={"DEPLOY_ZONE": "us-west1"})
+while pipeline.finished_at is None:
+    pipeline.refresh()
+    os.sleep(1)
+
+# end pipeline trigger
+
 # list
 builds = project.builds.list()  # v3
 jobs = project.jobs.list()  # v4

--- a/docs/gl_objects/builds.rst
+++ b/docs/gl_objects/builds.rst
@@ -102,6 +102,12 @@ Remove a trigger:
    :start-after: # trigger delete
    :end-before: # end trigger delete
 
+Full example with wait for finish:
+
+.. literalinclude:: builds.py
+   :start-after: # pipeline trigger
+   :end-before: # end pipeline trigger
+
 Pipeline schedule
 =================
 

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -68,6 +68,25 @@ class GetWithoutIdMixin(object):
         return self._obj_cls(self, server_data)
 
 
+class RefreshMixin(object):
+    @exc.on_http_error(exc.GitlabGetError)
+    def refresh(self, **kwargs):
+        """Refresh a single object from server.
+
+        Args:
+            **kwargs: Extra options to send to the Gitlab server (e.g. sudo)
+
+        Returns None (updates the object)
+
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabGetError: If the server cannot perform the request
+        """
+        path = '%s/%s' % (self.manager.path, self.id)
+        server_data = self.manager.gitlab.http_get(path, **kwargs)
+        self._update_attrs(server_data)
+
+
 class ListMixin(object):
     @exc.on_http_error(exc.GitlabListError)
     def list(self, **kwargs):

--- a/gitlab/tests/test_mixins.py
+++ b/gitlab/tests/test_mixins.py
@@ -153,6 +153,25 @@ class TestMixinMethods(unittest.TestCase):
             self.assertEqual(obj.foo, 'bar')
             self.assertEqual(obj.id, 42)
 
+    def test_refresh_mixin(self):
+        class O(RefreshMixin, FakeObject):
+            pass
+
+        @urlmatch(scheme="http", netloc="localhost", path='/api/v4/tests/42',
+                  method="get")
+        def resp_cont(url, request):
+            headers = {'Content-Type': 'application/json'}
+            content = '{"id": 42, "foo": "bar"}'
+            return response(200, content, headers, None, 5, request)
+
+        with HTTMock(resp_cont):
+            mgr = FakeManager(self.gl)
+            obj = O(mgr, {'id': 42})
+            res = obj.refresh()
+            self.assertIsNone(res)
+            self.assertEqual(obj.foo, 'bar')
+            self.assertEqual(obj.id, 42)
+
     def test_get_without_id_mixin(self):
         class M(GetWithoutIdMixin, FakeManager):
             pass

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -909,7 +909,7 @@ class ProjectCustomAttributeManager(RetrieveMixin, SetMixin, DeleteMixin,
     _from_parent_attrs = {'project_id': 'id'}
 
 
-class ProjectJob(RESTObject):
+class ProjectJob(RESTObject, RefreshMixin):
     @cli.register_custom_action('ProjectJob')
     @exc.on_http_error(exc.GitlabJobCancelError)
     def cancel(self, **kwargs):
@@ -1045,7 +1045,7 @@ class ProjectJobManager(RetrieveMixin, RESTManager):
     _from_parent_attrs = {'project_id': 'id'}
 
 
-class ProjectCommitStatus(RESTObject):
+class ProjectCommitStatus(RESTObject, RefreshMixin):
     pass
 
 
@@ -1964,7 +1964,7 @@ class ProjectPipelineJobsManager(ListMixin, RESTManager):
     _list_filters = ('scope',)
 
 
-class ProjectPipeline(RESTObject):
+class ProjectPipeline(RESTObject, RefreshMixin):
     _managers = (('jobs', 'ProjectPipelineJobManager'), )
 
     @cli.register_custom_action('ProjectPipeline')


### PR DESCRIPTION
RefreshMixin allows to update a REST object so that you can poll on it.
This is mostly useful for pipelines and jobs, but could be set on most of other objects, with unknown usecases.