### PR TITLE
feat: add methods to retrieve an individual project environment

### DIFF
--- a/docs/gl_objects/environments.rst
+++ b/docs/gl_objects/environments.rst
@@ -24,6 +24,10 @@ Create an environment for a project::
 
     environment = project.environments.create({'name': 'production'})
 
+Retrieve a specific environment for a project::
+
+    environment = project.environments.get(112)
+
 Update an environment for a project::
 
     environment.external_url = 'http://foo.bar.com'

--- a/gitlab/tests/test_gitlab.py
+++ b/gitlab/tests/test_gitlab.py
@@ -556,6 +556,36 @@ class TestGitlab(unittest.TestCase):
             self.assertEqual(data.name, "name")
             self.assertEqual(data.id, 1)
 
+    def test_project_environments(self):
+        @urlmatch(
+            scheme="http", netloc="localhost", path="/api/v4/projects/1$", method="get"
+        )
+        def resp_get_project(url, request):
+            headers = {"content-type": "application/json"}
+            content = '{"name": "name", "id": 1}'.encode("utf-8")
+            return response(200, content, headers, None, 5, request)
+
+        @urlmatch(
+            scheme="http",
+            netloc="localhost",
+            path="/api/v4/projects/1/environments/1",
+            method="get",
+        )
+        def resp_get_environment(url, request):
+            headers = {"content-type": "application/json"}
+            content = '{"name": "environment_name", "id": 1, "last_deployment": "sometime"}'.encode(
+                "utf-8"
+            )
+            return response(200, content, headers, None, 5, request)
+
+        with HTTMock(resp_get_project, resp_get_environment):
+            project = self.gl.projects.get(1)
+            environment = project.environments.get(1)
+            self.assertIsInstance(environment, ProjectEnvironment)
+            self.assertEqual(environment.id, 1)
+            self.assertEqual(environment.last_deployment, "sometime")
+            self.assertEqual(environment.name, "environment_name")
+
     def test_groups(self):
         @urlmatch(
             scheme="http", netloc="localhost", path="/api/v4/groups/1", method="get"

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -1944,7 +1944,7 @@ class ProjectEnvironment(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectEnvironmentManager(
-    ListMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
+    RetrieveMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
 ):
     _path = "/projects/%(project_id)s/environments"
     _obj_cls = ProjectEnvironment


### PR DESCRIPTION
Gitlab supports this: https://docs.gitlab.com/ce/api/environments.html#get-a-specific-environment

I'm using the same `ProjectEnvironment` object, even though retrieving an environment has wildly more attributes (including nested ones). Please let me know if I should add anything else to this.