### PR TITLE
feat: obey the rate limit

### DIFF
--- a/docs/api-usage.rst
+++ b/docs/api-usage.rst
@@ -326,3 +326,26 @@ The following sample illustrates how to use a client-side certificate:
 
 Reference:
 http://docs.python-requests.org/en/master/user/advanced/#client-side-certificates
+
+Rate limits
+-----------
+
+python-gitlab will obey the rate limit of the GitLab server by default.
+On receiving a 429 response (Too Many Requests), python-gitlab will sleep for the amount of time
+in the Retry-After header, that GitLab sends back.
+
+If you don't want to wait, you can disable the rate-limiting feature, by supplying the
+``obey_rate_limit`` argument.
+
+.. code-block:: python
+
+   import gitlab
+   import requests
+
+   gl = gitlab.gitlab(url, token, api_version=4)
+   gl.projects.list(all=True, obey_rate_limit=False)
+
+
+.. warning::
+
+   You will get an Exception, if you then go over the rate limit of your GitLab instance.


### PR DESCRIPTION
This PR enables python-gitlab to wait if the GitLab rate-limit is hit.
It waits as long as GitLab specifies via the [Retry-After header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After)

GitLab lacks documentation about this feature, but rate-limits can be set in the Admin UI (see screenshot)
and via the settings API.
![image](https://user-images.githubusercontent.com/6639323/38921537-4fb45bdc-42f6-11e8-8bf1-397dff48c7a4.png)

```json
{
 "throttle_authenticated_api_enabled": false,
 "throttle_authenticated_api_requests_per_period": 2,
 "throttle_authenticated_api_period_in_seconds": 10,
}
```

It can be disabled using the `obey_rate_limit=False` parameter