### PR TITLE
Add project protected tags management

### DIFF
--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -657,3 +657,36 @@ Edit project push rules::
 Delete project push rules::
 
     pr.delete()
+
+Project protected tags
+==================
+
+Reference
+---------
+
+* v4 API:
+
+  + :class:`gitlab.v4.objects.ProjectProtectedTag`
+  + :class:`gitlab.v4.objects.ProjectProtectedTagManager`
+  + :attr:`gitlab.v4.objects.Project.protectedtags`
+
+* GitLab API: https://docs.gitlab.com/ce/api/protected_tags.html
+
+Examples
+---------
+
+Get a list of protected tags from a project::
+
+    protected_tags = project.protectedtags.list()
+
+Get a single protected tag or wildcard protected tag::
+
+    protected_tag = project.protectedtags.get('v*')
+
+Protect a single repository tag or several project repository tags using a wildcard protected tag::
+
+    tag = project.protectedtags.create({'name': 'v*', 'create_access_level': '40'})
+
+Unprotect the given protected tag or wildcard protected tag.::
+
+    protected_tag.delete()

--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -685,7 +685,7 @@ Get a single protected tag or wildcard protected tag::
 
 Protect a single repository tag or several project repository tags using a wildcard protected tag::
 
-    tag = project.protectedtags.create({'name': 'v*', 'create_access_level': '40'})
+    project.protectedtags.create({'name': 'v*', 'create_access_level': '40'})
 
 Unprotect the given protected tag or wildcard protected tag.::
 

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -1965,6 +1965,18 @@ class ProjectTagManager(NoUpdateMixin, RESTManager):
     _create_attrs = (('tag_name', 'ref'), ('message',))
 
 
+class ProjectProtectedTag(ObjectDeleteMixin, RESTObject):
+    _id_attr = 'name'
+    _short_print_attr = 'name'
+
+
+class ProjectProtectedTagManager(NoUpdateMixin, RESTManager):
+    _path = '/projects/%(project_id)s/protected_tags'
+    _obj_cls = ProjectProtectedTag
+    _from_parent_attrs = {'project_id': 'id'}
+    _create_attrs = (('name',), ('create_access_level',))
+
+
 class ProjectMergeRequestApproval(SaveMixin, RESTObject):
     _id_attr = None
 
@@ -3124,6 +3136,7 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
         ('pagesdomains', 'ProjectPagesDomainManager'),
         ('pipelines', 'ProjectPipelineManager'),
         ('protectedbranches', 'ProjectProtectedBranchManager'),
+        ('protectedtags', 'ProjectProtectedTagManager'),
         ('pipelineschedules', 'ProjectPipelineScheduleManager'),
         ('pushrules', 'ProjectPushRulesManager'),
         ('runners', 'ProjectRunnerManager'),


### PR DESCRIPTION
This PR introduces support for [protected tags](https://docs.gitlab.com/ce/api/protected_tags.html) management.