### PR TITLE
Correct issue with wrong variable being used in path creation.

### DIFF
--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -237,7 +237,7 @@ class UserProjectManager(ListMixin, CreateMixin, RESTManager):
             GitlabListError: If the server cannot perform the request
         """
 
-        path = '/users/%s/projects' % self._parent.id
+        path = '/users/%s/projects' % kwargs['user_id']
         return ListMixin.list(self, path=path, **kwargs)
 
 


### PR DESCRIPTION
`self._parent.id` doesn't seem to exist at this point, so listing user projects fails. However, when replaced with `kwargs['user_id']`, projects are successfully returned.