### PR TITLE
fix: enable use of YAML in the CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ FROM python:3.7-alpine
 
 WORKDIR /opt/python-gitlab
 COPY --from=build /opt/python-gitlab/dist dist/
+RUN pip install PyYaml
 RUN pip install $(find dist -name *.whl) && \
     rm -rf dist/
 COPY docker-entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
In order to use the YAML output, PyYaml needs to be installed on the docker image.
This commit adds the installation to the dockerfile as a separate layer.