### PR TITLE
Fix avatar uploading for projects

### DIFF
--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -84,6 +84,13 @@ Update a project::
     project.snippets_enabled = 1
     project.save()
 
+Set the avatar image for a project::
+
+    # the avatar image can be passed as data (content of the file) or as a file
+    # object opened in binary mode
+    project.avatar = open('path/to/file.png', 'rb')
+    project.save()
+
 Delete a project::
 
     gl.projects.delete(project_id)

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -4463,6 +4463,7 @@ class ProjectManager(CRUDMixin, RESTManager):
             "ci_config_path",
         ),
     )
+    _types = {"avatar": types.ImageAttribute}
     _list_filters = (
         "search",
         "owned",


### PR DESCRIPTION
The `avatar` attribute was already set for projects but it wasn't working because the type was missing.