### PR TITLE
Fix Pickle support: dump() after load() fails

### DIFF
--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -52,7 +52,7 @@ class RESTObject(object):
     def __setstate__(self, state):
         module_name = state.pop("_module_name")
         self.__dict__.update(state)
-        self._module = importlib.import_module(module_name)
+        self.__dict__["_module"] = importlib.import_module(module_name)
 
     def __getattr__(self, name):
         try:

--- a/gitlab/tests/test_base.py
+++ b/gitlab/tests/test_base.py
@@ -93,6 +93,7 @@ class TestRESTObject(unittest.TestCase):
         self.assertIsInstance(unpickled, FakeObject)
         self.assertTrue(hasattr(unpickled, "_module"))
         self.assertEqual(unpickled._module, original_obj_module)
+        pickled2 = pickle.dumps(unpickled)
 
     def test_attrs(self):
         obj = FakeObject(self.manager, {"foo": "bar"})


### PR DESCRIPTION
This is a one-liner fix to pickle support: pickle.dump() fails after pickle.load()
```
  File "/home/bourgesl/.local/lib/python3.6/site-packages/gitlab/base.py", line 50, in __getstate__
    module = state.pop("_module")
KeyError: '_module'
```

Reason:
Former self._module call invokes ```set_attr()``` that stores '_module' attribute in ```self.__dict__["_updated_attrs"]["_module"]``` that is not its correct place: ```self.__dict__["_module"]``` as expected by getstate()