### PR TITLE
Improve error message handling in exceptions

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -490,10 +490,14 @@ class Gitlab(object):
                 time.sleep(wait_time)
                 continue
 
+            error_message = result.content
             try:
-                error_message = result.json()['message']
+                error_json = result.json()
+                for k in ('message', 'error'):
+                    if k in error_json:
+                        error_message = error_json[k]
             except (KeyError, ValueError, TypeError):
-                error_message = result.content
+                pass
 
             if result.status_code == 401:
                 raise GitlabAuthenticationError(

--- a/gitlab/exceptions.py
+++ b/gitlab/exceptions.py
@@ -28,7 +28,12 @@ class GitlabError(Exception):
         # Full http response
         self.response_body = response_body
         # Parsed error message from gitlab
-        self.error_message = error_message
+        try:
+            # if we receive str/bytes we try to convert to unicode/str to have
+            # consistent message types (see #616)
+            self.error_message = error_message.decode()
+        except Exception:
+            self.error_message = error_message
 
     def __str__(self):
         if self.response_code is not None:


### PR DESCRIPTION
* Depending on the request Gitlab has a 'message' or 'error' attribute
in the json data, handle both
* Add some consistency by converting messages to unicode or str for
exceptions (depending on the python version)

Closes #616