### PR TITLE
fix: docker entry point argument passing

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,4 +18,4 @@ http_username = ${GITLAB_HTTP_USERNAME}
 http_password = ${GITLAB_HTTP_PASSWORD}
 EOF
 
-exec gitlab --config-file "${GITLAB_CFG}" $@
+exec gitlab --config-file "${GITLAB_CFG}" "$@"


### PR DESCRIPTION
Fixes the problem of passing spaces in the arguments to the docker entrypoint.

Before this fix, there was virtually no way to pass spaces in arguments such as task description.