### PR TITLE
Fix mutable default arguments

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -443,7 +443,7 @@ class Gitlab(object):
         self,
         verb,
         path,
-        query_data={},
+        query_data=None,
         post_data=None,
         streamed=False,
         files=None,
@@ -469,7 +469,7 @@ class Gitlab(object):
         Raises:
             GitlabHttpError: When the return code is not 2xx
         """
-
+        query_data = query_data or {}
         url = self._build_url(path)
 
         params = {}
@@ -564,7 +564,7 @@ class Gitlab(object):
                 response_body=result.content,
             )
 
-    def http_get(self, path, query_data={}, streamed=False, raw=False, **kwargs):
+    def http_get(self, path, query_data=None, streamed=False, raw=False, **kwargs):
         """Make a GET request to the Gitlab server.
 
         Args:
@@ -584,6 +584,7 @@ class Gitlab(object):
             GitlabHttpError: When the return code is not 2xx
             GitlabParsingError: If the json data could not be parsed
         """
+        query_data = query_data or {}
         result = self.http_request(
             "get", path, query_data=query_data, streamed=streamed, **kwargs
         )
@@ -602,7 +603,7 @@ class Gitlab(object):
         else:
             return result
 
-    def http_list(self, path, query_data={}, as_list=None, **kwargs):
+    def http_list(self, path, query_data=None, as_list=None, **kwargs):
         """Make a GET request to the Gitlab server for list-oriented queries.
 
         Args:
@@ -623,6 +624,7 @@ class Gitlab(object):
             GitlabHttpError: When the return code is not 2xx
             GitlabParsingError: If the json data could not be parsed
         """
+        query_data = query_data or {}
 
         # In case we want to change the default behavior at some point
         as_list = True if as_list is None else as_list
@@ -640,7 +642,7 @@ class Gitlab(object):
         # No pagination, generator requested
         return GitlabList(self, url, query_data, **kwargs)
 
-    def http_post(self, path, query_data={}, post_data={}, files=None, **kwargs):
+    def http_post(self, path, query_data=None, post_data=None, files=None, **kwargs):
         """Make a POST request to the Gitlab server.
 
         Args:
@@ -660,6 +662,9 @@ class Gitlab(object):
             GitlabHttpError: When the return code is not 2xx
             GitlabParsingError: If the json data could not be parsed
         """
+        query_data = query_data or {}
+        post_data = post_data or {}
+
         result = self.http_request(
             "post",
             path,
@@ -675,7 +680,7 @@ class Gitlab(object):
             raise GitlabParsingError(error_message="Failed to parse the server message")
         return result
 
-    def http_put(self, path, query_data={}, post_data={}, files=None, **kwargs):
+    def http_put(self, path, query_data=None, post_data=None, files=None, **kwargs):
         """Make a PUT request to the Gitlab server.
 
         Args:
@@ -694,6 +699,9 @@ class Gitlab(object):
             GitlabHttpError: When the return code is not 2xx
             GitlabParsingError: If the json data could not be parsed
         """
+        query_data = query_data or {}
+        post_data = post_data or {}
+
         result = self.http_request(
             "put",
             path,
@@ -755,7 +763,8 @@ class GitlabList(object):
         self._query(url, query_data, **kwargs)
         self._get_next = get_next
 
-    def _query(self, url, query_data={}, **kwargs):
+    def _query(self, url, query_data=None, **kwargs):
+        query_data = query_data or {}
         result = self._gl.http_request("get", url, query_data=query_data, **kwargs)
         try:
             self._next_url = result.links["next"]["url"]

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -240,7 +240,7 @@ class UpdateMixin(object):
         return http_method
 
     @exc.on_http_error(exc.GitlabUpdateError)
-    def update(self, id=None, new_data={}, **kwargs):
+    def update(self, id=None, new_data=None, **kwargs):
         """Update an object on the server.
 
         Args:
@@ -255,6 +255,7 @@ class UpdateMixin(object):
             GitlabAuthenticationError: If authentication is not correct
             GitlabUpdateError: If the server cannot perform the request
         """
+        new_data = new_data or {}
 
         if id is None:
             path = self.path

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -530,7 +530,7 @@ class ApplicationSettingsManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
     )
 
     @exc.on_http_error(exc.GitlabUpdateError)
-    def update(self, id=None, new_data={}, **kwargs):
+    def update(self, id=None, new_data=None, **kwargs):
         """Update an object on the server.
 
         Args:
