### PR TITLE
Add support for unsharing projects with groups

### DIFF
--- a/docs/gl_objects/projects.py
+++ b/docs/gl_objects/projects.py
@@ -101,6 +101,10 @@ member.delete()
 project.share(group.id, gitlab.DEVELOPER_ACCESS)
 # end share
 
+# unshare
+project.unshare(group.id)
+# end unshare
+
 # hook list
 hooks = project.hooks.list()
 # end hook list

--- a/gitlab/v3/cli.py
+++ b/gitlab/v3/cli.py
@@ -69,6 +69,7 @@ EXTRA_ACTIONS = {
         'archive': {'required': ['id']},
         'unarchive': {'required': ['id']},
         'share': {'required': ['id', 'group-id', 'group-access']},
+        'unshare': {'required': ['id', 'group-id']},
         'upload': {'required': ['id', 'filename', 'filepath']}},
     gitlab.v3.objects.User: {
         'block': {'required': ['id']},
@@ -212,6 +213,13 @@ class GitlabCLI(object):
             o.share(args['group_id'], args['group_access'])
         except Exception as e:
             cli.die("Impossible to share project", e)
+
+    def do_project_unshare(self, cls, gl, what, args):
+        try:
+            o = self.do_get(cls, gl, what, args)
+            o.unshare(args['group_id'])
+        except Exception as e:
+            cli.die("Impossible to unshare project", e)
 
     def do_user_block(self, cls, gl, what, args):
         try:

--- a/gitlab/v3/objects.py
+++ b/gitlab/v3/objects.py
@@ -2056,6 +2056,20 @@ class Project(GitlabObject):
         r = self.gitlab._raw_post(url, data=data, **kwargs)
         raise_error_from_response(r, GitlabCreateError, 201)
 
+    def unshare(self, group_id, **kwargs):
+        """Delete a shared project link within a group.
+
+        Args:
+            group_id (int): ID of the group.
+
+        Raises:
+            GitlabConnectionError: If the server cannot be reached.
+            GitlabDeleteError: If the server fails to perform the request.
+        """
+        url = "/projects/%s/share/%s" % (self.id, group_id)
+        r = self.gitlab._raw_delete(url, **kwargs)
+        raise_error_from_response(r, GitlabDeleteError, 204)
+
     def trigger_build(self, ref, token, variables={}, **kwargs):
         """Trigger a CI build.
 

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -2672,6 +2672,22 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
                 'expires_at': expires_at}
         self.manager.gitlab.http_post(path, post_data=data, **kwargs)
 
+    @cli.register_custom_action('Project', ('group_id', ))
+    @exc.on_http_error(exc.GitlabDeleteError)
+    def unshare(self, group_id, **kwargs):
+        """Delete a shared project link within a group.
+
+        Args:
+            group_id (int): ID of the group.
+            **kwargs: Extra options to send to the server (e.g. sudo)
+
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabDeleteError: If the server failed to perform the request
+        """
+        path = '/projects/%s/share/%s' % (self.get_id(), group_id)
+        self.manager.gitlab.http_delete(path, **kwargs)
+
     # variables not supported in CLI
     @cli.register_custom_action('Project', ('ref', 'token'))
     @exc.on_http_error(exc.GitlabCreateError)


### PR DESCRIPTION
This PR introduces support for project.unshare()

It relies on the https://docs.gitlab.com/ee/api/projects.html#delete-a-shared-project-link-within-a-group API. I needed only the v4 API support but I also added v3 just in case (https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md). v4 is operational, and v3 may be but is untested.