### PR TITLE
chore: build_sphinx needs sphinx >= 1.7.6

### DIFF
--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
 jinja2
-sphinx>=1.3
+sphinx>=1.7.6


### PR DESCRIPTION
Stepping thru Sphinx versions from 1.6.5 to 1.7.5 build_sphinx fails.  Once Sphinx == 1.7.6 build_sphinx finished.