### PR TITLE
docs(projects): fix file deletion docs

### DIFF
--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -368,7 +368,7 @@ encoded text::
 
 Delete a file::
 
-    f.delete(commit_message='Delete testfile')
+    f.delete(commit_message='Delete testfile', branch='master')
 
 Get file blame::
 


### PR DESCRIPTION
The function `file.delete()` requires `branch` argument in addition to `commit_message`.

Closes #965