### PR TITLE
add missing comma in ProjectIssueManager _create_attrs

### DIFF
--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -1862,8 +1862,8 @@ class ProjectIssueManager(CRUDMixin, RESTManager):
                      'order_by', 'sort', 'search', 'created_after',
                      'created_before', 'updated_after', 'updated_before')
     _create_attrs = (('title', ),
-                     ('description', 'confidential', 'assignee_id',
-                      'assignee_idss' 'milestone_id', 'labels', 'created_at',
+                     ('description', 'confidential', 'assignee_ids',
+                      'assignee_id', 'milestone_id', 'labels', 'created_at',
                       'due_date', 'merge_request_to_resolve_discussions_of',
                       'discussion_to_resolve'))
     _update_attrs = (tuple(), ('title', 'description', 'confidential',


### PR DESCRIPTION
Was trying to create issues set to a milestone via the CLI. The current code creates a help text of ` [--assignee-idssmilestone-id ASSIGNEE_IDSSMILESTONE_ID]` and then ignores the value. Have tested the change in my PIP user install.