### PR TITLE
README.rst: fix the upstream Docker image reference

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ How to use
 
 or run it directly from the upstream image:
 
-``docker run -it --rm -e GITLAB_PRIVATE_TOKEN=<your token> -v /path/to/python-gitlab.cfg:/python-gitlab.cfg registry.gitlab.com/python-gitlab/python-gitlab:v1.8.0 <command> ...``
+``docker run -it --rm -e GITLAB_PRIVATE_TOKEN=<your token> -v /path/to/python-gitlab.cfg:/python-gitlab.cfg registry.gitlab.com/python-gitlab/python-gitlab:latest <command> ...``
 
 To change the GitLab URL, use `-e GITLAB_URL=<your url>`
 


### PR DESCRIPTION
v1.8.0 is not available.
```
Unable to find image 'registry.gitlab.com/python-gitlab/python-gitlab:v1.8.0' locally
docker: Error response from daemon: manifest for registry.gitlab.com/python-gitlab/python-gitlab:v1.8.0 not found: manifest unknown: manifest unknown.
```