### PR TITLE
Modify list method of UserProjectManager 

### DIFF
--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -236,8 +236,11 @@ class UserProjectManager(ListMixin, CreateMixin, RESTManager):
             GitlabAuthenticationError: If authentication is not correct
             GitlabListError: If the server cannot perform the request
         """
+        if self._parent is not None:
+            path = '/users/%s/projects' % self._parent.id
+        else:
+            path = '/users/%s/projects' % kwargs['user_id']
 
-        path = '/users/%s/projects' % self._parent.id
         return ListMixin.list(self, path=path, **kwargs)
 
 


### PR DESCRIPTION
...to use kwargs['user_id'] and self._parent.id

When running via CLI, as with `python-gitlab user-projects list --user-id 1`, the `self._parent.id` variable does not exist. However, the user id is passed through to the function as `kwargs['user_id']`. This changes adds an if/else block to check to see if `self._parent.id` exists, and then use the appropriate variable.  