### PR TITLE
fix(types): return _value when _value is not iterable

### DIFF
--- a/gitlab/types.py
+++ b/gitlab/types.py
@@ -43,6 +43,7 @@ class ListAttribute(GitlabAttribute):
         except TypeError:
             return self._value
 
+
 class LowercaseStringAttribute(GitlabAttribute):
     def get_for_api(self):
         return str(self._value).lower()

--- a/gitlab/types.py
+++ b/gitlab/types.py
@@ -38,8 +38,10 @@ class ListAttribute(GitlabAttribute):
             self._value = [item.strip() for item in cli_value.split(',')]
 
     def get_for_api(self):
-        return ",".join(self._value)
-
+        try:
+            return ",".join(self._value)
+        except TypeError:
+            return self._value
 
 class LowercaseStringAttribute(GitlabAttribute):
     def get_for_api(self):


### PR DESCRIPTION
- In gitlab/types.py, the `get_for_api` in ListAttribute will trigger an exception if self._value is None. The error like below:
`TypeError: can only join an iterable`
- Catch the exception and return self._value if there is TypeError.