### PR TITLE
Add support for project-level MR approval configuration.

### DIFF
--- a/docs/gl_objects/mr_approvals.rst
+++ b/docs/gl_objects/mr_approvals.rst
@@ -1,0 +1,26 @@
+#######################
+Merge request approvals
+#######################
+
+References
+----------
+
+* v4 API:
+
+  + :class:`gitlab.v4.objects.ProjectMergeRequestApproval`
+  + :class:`gitlab.v4.objects.ProjectMergeRequestApprovalManager`
+  + :attr:`gitlab.v4.objects.Project.approvals`
+
+* GitLab API: https://docs.gitlab.com/ce/api/merge_request_approvals.html
+
+Examples
+--------
+
+Get project-level MR approvals configuration::
+
+    mrac = project.approvals.get()
+
+Save project-level MR approvals configuration::
+
+    mrac.approvals_before_merge = 2
+    mrac.save()

--- a/docs/gl_objects/mr_approvals.rst
+++ b/docs/gl_objects/mr_approvals.rst
@@ -24,3 +24,7 @@ Change project-level MR approvals configuration::
 
     mrac.approvals_before_merge = 2
     mrac.save()
+
+Change project-level MR allowed approvers::
+
+	project.approvals.change_approvers(approver_ids = [105], approver_group_ids=[653, 654])

--- a/docs/gl_objects/mr_approvals.rst
+++ b/docs/gl_objects/mr_approvals.rst
@@ -1,30 +1,30 @@
-#######################
-Merge request approvals
-#######################
+##############################################
+Project-level merge request approvals settings
+##############################################
 
 References
 ----------
 
 * v4 API:
 
-  + :class:`gitlab.v4.objects.ProjectMergeRequestApproval`
-  + :class:`gitlab.v4.objects.ProjectMergeRequestApprovalManager`
-  + :attr:`gitlab.v4.objects.Project.approvals`
+  + :class:`gitlab.v4.objects.ProjectMergeRequestApprovalSettings`
+  + :class:`gitlab.v4.objects.ProjectMergeRequestApprovalSettingsManager`
+  + :attr:`gitlab.v4.objects.Project.approvalsettings`
 
-* GitLab API: https://docs.gitlab.com/ce/api/merge_request_approvals.html
+* GitLab API: https://docs.gitlab.com/ee/api/merge_request_approvals.html#project-level-mr-approvals
 
 Examples
 --------
 
-Get project-level MR approvals configuration::
+Get project-level MR approvals settings::
 
-    mrac = project.approvals.get()
+    mras = project.approvalsettings.get()
 
-Change project-level MR approvals configuration::
+Change project-level MR approvals settings::
 
-    mrac.approvals_before_merge = 2
-    mrac.save()
+    mras.approvals_before_merge = 2
+    mras.save()
 
 Change project-level MR allowed approvers::
 
-	project.approvals.change_approvers(approver_ids = [105], approver_group_ids=[653, 654])
+	project.approvalsettings.set_approvers(approver_ids = [105], approver_group_ids=[653, 654])

--- a/docs/gl_objects/mr_approvals.rst
+++ b/docs/gl_objects/mr_approvals.rst
@@ -7,9 +7,9 @@ References
 
 * v4 API:
 
-  + :class:`gitlab.v4.objects.ProjectMergeRequestApprovalSettings`
-  + :class:`gitlab.v4.objects.ProjectMergeRequestApprovalSettingsManager`
-  + :attr:`gitlab.v4.objects.Project.approvalsettings`
+  + :class:`gitlab.v4.objects.ProjectApproval`
+  + :class:`gitlab.v4.objects.ProjectApprovalManager`
+  + :attr:`gitlab.v4.objects.Project.approvals`
 
 * GitLab API: https://docs.gitlab.com/ee/api/merge_request_approvals.html#project-level-mr-approvals
 
@@ -18,7 +18,7 @@ Examples
 
 Get project-level MR approvals settings::
 
-    mras = project.approvalsettings.get()
+    mras = project.approvals.get()
 
 Change project-level MR approvals settings::
 
@@ -27,4 +27,4 @@ Change project-level MR approvals settings::
 
 Change project-level MR allowed approvers::
 
-	project.approvalsettings.set_approvers(approver_ids = [105], approver_group_ids=[653, 654])
+	project.approvals.set_approvers(approver_ids = [105], approver_group_ids=[653, 654])

--- a/docs/gl_objects/mr_approvals.rst
+++ b/docs/gl_objects/mr_approvals.rst
@@ -20,7 +20,7 @@ Get project-level MR approvals configuration::
 
     mrac = project.approvals.get()
 
-Save project-level MR approvals configuration::
+Change project-level MR approvals configuration::
 
     mrac.approvals_before_merge = 2
     mrac.save()

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -278,8 +278,7 @@ class UpdateMixin(object):
                         new_data[attr_name] = type_obj.get_for_api()
 
         http_method = self.get_update_method()
