### PR TITLE
Fix example to access a group

### DIFF
--- a/docs/api-usage.rst
+++ b/docs/api-usage.rst
@@ -77,8 +77,8 @@ Examples:
 
    # get the group with id == 2
    group = gl.groups.get(2)
-   for group in groups:
-       print()
+   for project in group.projects.list():
+       print(project)
 
    # create a new user
    user_data = {'email': 'jen@foo.com', 'username': 'jen', 'name': 'Jen'}


### PR DESCRIPTION
Hello!

The existing (previous) example prints the following
```
    for group in groups:
NameError: name 'groups' is not defined
```