### PR TITLE
Remove warning about open files from test_todo()

### DIFF
--- a/gitlab/tests/test_gitlab.py
+++ b/gitlab/tests/test_gitlab.py
@@ -673,14 +673,15 @@ class TestGitlab(unittest.TestCase):
             self.assertEqual(status.emoji, "thumbsup")
 
     def test_todo(self):
-        todo_content = open(os.path.dirname(__file__) + "/data/todo.json", "r").read()
-        json_content = json.loads(todo_content)
+        with open(os.path.dirname(__file__) + "/data/todo.json", "r") as json_file:
+            todo_content = json_file.read()
+            json_content = json.loads(todo_content)
+            encoded_content = todo_content.encode("utf-8")
 
         @urlmatch(scheme="http", netloc="localhost", path="/api/v4/todos", method="get")
         def resp_get_todo(url, request):
             headers = {"content-type": "application/json"}
-            content = todo_content.encode("utf-8")
-            return response(200, content, headers, None, 5, request)
+            return response(200, encoded_content, headers, None, 5, request)
 
         @urlmatch(
             scheme="http",


### PR DESCRIPTION
When running unittests python warns that the json file from test_todo()
was still open. Use with to open, read, and create encoded json data
that is used by resp_get_todo().