### PR TITLE
feat: add support for /import/github

### DIFF
--- a/docs/api-usage.rst
+++ b/docs/api-usage.rst
@@ -366,3 +366,20 @@ default an exception is raised for these errors.
 
    gl = gitlab.gitlab(url, token, api_version=4)
    gl.projects.list(all=True, retry_transient_errors=True)
+
+Timeout
+-------
+
+python-gitlab will by default use the ``timeout`` option from it's configuration
+for all requests. This is passed downwards to the ``requests`` module at the
+time of making the HTTP request. However if you would like to override the
+global timeout parameter for a particular call, you can provide the ``timeout``
+parameter to that API invocation:
+
+.. code-block:: python
+
+   import gitlab
+
+   gl = gitlab.gitlab(url, token, api_version=4)
+   gl.projects.import_github(ACCESS_TOKEN, 123456, "root", timeout=120.0)
+

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -491,6 +491,8 @@ class Gitlab(object):
 
         verify = opts.pop("verify")
         timeout = opts.pop("timeout")
+        # If timeout was passed into kwargs, allow it to override the default
+        timeout = kwargs.get("timeout", timeout)
 
         # We need to deal with json vs. data when uploading files
         if files:


### PR DESCRIPTION
Addresses #952

This adds a method to the `ProjectManager` called `import_github`, which maps to the `/import/github` API endpoint. Calling `import_github` will trigger an import operation from <repo_id> into <target_namespace>, using <personal_access_token> to authenticate against github. In practice a gitlab server may take many 10's of seconds to respond to this API call, so we also take the liberty of increasing the default timeout (only for this method invocation).

Unfortunately since `import` is a protected keyword in python, I was unable to follow the endpoint structure with the manager namespace (eg: `gitlab.import.github` is not allowed`). I'm open to suggestions on a more sensible interface.

I'm successfully using this addition to batch-import hundreds of github repositories into gitlab. I didn't see any low-hanging-fruit way to add a unit test for this - please advise if this is acceptable.