### PR TITLE
Minor typo "ou" vs. "or"

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -69,7 +69,7 @@ parameters. You can override the values in each GitLab server section.
      - Integer
      - Number of seconds to wait for an answer before failing.
    * - ``api_version``
-     - ``3`` ou ``4``
+     - ``3`` or ``4``
      - The API version to use to make queries. Requires python-gitlab >= 1.3.0.
    * - ``per_page``
      - Integer between 1 and 100


### PR DESCRIPTION
This change fixes a minor type in the table of possible values for options in the global section.