### PR TITLE
Add support for project transfers from the projects interface.

### DIFF
--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -3589,6 +3589,25 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
         path = '/projects/%d/mirror/pull' % self.get_id()
         self.manager.gitlab.http_post(path, **kwargs)
 
+    @cli.register_custom_action('Project', ('to_namespace', ))
+    @exc.on_http_error(exc.GitlabTransferProjectError)
+    def transfer_project(self, to_namespace, **kwargs):
+        """Transfer a project to the given namespace ID
+
+        Args:
+            to_namespace (str): ID or path of the namespace to transfer the
+            project to
+            **kwargs: Extra options to send to the server (e.g. sudo)
+
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabTransferProjectError: If the project could not be transfered
+        """
+        path = '/projects/%d/transfer' % (self.id,)
+        self.manager.gitlab.http_put(path,
+                                     post_data={"namespace": to_namespace},
+                                     **kwargs)
+
 
 class ProjectManager(CRUDMixin, RESTManager):
     _path = '/projects'


### PR DESCRIPTION
Adds missing transfer_project function to the Project object, which provides for an ergonomic way to move projects around.

See https://docs.gitlab.com/ee/api/projects.html#transfer-a-project-to-a-new-namespace