### PR TITLE
Issue 653 Add access control options to protected branch creation

### DIFF
--- a/docs/gl_objects/protected_branches.rst
+++ b/docs/gl_objects/protected_branches.rst
@@ -35,6 +35,15 @@ Create a protected branch::
         'push_access_level': gitlab.MAINTAINER_ACCESS
     })
 
+Create a protected branch with more granular access control::
+
+    p_branch = project.protectedbranches.create({
+        'name': '*-stable',
+        'allowed_to_push': [{"user_id": 99}, {"user_id": 98}],
+        'allowed_to_merge': [{"group_id": 653}],
+        'allowed_to_unprotect': [{"access_level": gitlab.MAINTAINER_ACCESS}]
+    })
+
 Delete a protected branch::
 
     project.protectedbranches.delete('*-stable')

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -3117,7 +3117,10 @@ class ProjectProtectedBranchManager(NoUpdateMixin, RESTManager):
     _path = '/projects/%(project_id)s/protected_branches'
     _obj_cls = ProjectProtectedBranch
     _from_parent_attrs = {'project_id': 'id'}
-    _create_attrs = (('name', ), ('push_access_level', 'merge_access_level'))
+    _create_attrs = (('name', ),
+                     ('push_access_level', 'merge_access_level',
+                      'unprotect_access_level', 'allowed_to_push',
+                      'allowed_to_merge', 'allowed_to_unprotect'))
 
 
 class ProjectRunner(ObjectDeleteMixin, RESTObject):


### PR DESCRIPTION
This PR introduces support for protected branches [access control options introduced in GitLab 10.3](https://docs.gitlab.com/ee/api/protected_branches.html#example-with-user--group-level-access).

Fix #653 