-        return http_method(path, post_data=new_data, files=files,
-                                    **kwargs)
+        return http_method(path, post_data=new_data, files=files, **kwargs)
 
 
 class SetMixin(object):

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -223,6 +223,18 @@ class UpdateMixin(object):
         """
         return getattr(self, '_update_attrs', (tuple(), tuple()))
 
+    def get_update_method(self):
+        """Return the HTTP method to use.
+
+        Returns:
+            object: http_put (default) or http_post
+        """
+        if getattr(self, '_update_post', False):
+            http_method = self.gitlab.http_post
+        else:
+            http_method = self.gitlab.http_put
+        return http_method
+
     @exc.on_http_error(exc.GitlabUpdateError)
     def update(self, id=None, new_data={}, **kwargs):
         """Update an object on the server.
@@ -265,7 +277,8 @@ class UpdateMixin(object):
                     else:
                         new_data[attr_name] = type_obj.get_for_api()
 
-        return self.gitlab.http_put(path, post_data=new_data, files=files,
+        http_method = self.get_update_method()
+        return http_method(path, post_data=new_data, files=files,
                                     **kwargs)
 
 

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -223,13 +223,13 @@ class UpdateMixin(object):
         """
         return getattr(self, '_update_attrs', (tuple(), tuple()))
 
-    def get_update_method(self):
+    def _get_update_method(self):
         """Return the HTTP method to use.
 
         Returns:
             object: http_put (default) or http_post
         """
-        if getattr(self, '_update_post', False):
+        if getattr(self, '_update_uses_post', False):
             http_method = self.gitlab.http_post
         else:
             http_method = self.gitlab.http_put
@@ -277,7 +277,7 @@ class UpdateMixin(object):
                     else:
                         new_data[attr_name] = type_obj.get_for_api()
 
-        http_method = self.get_update_method()
+        http_method = self._get_update_method()
         return http_method(path, post_data=new_data, files=files, **kwargs)
 
 

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -2630,6 +2630,19 @@ class ProjectAccessRequestManager(ListMixin, CreateMixin, DeleteMixin,
     _from_parent_attrs = {'project_id': 'id'}
 
 
+class ProjectMergeRequestApproval(SaveMixin, RESTObject):
+    _id_attr = None
+
+
+class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin,
+                                  RESTManager):
+    _path = '/projects/%(project_id)s/approvals'
+    _obj_cls = ProjectMergeRequestApproval
+    _from_parent_attrs = {'project_id': 'id'}
+    _update_attrs = (tuple(), ('approvals_before_merge', 'reset_approvals_on_push', 'disable_overriding_approvers_per_merge_request'))
+    _update_post = True
+
+
 class ProjectDeployment(RESTObject):
     pass
 
@@ -2728,6 +2741,7 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
     _short_print_attr = 'path'
     _managers = (
         ('accessrequests', 'ProjectAccessRequestManager'),
+        ('approvals', 'ProjectMergeRequestApprovalManager'),
         ('badges', 'ProjectBadgeManager'),
         ('boards', 'ProjectBoardManager'),
         ('branches', 'ProjectBranchManager'),

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -2631,14 +2631,13 @@ class ProjectAccessRequestManager(ListMixin, CreateMixin, DeleteMixin,
     _from_parent_attrs = {'project_id': 'id'}
 
 
-class ProjectMergeRequestApprovalSettings(SaveMixin, RESTObject):
+class ProjectApproval(SaveMixin, RESTObject):
     _id_attr = None
 
 
-class ProjectMergeRequestApprovalSettingsManager(GetWithoutIdMixin,
-                                                 UpdateMixin, RESTManager):
+class ProjectApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
     _path = '/projects/%(project_id)s/approvals'
-    _obj_cls = ProjectMergeRequestApprovalSettings
+    _obj_cls = ProjectApproval
     _from_parent_attrs = {'project_id': 'id'}
     _update_attrs = (tuple(),
                      ('approvals_before_merge', 'reset_approvals_on_push',
@@ -2766,7 +2765,7 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
     _short_print_attr = 'path'
     _managers = (
         ('accessrequests', 'ProjectAccessRequestManager'),
-        ('approvalsettings', 'ProjectMergeRequestApprovalSettingsManager'),
+        ('approvals', 'ProjectApprovalManager'),
         ('badges', 'ProjectBadgeManager'),
         ('boards', 'ProjectBoardManager'),
         ('branches', 'ProjectBranchManager'),

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -2644,6 +2644,28 @@ class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin,
                       'disable_overriding_approvers_per_merge_request'))
     _update_post = True
 
+    @exc.on_http_error(exc.GitlabUpdateError)
+    def change_approvers(self, approver_ids=[], approver_group_ids=[],
+                         **kwargs):
+        """Change project-level allowed approvers and approver groups.
+
+        Args:
+            approver_ids (list): User IDs that can approve MRs.
+            approver_group_ids (list): Group IDs whose members can approve MRs.
+
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabUpdateError: If the server failed to perform the request
+        """
+
+        path = '/projects/%s/approvers' % self._parent.get_id()
+        data = {'approver_ids': approver_ids,
+                'approver_group_ids': approver_group_ids}
+        try:
+            self.gitlab.http_put(path, post_data=data, **kwargs)
+        except exc.GitlabHttpError as e:
+                raise exc.GitlabUpdateError(e.response_code, e.error_message)
+
 
 class ProjectDeployment(RESTObject):
     pass

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -2635,11 +2635,13 @@ class ProjectMergeRequestApproval(SaveMixin, RESTObject):
 
 
 class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin,
-                                  RESTManager):
+                                         RESTManager):
     _path = '/projects/%(project_id)s/approvals'
     _obj_cls = ProjectMergeRequestApproval
     _from_parent_attrs = {'project_id': 'id'}
-    _update_attrs = (tuple(), ('approvals_before_merge', 'reset_approvals_on_push', 'disable_overriding_approvers_per_merge_request'))
+    _update_attrs = (tuple(),
+                     ('approvals_before_merge', 'reset_approvals_on_push',
+                      'disable_overriding_approvers_per_merge_request'))
     _update_post = True
 
 

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -2357,10 +2357,6 @@ class ProjectPipelineScheduleManager(CRUDMixin, RESTManager):
                      ('description', 'ref', 'cron', 'cron_timezone', 'active'))
 
 
-class ProjectPipelineJob(ProjectJob):
-    pass
-
-
 class ProjectPipelineJobManager(ListMixin, RESTManager):
     _path = '/projects/%(project_id)s/pipelines/%(pipeline_id)s/jobs'
     _obj_cls = ProjectPipelineJob

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -2635,8 +2635,8 @@ class ProjectMergeRequestApprovalSettings(SaveMixin, RESTObject):
     _id_attr = None
 
 
-class ProjectMergeRequestApprovalSettingsManager(GetWithoutIdMixin, UpdateMixin,
-                                         RESTManager):
+class ProjectMergeRequestApprovalSettingsManager(GetWithoutIdMixin,
+                                                 UpdateMixin, RESTManager):
     _path = '/projects/%(project_id)s/approvals'
     _obj_cls = ProjectMergeRequestApprovalSettings
     _from_parent_attrs = {'project_id': 'id'}
@@ -2647,7 +2647,7 @@ class ProjectMergeRequestApprovalSettingsManager(GetWithoutIdMixin, UpdateMixin,
 
     @exc.on_http_error(exc.GitlabUpdateError)
     def set_approvers(self, approver_ids=[], approver_group_ids=[],
-                         **kwargs):
+                      **kwargs):
         """Change project-level allowed approvers and approver groups.
 
         Args:

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -2631,22 +2631,22 @@ class ProjectAccessRequestManager(ListMixin, CreateMixin, DeleteMixin,
     _from_parent_attrs = {'project_id': 'id'}
 
 
-class ProjectMergeRequestApproval(SaveMixin, RESTObject):
+class ProjectMergeRequestApprovalSettings(SaveMixin, RESTObject):
     _id_attr = None
 
 
-class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin,
+class ProjectMergeRequestApprovalSettingsManager(GetWithoutIdMixin, UpdateMixin,
                                          RESTManager):
     _path = '/projects/%(project_id)s/approvals'
-    _obj_cls = ProjectMergeRequestApproval
+    _obj_cls = ProjectMergeRequestApprovalSettings
     _from_parent_attrs = {'project_id': 'id'}
     _update_attrs = (tuple(),
                      ('approvals_before_merge', 'reset_approvals_on_push',
                       'disable_overriding_approvers_per_merge_request'))
-    _update_post = True
+    _update_uses_post = True
 
     @exc.on_http_error(exc.GitlabUpdateError)
-    def change_approvers(self, approver_ids=[], approver_group_ids=[],
+    def set_approvers(self, approver_ids=[], approver_group_ids=[],
                          **kwargs):
         """Change project-level allowed approvers and approver groups.
 
@@ -2766,7 +2766,7 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
     _short_print_attr = 'path'
     _managers = (
         ('accessrequests', 'ProjectAccessRequestManager'),
-        ('approvals', 'ProjectMergeRequestApprovalManager'),
+        ('approvalsettings', 'ProjectMergeRequestApprovalSettingsManager'),
         ('badges', 'ProjectBadgeManager'),
         ('boards', 'ProjectBoardManager'),
         ('branches', 'ProjectBranchManager'),


### PR DESCRIPTION
This PR introduces support for [project-level MR approval configuration](https://docs.gitlab.com/ee/api/merge_request_approvals.html#project-level-mr-approvals).

The 'GET/POST /projects/:id/approvals' and 'PUT /projects/:id/approvers' API endpoint are a bit unusual, so I chose to keep the Python API consistent with them.

Travis build was [ok](https://travis-ci.org/esabouraud/python-gitlab/builds/388814353) before I merged the latest changes from master.