### PR TITLE
fix auth() for cookie based authentication

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -211,10 +211,10 @@ class Gitlab(object):
         The `user` attribute will hold a `gitlab.objects.CurrentUser` object on
         success.
         """
-        if self.private_token or self.oauth_token:
-            self._token_auth()
-        else:
+        if self.email and self.password:
             self._credentials_auth()
+        else:
+            self._token_auth()
 
     def _credentials_auth(self):
         data = {"email": self.email, "password": self.password}


### PR DESCRIPTION
It is possible to do a cookie based authentication. This change enable the use of the GitLab user element.

https://python-gitlab.readthedocs.io/en/stable/api-usage.html
https://gist.github.com/gpocentek/bd4c3fbf8a6ce226ebddc4aad6b46c0a