### PR TITLE
Change method for getting content of snippet

### DIFF
--- a/docs/gl_objects/snippets.py
+++ b/docs/gl_objects/snippets.py
@@ -9,7 +9,7 @@ public_snippets = gl.snippets.public()
 # get
 snippet = gl.snippets.get(snippet_id)
 # get the content
-content = snippet.raw()
+content = snippet.content()
 # end get
 
 # create


### PR DESCRIPTION
There is an [example](http://python-gitlab.readthedocs.io/en/stable/gl_objects/snippets.html#examples) in snippet section of the docs (get content) that raises AttributeError. The `raw` method was supported in APIv3. Maybe the example should use APIv4 method.