### PR TITLE
fix(projects): support `approval_rules` endpoint for projects

### DIFF
--- a/docs/gl_objects/mr_approvals.rst
+++ b/docs/gl_objects/mr_approvals.rst
@@ -12,6 +12,8 @@ References
 
   + :class:`gitlab.v4.objects.ProjectApproval`
   + :class:`gitlab.v4.objects.ProjectApprovalManager`
+  + :class:`gitlab.v4.objects.ProjectApprovalRule`
+  + :class:`gitlab.v4.objects.ProjectApprovalRuleManager`
   + :attr:`gitlab.v4.objects.Project.approvals`
   + :class:`gitlab.v4.objects.ProjectMergeRequestApproval`
   + :class:`gitlab.v4.objects.ProjectMergeRequestApprovalManager`
@@ -21,6 +23,19 @@ References
 
 Examples
 --------
+
+List project-level MR approval rules::
+
+    p_mras = project.approvalrules.list()
+
+Change project-level MR approval rule::
+
+    p_approvalrule.user_ids = [234]
+    p_approvalrule.save()
+
+Delete project-level MR approval rule::
+
+    p_approvalrule.delete()
 
 Get project-level or MR-level MR approvals settings::
 

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -3777,6 +3777,19 @@ class ProjectApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
         self.gitlab.http_put(path, post_data=data, **kwargs)
 
 
+class ProjectApprovalRule(SaveMixin, ObjectDeleteMixin, RESTObject):
+    _id_attr = "id"
+
+
+class ProjectApprovalRuleManager(
+    ListMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
+):
+    _path = "/projects/%(project_id)s/approval_rules"
+    _obj_cls = ProjectApprovalRule
+    _from_parent_attrs = {"project_id": "id"}
+    _create_attrs = (("name", "approvals_required"), ("user_ids", "group_ids"))
+
+
 class ProjectDeployment(RESTObject, SaveMixin):
     pass
 
@@ -3888,6 +3901,7 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
     _managers = (
         ("accessrequests", "ProjectAccessRequestManager"),
         ("approvals", "ProjectApprovalManager"),
+        ("approvalrules", "ProjectApprovalRuleManager"),
         ("badges", "ProjectBadgeManager"),
         ("boards", "ProjectBoardManager"),
         ("branches", "ProjectBranchManager"),

--- a/tools/ee-test.py
+++ b/tools/ee-test.py
@@ -53,6 +53,22 @@ assert approval.approvals_required == 3
 mr.approvals.set_approvers([1], [])
 approval = mr.approvals.get()
 assert approval.approvers[0]["user"]["id"] == 1
+
+ars = project1.approvalrules.list(all=True)
+assert len(ars) == 0
+project.approvalrules.create(
+    {"name": "approval-rule", "approvals_required": 1, "group_ids": [group1.id]}
+)
+ars = project1.approvalrules.list(all=True)
+assert len(ars) == 1
+ars[0].approvals_required == 2
+ars[0].save()
+ars = project1.approvalrules.list(all=True)
+assert len(ars) == 1
+assert ars[0].approvals_required == 2
+ars[0].delete()
+ars = project1.approvalrules.list(all=True)
+assert len(ars) == 0
 end_log()
 
 start_log("geo nodes")


### PR DESCRIPTION
The `approvers` API endpoint is deprecated [1]. GitLab instead uses
the `approval_rules` API endpoint to modify approval settings for
merge requests. This adds the functionality for project-level
merge request approval settings.

Note that there does not exist an endpoint to 'get' a single
approval rule at this moment - only 'list'.

[1] https://docs.gitlab.com/ee/api/merge_request_approvals.html