@@ -545,7 +545,7 @@ class ApplicationSettingsManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
             GitlabAuthenticationError: If authentication is not correct
             GitlabUpdateError: If the server cannot perform the request
         """
-
+        new_data = new_data or {}
         data = new_data.copy()
         if "domain_whitelist" in data and data["domain_whitelist"] is None:
             data.pop("domain_whitelist")
@@ -865,13 +865,14 @@ class GroupLabelManager(ListMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
     _update_attrs = (("name",), ("new_name", "color", "description", "priority"))
 
     # Update without ID.
-    def update(self, name, new_data={}, **kwargs):
+    def update(self, name, new_data=None, **kwargs):
         """Update a Label on the server.
 
         Args:
             name: The name of the label
             **kwargs: Extra options to send to the server (e.g. sudo)
         """
+        new_data = new_data or {}
         new_data["name"] = name
         super().update(id=None, new_data=new_data, **kwargs)
 
@@ -2994,13 +2995,14 @@ class ProjectLabelManager(
     _update_attrs = (("name",), ("new_name", "color", "description", "priority"))
 
     # Update without ID.
-    def update(self, name, new_data={}, **kwargs):
+    def update(self, name, new_data=None, **kwargs):
         """Update a Label on the server.
 
         Args:
             name: The name of the label
             **kwargs: Extra options to send to the server (e.g. sudo)
         """
+        new_data = new_data or {}
         new_data["name"] = name
         super().update(id=None, new_data=new_data, **kwargs)
 
@@ -3130,7 +3132,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         return self._obj_cls(self, server_data)
 
     @exc.on_http_error(exc.GitlabUpdateError)
-    def update(self, file_path, new_data={}, **kwargs):
+    def update(self, file_path, new_data=None, **kwargs):
         """Update an object on the server.
 
         Args:
@@ -3145,7 +3147,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
             GitlabAuthenticationError: If authentication is not correct
             GitlabUpdateError: If the server cannot perform the request
         """
-
+        new_data = new_data or {}
         data = new_data.copy()
         file_path = file_path.replace("/", "%2F")
         data["file_path"] = file_path
@@ -3632,7 +3634,7 @@ class ProjectServiceManager(GetMixin, UpdateMixin, DeleteMixin, RESTManager):
         obj.id = id
         return obj
 
-    def update(self, id=None, new_data={}, **kwargs):
+    def update(self, id=None, new_data=None, **kwargs):
         """Update an object on the server.
 
         Args:
@@ -3647,6 +3649,7 @@ class ProjectServiceManager(GetMixin, UpdateMixin, DeleteMixin, RESTManager):
             GitlabAuthenticationError: If authentication is not correct
             GitlabUpdateError: If the server cannot perform the request
         """
+        new_data = new_data or {}
         super(ProjectServiceManager, self).update(id, new_data, **kwargs)
         self.id = id
 
@@ -4182,7 +4185,7 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
     # variables not supported in CLI
     @cli.register_custom_action("Project", ("ref", "token"))
     @exc.on_http_error(exc.GitlabCreateError)
-    def trigger_pipeline(self, ref, token, variables={}, **kwargs):
+    def trigger_pipeline(self, ref, token, variables=None, **kwargs):
         """Trigger a CI build.
 
         See https://gitlab.com/help/ci/triggers/README.md#trigger-a-build
@@ -4197,6 +4200,7 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabCreateError: If the server failed to perform the request
         """
+        variables = variables or {}
         path = "/projects/%s/trigger/pipeline" % self.get_id()
         post_data = {"ref": ref, "token": token, "variables": variables}
         attrs = self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -2490,7 +2490,7 @@ class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTMan
     _update_uses_post = True
 
     @exc.on_http_error(exc.GitlabUpdateError)
-    def set_approvers(self, approver_ids=[], approver_group_ids=[], **kwargs):
+    def set_approvers(self, approver_ids=None, approver_group_ids=None, **kwargs):
         """Change MR-level allowed approvers and approver groups.
 
         Args:
@@ -2501,6 +2501,9 @@ class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTMan
             GitlabAuthenticationError: If authentication is not correct
             GitlabUpdateError: If the server failed to perform the request
         """
+        approver_ids = approver_ids or []
+        approver_group_ids = approver_group_ids or []
+
         path = "%s/%s/approvers" % (self._parent.manager.path, self._parent.get_id())
         data = {"approver_ids": approver_ids, "approver_group_ids": approver_group_ids}
         self.gitlab.http_put(path, post_data=data, **kwargs)
@@ -3692,7 +3695,7 @@ class ProjectApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
     _update_uses_post = True
 
     @exc.on_http_error(exc.GitlabUpdateError)
-    def set_approvers(self, approver_ids=[], approver_group_ids=[], **kwargs):
+    def set_approvers(self, approver_ids=None, approver_group_ids=None, **kwargs):
         """Change project-level allowed approvers and approver groups.
 
         Args:
@@ -3703,6 +3706,8 @@ class ProjectApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
             GitlabAuthenticationError: If authentication is not correct
             GitlabUpdateError: If the server failed to perform the request
         """
+        approver_ids = approver_ids or []
+        approver_group_ids = approver_group_ids or []
 
         path = "/projects/%s/approvers" % self._parent.get_id()
         data = {"approver_ids": approver_ids, "approver_group_ids": approver_group_ids}


### PR DESCRIPTION
Using mutable default arguments (e.g. `{}` or `[]`) will produce shared instances. More info e.g. [here](https://pythonconquerstheuniverse.wordpress.com/2012/02/15/mutable-default-arguments/).

- Remove empty list default arguments.
- Remove empty dict default arguments.