### PR TITLE
docs(projects): add mention about project listings

### DIFF
--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -39,6 +39,8 @@ Results can also be sorted using the following parameters:
 
 ::
 
+    # List all projects (default 20)
+    projects = gl.projects.list(all=True)
     # Archived projects
     projects = gl.projects.list(archived=1)
     # Limit to projects with a defined visibility


### PR DESCRIPTION
Having exactly 20 internal and 5 private projects in the group
spent some time debugging this issue.

Hopefully that helped: https://github.com/python-gitlab/python-gitlab/issues/93

Imho should be definitely mention about `all=True` parameter.

Fixes #784