### PR TITLE
chore(ci): use reliable ci system

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,96 @@
+image: python:3.7
+
+stages:
+  - lint
+  - build-test-image
+  - test
+  - deploy
+
+commitlint:
+  image: node:12
+  stage: lint
+  before_script:
+    - npm install -g @commitlint/cli @commitlint/config-conventional
+    - 'echo "module.exports = {extends: [\"@commitlint/config-conventional\"]}" > commitlint.config.js'
+  script:
+    - npx commitlint --from=origin/master
+  except:
+    - master
+
+#build_test_image:  # Currently hangs forever, because of GitLab Runner infrastructure issues
+#  stage: build-test-image
+#  image:
+#    name: gcr.io/kaniko-project/executor:debug
+#    entrypoint: [""]
+#  script:
+#    - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
+#    - /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/tools/Dockerfile-test --destination $CI_REGISTRY_IMAGE:test
+#  only:
+#    refs:
+#      - master
+#    changes:
+#      - tools/
+
+.tox_includes: &tox_includes
+  stage: test
+  before_script:
+    - pip install tox
+  script:
+    - tox -e $TOX_ENV
+
+test_2.7:
+  <<: *tox_includes
+  image: python:2.7
+  variables:
+    TOX_ENV: py27
+
+test_3.4:
+  <<: *tox_includes
+  image: python:3.4
+  variables:
+    TOX_ENV: py34
+    
+test_3.5:
+  <<: *tox_includes
+  image: python:3.5
+  variables:
+    TOX_ENV: py35
+    
+test_3.6:
+  <<: *tox_includes
+  image: python:3.6
+  variables:
+    TOX_ENV: py36
+    
+test_3.7:
+  <<: *tox_includes
+  image: python:3.7
+  variables:
+    TOX_ENV: py37
+
+test_3.8:
+  <<: *tox_includes
+  image: python:3.8-rc-alpine
+  variables:
+    TOX_ENV: py38
+  allow_failure: true
+
+test_docs:
+  <<: *tox_includes
+  variables:
+    TOX_ENV: docs
+
+deploy:
+  stage: deploy
+  script:
+    - pip install -U setuptools wheel twine
+    - python setup.py sdist bdist_wheel
+    # test package
+    - python3 -m venv test
+    - . test/bin/activate
+    - pip install -U dist/python-gitlab*.whl
+    - gitlab -h
+    - deactivate
+    - twine upload --skip-existing -u $TWINE_USERNAME -p $TWINE_PASSWORD dist/*
+  only:
+    - tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,12 @@
 sudo: required
 services:
   - docker
-addons:
-  apt:
-    sources:
-      - deadsnakes
-    packages:
-      - python3.5
 language: python
 python: 2.7
 env:
-  - TOX_ENV=py35
-  - TOX_ENV=py34
-  - TOX_ENV=py27
-  - TOX_ENV=pep8
-  - TOX_ENV=docs
   - TOX_ENV=py_func_v4
   - TOX_ENV=cli_func_v4
 install:
   - pip install tox
 script:
   - tox -e $TOX_ENV
-
-deploy:
-  provider: pypi
-  user: max-wittig
-  password:
-    secure: LmNkZdbNe1oBSJ/PeTCKXaeu9Ml/biY4ZN4aedbD4lLXbxV/sgsHEE4N1Xrg2D/CJsnNjBY7CHzO0vL5iak8IRpV61xkdquZHvAUQKuhjMY30HopReAEw8sP+Wpf3lYcD1BjC5KT9vqWG99feoQ6epRt//Xm4DdkBYNmmUsCsMBTZLlGnj3B/mE8w+XQxQpdA2QzpRJ549N12vidwZRKqP0Zuug3rELVSo64O2bpqarKx/EeUUhTXZ0Y4XeVYgvuHBjvPqtuSJzR17CNkjaBhacD7EFTP34sAaCKGRDpfYiiiGx9LeKOEAv5Hj0+LOqEC/o6EyiIFviE+HvLQ/kBLJ6Oo2p47fibyIU/YOAFdZYKmBRq2ZUaV0DhhuuCRPZ+yLrsuaFRrKTVEMsHVtdsXJkW5gKG08vwOndW+kamppRhkAcdFVyokIgu/6nPBRWMuS6ue2aKoKRdP2gmqk0daKM1ao2uv06A2/J1/xkPy1EX5MjyK8Mh78ooKjITp5DHYn8l1pxaB0YcEkRzfwMyLErGQaRDgo7rCOm0tTRNhArkn0VE1/KLKFbATo2NSxZDwUJQ5TBNCEqfdBN1VzNEduJ7ajbZpq3DsBRM/9hzQ5LLxn7azMl9m+WmT12Qcgz25wg2Sgbs9Z2rT6fto5h8GSLpy8ReHo+S6fALJBzA4pg=
-  distributions: sdist bdist_wheel
-  on:
-    tags: true
-  skip_existing: true

--- a/tools/Dockerfile-test
+++ b/tools/Dockerfile-test
@@ -1,0 +1,34 @@
+FROM ubuntu:16.04
+# based on Vincent Robert <vincent.robert@genezys.net> initial Dockerfile
+MAINTAINER Gauvain Pocentek <gauvain@pocentek.net>
+
+# Install required packages
+RUN apt-get update \
+    && apt-get install -qy --no-install-recommends \
+      openssh-server \
+      ca-certificates \
+      curl \
+      tzdata \
+    && curl https://packages.gitlab.com/install/repositories/gitlab/gitlab-ce/script.deb.sh | bash \
+    && apt-get install -qy --no-install-recommends \
+      gitlab-ce=11.10.0-ce.0
+
+# Manage SSHD through runit
+RUN mkdir -p /opt/gitlab/sv/sshd/supervise \
+    && mkfifo /opt/gitlab/sv/sshd/supervise/ok \
+    && printf "#!/bin/sh\nexec 2>&1\numask 077\nexec /usr/sbin/sshd -D" > /opt/gitlab/sv/sshd/run \
+    && chmod a+x /opt/gitlab/sv/sshd/run \
+    && ln -s /opt/gitlab/sv/sshd /opt/gitlab/service \
+    && mkdir -p /var/run/sshd
+
+# Default root password
+RUN echo "gitlab_rails['initial_root_password'] = '5iveL!fe'" >> /etc/gitlab/gitlab.rb; \
+    sed -i "s,^external_url.*,external_url 'http://gitlab.test'," /etc/gitlab/gitlab.rb; \
+    echo 'pages_external_url "http://pages.gitlab.lxd/"' >> /etc/gitlab/gitlab.rb; \
+    echo "gitlab_pages['enable'] = true" >> /etc/gitlab/gitlab.rb
+
+# Expose web & ssh
+EXPOSE 80 22
+
+# Default is to run runit & reconfigure
+CMD sleep 3 && gitlab-ctl reconfigure & /opt/gitlab/embedded/bin/runsvdir-start


### PR DESCRIPTION
We currently still need to rely on Travis for the docker tests, but I will look into changing that.

Job succeeded on GitLab.com: https://gitlab.com/python-gitlab/python-gitlab/pipelines/60606601

I'm using the GitLab feature to report back to GitHub for my own open source project and it works pretty well: https://github.com/max-wittig/gitlab-languages/commits/master (certainly better than travis)

