### PR TITLE
silence logs/warnings in unittests

### DIFF
--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -120,7 +120,8 @@ def _parse_value(v):
         # If the user-provided value starts with @, we try to read the file
         # path provided after @ as the real value. Exit on any error.
         try:
-            return open(v[1:]).read()
+            with open(v[1:]) as fl:
+                return fl.read()
         except Exception as e:
             sys.stderr.write("%s\n" % e)
             sys.exit(1)

--- a/gitlab/tests/test_gitlab.py
+++ b/gitlab/tests/test_gitlab.py
@@ -439,7 +439,7 @@ class TestGitlab(unittest.TestCase):
         with HTTMock(resp_cont):
             callback()
         self.assertEqual(self.gl.private_token, token)
-        self.assertDictContainsSubset(expected, self.gl.headers)
+        self.assertDictEqual(expected, self.gl.headers)
         self.assertEqual(self.gl.user.id, id_)
 
     def test_token_auth(self, callback=None):


### PR DESCRIPTION
before
```
............foobar
./home/cjouve/work/gitlab/python-gitlab/gitlab/cli.py:123: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/tmporr_ffy7' mode='r' encoding='UTF-8'>
  return open(v[1:]).read()
[Errno 2] No such file or directory: '/thisfileprobablydoesntexist'
......./usr/lib/python3.6/unittest/case.py:1126: DeprecationWarning: assertDictContainsSubset is deprecated
  DeprecationWarning)
....................................................................
----------------------------------------------------------------------
Ran 88 tests in 0.562s

OK
```

after:
```
........................................................................................
----------------------------------------------------------------------
Ran 88 tests in 0.533s

OK
```