### PR TITLE
Fix constructing Gitlab object without authentication

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -355,7 +355,7 @@ class Gitlab(object):
                 bool(arg)
                 for arg in [self.private_token, self.oauth_token, self.job_token]
             )
-            != 1
+            > 1
         ):
             raise ValueError(
                 "Only one of private_token, oauth_token or job_token should "


### PR DESCRIPTION
unauthenticated access is broken since #876 was merged

fixes getting the error `Only one of private_token, oauth_token or job_token should be defined` when using no authentication method at all.