### PR TITLE
Nicer stacktrace

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -837,8 +837,10 @@ class GitlabList(object):
             self._current += 1
             return item
         except IndexError:
-            if self._next_url and self._get_next is True:
-                self._query(self._next_url)
-                return self.next()
+            pass
 
-            raise StopIteration
+        if self._next_url and self._get_next is True:
+            self._query(self._next_url)
+            return self.next()
+
+        raise StopIteration


### PR DESCRIPTION
Otherwise the stacktrace is like:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/gitlab/__init__.py", line 832, in next
    item = self._data[self._current]
IndexError: list index out of range

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./bot.py", line 241, in <module>
    main(sys.argv)
  File "./bot.py", line 209, in main
    for project in projects:
  File "/usr/local/lib/python3.6/site-packages/gitlab/base.py", line 184, in __next__
    return self.next()
  File "/usr/local/lib/python3.6/site-packages/gitlab/base.py", line 187, in next
    data = self._list.next()
  File "/usr/local/lib/python3.6/site-packages/gitlab/__init__.py", line 837, in next
    self._query(self._next_url)
  File "/usr/local/lib/python3.6/site-packages/gitlab/__init__.py", line 766, in _query
    result = self._gl.http_request("get", url, query_data=query_data, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/gitlab/__init__.py", line 562, in http_request
    response_body=result.content,
gitlab.exceptions.GitlabHttpError: 502: GitLab is not responding
```