### PR TITLE
Issue 643 project-variable update. Fix to remove 'key' from require3d…

### DIFF
--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -208,6 +208,8 @@ class CreateMixin(object):
 class UpdateMixin(object):
     def _check_missing_update_attrs(self, data):
         required, optional = self.get_update_attrs()
+        # Remove the id field from the required list as it has been moved to the http path.
+        required = tuple(filter(lambda k: k != self._obj_cls._id_attr, required))
         missing = []
         for attr in required:
             if attr not in data:

--- a/gitlab/tests/test_project_variable_api.py
+++ b/gitlab/tests/test_project_variable_api.py
@@ -1,0 +1,59 @@
+from gitlab import cli
+import pytest
+import sys
+
+PROJECT_ID = 9460322
+
+
+def test_project_variable(capsys):
+    key = "junk1"
+    value1 = "car"
+    value2 = "bus"
+
+    with pytest.raises(SystemExit) as exit_exc:
+        cmd_line = f"gitlab project-variable list --project-id {PROJECT_ID}"
+        print("--->", cmd_line)
+        sys.argv = cmd_line.split()
+        cli.main()
+    out, err = capsys.readouterr()
+
+    if key not in out:
+        with pytest.raises(SystemExit) as exit_exc:
+            cmd_line = f"gitlab project-variable create --project-id {PROJECT_ID} --key {key} --value {value1}"
+            print("--->", cmd_line)
+            sys.argv = cmd_line.split()
+            cli.main()
+    out, err = capsys.readouterr()
+
+    with pytest.raises(SystemExit) as exit_exc:
+        cmd_line = f"gitlab project-variable get --project-id {PROJECT_ID} --key {key}"
+        print("--->", cmd_line)
+        sys.argv = cmd_line.split()
+        cli.main()
+    out, err = capsys.readouterr()
+
+    with pytest.raises(SystemExit) as exit_exc:
+        cmd_line = f"gitlab project-variable update --project-id {PROJECT_ID} --key {key} --value {value2}"
+        print("--->", cmd_line)
+        sys.argv = cmd_line.split()
+        cli.main()
+    out, err = capsys.readouterr()
+    assert key in out
+    assert value2 in out
+
+    with pytest.raises(SystemExit) as exit_exc:
+        cmd_line = f"gitlab project-variable list --project-id {PROJECT_ID}"
+        print("--->", cmd_line)
+        sys.argv = cmd_line.split()
+        cli.main()
+    out, _ = capsys.readouterr()
+
+    if key in out:
+        with pytest.raises(SystemExit) as exit_exc:
+            cmd_line = f"gitlab project-variable delete --project-id {PROJECT_ID} --key {key}"
+            print("--->", cmd_line)
+            sys.argv = cmd_line.split()
+            cli.main()
+    out, _ = capsys.readouterr()
+
+    pass

--- a/tools/cli_test_v4.sh
+++ b/tools/cli_test_v4.sh
@@ -89,6 +89,31 @@ testcase "merge request validation" '
         --iid "$MR_ID" >/dev/null 2>&1
 '
 
+# Test project variables
+testcase "create project variable" '
+    OUTPUT=$(GITLAB -v project-variable create --project-id $PROJECT_ID \
+        --key junk --value car)
+'
+
+testcase "get project variable" '
+    OUTPUT=$(GITLAB -v project-variable get --project-id $PROJECT_ID \
+        --key junk)
+'
+
+testcase "update project variable" '
+    OUTPUT=$(GITLAB -v project-variable update --project-id $PROJECT_ID \
+        --key junk --value bus)
+'
+
+testcase "list project variable" '
+    OUTPUT=$(GITLAB -v project-variable list --project-id $PROJECT_ID)
+'
+
+testcase "delete project variable" '
+    OUTPUT=$(GITLAB -v project-variable delete --project-id $PROJECT_ID \
+        --key junk)
+'
+
 testcase "branch deletion" '
     GITLAB project-branch delete --project-id "$PROJECT_ID" \
         --name branch1 >/dev/null 2>&1


### PR DESCRIPTION
gitlab project-variable update fails for missing --key parameter.

See issue: https://github.com/python-gitlab/python-gitlab/issues/643 for more complete description.