### PR TITLE
fix(labels): ensure label.save() works

### DIFF
--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -914,7 +914,7 @@ class GroupLabelManager(ListMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         new_data = new_data or {}
         if name:
             new_data["name"] = name
-        super().update(id=None, new_data=new_data, **kwargs)
+        return super().update(id=None, new_data=new_data, **kwargs)
 
     # Delete without ID.
     @exc.on_http_error(exc.GitlabDeleteError)
@@ -3049,7 +3049,7 @@ class ProjectLabelManager(
         new_data = new_data or {}
         if name:
             new_data["name"] = name
-        super().update(id=None, new_data=new_data, **kwargs)
+        return super().update(id=None, new_data=new_data, **kwargs)
 
     # Delete without ID.
     @exc.on_http_error(exc.GitlabDeleteError)


### PR DESCRIPTION
Otherwise, we get:
```
   File "gitlabracadabra/mixins/labels.py", line 67, in _process_labels
     current_label.save()
   File "gitlab/exceptions.py", line 267, in wrapped_f
     return f(*args, **kwargs)
   File "gitlab/v4/objects.py", line 896, in save
     self._update_attrs(server_data)
   File "gitlab/base.py", line 131, in _update_attrs
     self.__dict__["_attrs"].update(new_attrs)
 TypeError: 'NoneType' object is not iterable
```

Because `server_data` is `None`.