### PR TITLE
Fix all kwarg behaviour

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -590,7 +590,7 @@ class Gitlab(object):
         # In case we want to change the default behavior at some point
         as_list = True if as_list is None else as_list
 
-        get_all = kwargs.get('all', False)
+        get_all = kwargs.pop('all', False)
         url = self._build_url(path)
 
         if get_all is True:


### PR DESCRIPTION
`all` kwarg is used to manage GitlabList generator behaviour.
However, as it is not pop'ed from kwargs, it is sent to Gitlab API.
Some endpoints such as [the project commits](https://docs.gitlab.com/ee/api/commits.html#list-repository-commits) one,
support a `all` attribute.
This means a call like `project.commits.list(all=True, ref_name='master')`
won't return all the master commits as one might expect but all the
repository's commits.
To prevent confusion, the same kwarg shouldn't be used for 2 distinct
purposes.
Moreover according to [the documentation](https://python-gitlab.readthedocs.io/en/stable/gl_objects/commits.html#examples),
the `all` project commits API endpoint attribute doesn't seem supported.