### PR TITLE
WIP: migrate to asyncio and httpx

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -23,6 +23,7 @@ import time
 import warnings
 
 import httpx
+import asyncio
 
 import gitlab.config
 from gitlab.const import *  # noqa
@@ -146,8 +147,9 @@ class Gitlab(object):
     def __enter__(self):
         return self
 
-    async def __exit__(self, *args):
-        await self.client.aclose()
+    def __exit__(self, *args):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self.client.aclose())
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -27,10 +27,17 @@ import asyncio
 
 import gitlab.config
 from gitlab.const import *  # noqa
-from gitlab.exceptions import (on_http_error, GitlabVerifyError,
-                               GitlabMarkdownError, GitlabLicenseError, RedirectError,
-                               GitlabHttpError, GitlabAuthenticationError,
-                               GitlabParsingError, GitlabSearchError)
+from gitlab.exceptions import (
+    on_http_error,
+    GitlabVerifyError,
+    GitlabMarkdownError,
+    GitlabLicenseError,
+    RedirectError,
+    GitlabHttpError,
+    GitlabAuthenticationError,
+    GitlabParsingError,
+    GitlabSearchError,
+)
 from gitlab import utils  # noqa
 
 __title__ = "python-gitlab"
@@ -572,7 +579,9 @@ class Gitlab(object):
                 response_body=result.content,
             )
 
-    async def http_get(self, path, query_data=None, streamed=False, raw=False, **kwargs):
+    async def http_get(
+        self, path, query_data=None, streamed=False, raw=False, **kwargs
+    ):
         """Make a GET request to the Gitlab server.
 
         Args:
@@ -650,8 +659,9 @@ class Gitlab(object):
         # No pagination, generator requested
         return GitlabList(self, url, query_data, **kwargs)
 
-    async def http_post(self, path, query_data=None,
-                        post_data=None, files=None, **kwargs):
+    async def http_post(
+        self, path, query_data=None, post_data=None, files=None, **kwargs
+    ):
         """Make a POST request to the Gitlab server.
 
         Args:
@@ -689,8 +699,9 @@ class Gitlab(object):
             raise GitlabParsingError(error_message="Failed to parse the server message")
         return result
 
-    async def http_put(self, path, query_data=None,
-                       post_data=None, files=None, **kwargs):
+    async def http_put(
+        self, path, query_data=None, post_data=None, files=None, **kwargs
+    ):
         """Make a PUT request to the Gitlab server.
 
         Args:
@@ -775,10 +786,9 @@ class GitlabList(object):
 
     async def _query(self, url, query_data=None, **kwargs):
         query_data = query_data or {}
-        result = await self._gl.http_request("get",
-                                             url,
-                                             query_data=query_data,
-                                             **kwargs)
+        result = await self._gl.http_request(
+            "get", url, query_data=query_data, **kwargs
+        )
         try:
             self._next_url = result.links["next"]["url"]
         except KeyError:

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -80,6 +80,7 @@ class GetWithoutIdMixin(object):
         loop = asyncio.get_event_loop()
         return loop.run_until_complete(self.async_get(id, **kwargs))
 
+
 class RefreshMixin(object):
     @exc.on_http_error(exc.GitlabGetError)
     async def async_refresh(self, **kwargs):
@@ -217,8 +218,9 @@ class CreateMixin(object):
 
         # Handle specific URL for creation
         path = kwargs.pop("path", self.path)
-        server_data = await self.gitlab.http_post(path, post_data=data,
-                                                  files=files, **kwargs)
+        server_data = await self.gitlab.http_post(
+            path, post_data=data, files=files, **kwargs
+        )
         return self._obj_cls(self, server_data)
 
     def create(self, data, **kwargs):

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -46,7 +46,7 @@ class SidekiqManager(RESTManager):
 
     @cli.register_custom_action("SidekiqManager")
     @exc.on_http_error(exc.GitlabGetError)
-    def queue_metrics(self, **kwargs):
+    async def queue_metrics(self, **kwargs):
         """Return the registred queues information.
 
         Args:
@@ -63,7 +63,7 @@ class SidekiqManager(RESTManager):
 
     @cli.register_custom_action("SidekiqManager")
     @exc.on_http_error(exc.GitlabGetError)
-    def process_metrics(self, **kwargs):
+    async def process_metrics(self, **kwargs):
         """Return the registred sidekiq workers.
 
         Args:
@@ -76,11 +76,11 @@ class SidekiqManager(RESTManager):
         Returns:
             dict: Information about the register Sidekiq worker
         """
-        return self.gitlab.http_get("/sidekiq/process_metrics", **kwargs)
+        return await self.gitlab.http_get("/sidekiq/process_metrics", **kwargs)
 
     @cli.register_custom_action("SidekiqManager")
     @exc.on_http_error(exc.GitlabGetError)
-    def job_stats(self, **kwargs):
+    async def job_stats(self, **kwargs):
         """Return statistics about the jobs performed.
 
         Args:
@@ -93,11 +93,11 @@ class SidekiqManager(RESTManager):
         Returns:
             dict: Statistics about the Sidekiq jobs performed
         """
-        return self.gitlab.http_get("/sidekiq/job_stats", **kwargs)
+        return await self.gitlab.http_get("/sidekiq/job_stats", **kwargs)
 
     @cli.register_custom_action("SidekiqManager")
     @exc.on_http_error(exc.GitlabGetError)
-    def compound_metrics(self, **kwargs):
+    async def compound_metrics(self, **kwargs):
         """Return all available metrics and statistics.
 
         Args:
@@ -110,7 +110,7 @@ class SidekiqManager(RESTManager):
         Returns:
             dict: All available Sidekiq metrics and statistics
         """
-        return self.gitlab.http_get("/sidekiq/compound_metrics", **kwargs)
+        return await self.gitlab.http_get("/sidekiq/compound_metrics", **kwargs)
 
 
 class Event(RESTObject):
@@ -310,7 +310,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
 
     @cli.register_custom_action("User")
     @exc.on_http_error(exc.GitlabBlockError)
-    def block(self, **kwargs):
+    async def block(self, **kwargs):
         """Block the user.
 
         Args:
@@ -324,14 +324,14 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
             bool: Whether the user status has been changed
         """
         path = "/users/%s/block" % self.id
-        server_data = self.manager.gitlab.http_post(path, **kwargs)
+        server_data = await self.manager.gitlab.http_post(path, **kwargs)
         if server_data is True:
             self._attrs["state"] = "blocked"
         return server_data
 
     @cli.register_custom_action("User")
     @exc.on_http_error(exc.GitlabUnblockError)
-    def unblock(self, **kwargs):
+    async def unblock(self, **kwargs):
         """Unblock the user.
 
         Args:
@@ -345,14 +345,14 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
             bool: Whether the user status has been changed
         """
         path = "/users/%s/unblock" % self.id
-        server_data = self.manager.gitlab.http_post(path, **kwargs)
+        server_data = await self.manager.gitlab.http_post(path, **kwargs)
         if server_data is True:
             self._attrs["state"] = "active"
         return server_data
 
     @cli.register_custom_action("User")
     @exc.on_http_error(exc.GitlabDeactivateError)
-    def deactivate(self, **kwargs):
+    async def deactivate(self, **kwargs):
         """Deactivate the user.
 
         Args:
@@ -366,14 +366,14 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
             bool: Whether the user status has been changed
         """
         path = "/users/%s/deactivate" % self.id
-        server_data = self.manager.gitlab.http_post(path, **kwargs)
+        server_data = await self.manager.gitlab.http_post(path, **kwargs)
         if server_data:
             self._attrs["state"] = "deactivated"
         return server_data
 
     @cli.register_custom_action("User")
     @exc.on_http_error(exc.GitlabActivateError)
-    def activate(self, **kwargs):
+    async def activate(self, **kwargs):
         """Activate the user.
 
         Args:
@@ -387,7 +387,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
             bool: Whether the user status has been changed
         """
         path = "/users/%s/activate" % self.id
-        server_data = self.manager.gitlab.http_post(path, **kwargs)
+        server_data = await self.manager.gitlab.http_post(path, **kwargs)
         if server_data:
             self._attrs["state"] = "active"
         return server_data
@@ -667,7 +667,7 @@ class FeatureManager(ListMixin, DeleteMixin, RESTManager):
     _obj_cls = Feature
 
     @exc.on_http_error(exc.GitlabSetError)
-    def set(self, name, value, feature_group=None, user=None, **kwargs):
+    async def set(self, name, value, feature_group=None, user=None, **kwargs):
         """Create or update the object.
 
         Args:
@@ -686,7 +686,7 @@ class FeatureManager(ListMixin, DeleteMixin, RESTManager):
         """
         path = "%s/%s" % (self.path, name.replace("/", "%2F"))
         data = {"value": value, "feature_group": feature_group, "user": user}
-        server_data = self.gitlab.http_post(path, post_data=data, **kwargs)
+        server_data = await self.gitlab.http_post(path, post_data=data, **kwargs)
         return self._obj_cls(self, server_data)
 
 
@@ -843,7 +843,7 @@ class GroupEpicIssueManager(
     _update_attrs = (tuple(), ("move_before_id", "move_after_id"))
 
     @exc.on_http_error(exc.GitlabCreateError)
-    def create(self, data, **kwargs):
+    async def create(self, data, **kwargs):
         """Create a new object.
 
         Args:
@@ -861,7 +861,7 @@ class GroupEpicIssueManager(
         """
         CreateMixin._check_missing_create_attrs(self, data)
         path = "%s/%s" % (self.path, data.pop("issue_id"))
-        server_data = self.gitlab.http_post(path, **kwargs)
+        server_data = await self.gitlab.http_post(path, **kwargs)
         # The epic_issue_id attribute doesn't exist when creating the resource,
         # but is used everywhere elese. Let's create it to be consistent client
         # side
@@ -973,7 +973,7 @@ class GroupLabelManager(ListMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
 
     # Delete without ID.
     @exc.on_http_error(exc.GitlabDeleteError)
-    def delete(self, name, **kwargs):
+    async def delete(self, name, **kwargs):
         """Delete a Label on the server.
 
         Args:
@@ -984,7 +984,7 @@ class GroupLabelManager(ListMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server cannot perform the request
         """
-        self.gitlab.http_delete(self.path, query_data={"name": name}, **kwargs)
+        await self.gitlab.http_delete(self.path, query_data={"name": name}, **kwargs)
 
 
 class GroupMember(SaveMixin, ObjectDeleteMixin, RESTObject):
@@ -1000,7 +1000,7 @@ class GroupMemberManager(CRUDMixin, RESTManager):
 
     @cli.register_custom_action("GroupMemberManager")
     @exc.on_http_error(exc.GitlabListError)
-    def all(self, **kwargs):
+    async def all(self, **kwargs):
         """List all the members, included inherited ones.
 
         Args:
@@ -1020,7 +1020,7 @@ class GroupMemberManager(CRUDMixin, RESTManager):
         """
 
         path = "%s/all" % self.path
-        obj = self.gitlab.http_list(path, **kwargs)
+        obj = await self.gitlab.http_list(path, **kwargs)
         return [self._obj_cls(self, item) for item in obj]
 
 
@@ -1059,7 +1059,7 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
 
     @cli.register_custom_action("GroupMilestone")
     @exc.on_http_error(exc.GitlabListError)
-    def issues(self, **kwargs):
+    async def issues(self, **kwargs):
         """List issues related to this milestone.
 
         Args:
@@ -1079,14 +1079,14 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
         """
 
         path = "%s/%s/issues" % (self.manager.path, self.get_id())
-        data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
+        data_list = await self.manager.gitlab.http_list(path, as_list=False, **kwargs)
         manager = GroupIssueManager(self.manager.gitlab, parent=self.manager._parent)
         # FIXME(gpocentek): the computed manager path is not correct
         return RESTObjectList(manager, GroupIssue, data_list)
 
     @cli.register_custom_action("GroupMilestone")
     @exc.on_http_error(exc.GitlabListError)
-    def merge_requests(self, **kwargs):
+    async def merge_requests(self, **kwargs):
         """List the merge requests related to this milestone.
 
         Args:
@@ -1105,7 +1105,7 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
             RESTObjectList: The list of merge requests
         """
         path = "%s/%s/merge_requests" % (self.manager.path, self.get_id())
-        data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
+        data_list = await self.manager.gitlab.http_list(path, as_list=False, **kwargs)
         manager = GroupIssueManager(self.manager.gitlab, parent=self.manager._parent)
         # FIXME(gpocentek): the computed manager path is not correct
         return RESTObjectList(manager, GroupMergeRequest, data_list)
@@ -1210,7 +1210,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
 
     @cli.register_custom_action("Group", ("to_project_id",))
     @exc.on_http_error(exc.GitlabTransferProjectError)
-    def transfer_project(self, to_project_id, **kwargs):
+    async def transfer_project(self, to_project_id, **kwargs):
         """Transfer a project to this group.
 
         Args:
@@ -1222,11 +1222,11 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabTransferProjectError: If the project could not be transfered
         """
         path = "/groups/%s/projects/%s" % (self.id, to_project_id)
-        self.manager.gitlab.http_post(path, **kwargs)
+        await self.manager.gitlab.http_post(path, **kwargs)
 
     @cli.register_custom_action("Group", ("scope", "search"))
     @exc.on_http_error(exc.GitlabSearchError)
-    def search(self, scope, search, **kwargs):
+    async def search(self, scope, search, **kwargs):
         """Search the group resources matching the provided string.'
 
         Args:
@@ -1243,11 +1243,11 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
         """
         data = {"scope": scope, "search": search}
         path = "/groups/%s/search" % self.get_id()
-        return self.manager.gitlab.http_list(path, query_data=data, **kwargs)
+        return await self.manager.gitlab.http_list(path, query_data=data, **kwargs)
 
     @cli.register_custom_action("Group", ("cn", "group_access", "provider"))
     @exc.on_http_error(exc.GitlabCreateError)
-    def add_ldap_group_link(self, cn, group_access, provider, **kwargs):
+    async def add_ldap_group_link(self, cn, group_access, provider, **kwargs):
         """Add an LDAP group link.
 
         Args:
@@ -1263,11 +1263,11 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
         """
         path = "/groups/%s/ldap_group_links" % self.get_id()
         data = {"cn": cn, "group_access": group_access, "provider": provider}
-        self.manager.gitlab.http_post(path, post_data=data, **kwargs)
+        await self.manager.gitlab.http_post(path, post_data=data, **kwargs)
 
     @cli.register_custom_action("Group", ("cn",), ("provider",))
     @exc.on_http_error(exc.GitlabDeleteError)
-    def delete_ldap_group_link(self, cn, provider=None, **kwargs):
+    async def delete_ldap_group_link(self, cn, provider=None, **kwargs):
         """Delete an LDAP group link.
 
         Args:
@@ -1283,11 +1283,11 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
         if provider is not None:
             path += "/%s" % provider
         path += "/%s" % cn
-        self.manager.gitlab.http_delete(path)
+        await self.manager.gitlab.http_delete(path)
 
     @cli.register_custom_action("Group")
     @exc.on_http_error(exc.GitlabCreateError)
-    def ldap_sync(self, **kwargs):
+    async def ldap_sync(self, **kwargs):
         """Sync LDAP groups.
 
         Args:
@@ -1298,7 +1298,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabCreateError: If the server cannot perform the request
         """
         path = "/groups/%s/ldap_sync" % self.get_id()
-        self.manager.gitlab.http_post(path, **kwargs)
+        await self.manager.gitlab.http_post(path, **kwargs)
 
 
 class GroupManager(CRUDMixin, RESTManager):
@@ -1386,7 +1386,7 @@ class LDAPGroupManager(RESTManager):
     _list_filters = ("search", "provider")
 
     @exc.on_http_error(exc.GitlabListError)
-    def list(self, **kwargs):
+    async def list(self, **kwargs):
         """Retrieve a list of objects.
 
         Args:
@@ -1413,7 +1413,7 @@ class LDAPGroupManager(RESTManager):
         else:
             path = self._path
 
-        obj = self.gitlab.http_list(path, **data)
+        obj = await self.gitlab.http_list(path, **data)
         if isinstance(obj, list):
             return [self._obj_cls(self, item) for item in obj]
         else:
@@ -1466,7 +1466,7 @@ class Snippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
 
     @cli.register_custom_action("Snippet")
     @exc.on_http_error(exc.GitlabGetError)
-    def content(self, streamed=False, action=None, chunk_size=1024, **kwargs):
+    async def content(self, streamed=False, action=None, chunk_size=1024, **kwargs):
         """Return the content of a snippet.
 
         Args:
@@ -1486,7 +1486,7 @@ class Snippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
             str: The snippet content
         """
         path = "/snippets/%s/raw" % self.get_id()
-        result = self.manager.gitlab.http_get(
+        result = await self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
         return utils.response_content(result, streamed, action, chunk_size)
@@ -1557,7 +1557,7 @@ class ProjectRegistryTagManager(DeleteMixin, RetrieveMixin, RESTManager):
         "ProjectRegistryTagManager", optional=("name_regex", "keep_n", "older_than")
     )
     @exc.on_http_error(exc.GitlabDeleteError)
-    def delete_in_bulk(self, name_regex=".*", **kwargs):
+    async def delete_in_bulk(self, name_regex=".*", **kwargs):
         """Delete Tag in bulk
 
         Args:
@@ -1574,7 +1574,7 @@ class ProjectRegistryTagManager(DeleteMixin, RetrieveMixin, RESTManager):
         valid_attrs = ["keep_n", "older_than"]
         data = {"name_regex": name_regex}
         data.update({k: v for k, v in kwargs.items() if k in valid_attrs})
-        self.gitlab.http_delete(self.path, query_data=data, **kwargs)
+        await self.gitlab.http_delete(self.path, query_data=data, **kwargs)
 
 
 class ProjectBoardList(SaveMixin, ObjectDeleteMixin, RESTObject):
@@ -1607,7 +1607,7 @@ class ProjectBranch(ObjectDeleteMixin, RESTObject):
         "ProjectBranch", tuple(), ("developers_can_push", "developers_can_merge")
     )
     @exc.on_http_error(exc.GitlabProtectError)
-    def protect(self, developers_can_push=False, developers_can_merge=False, **kwargs):
+    async def protect(self, developers_can_push=False, developers_can_merge=False, **kwargs):
         """Protect the branch.
 
         Args:
@@ -1627,12 +1627,12 @@ class ProjectBranch(ObjectDeleteMixin, RESTObject):
             "developers_can_push": developers_can_push,
             "developers_can_merge": developers_can_merge,
         }
-        self.manager.gitlab.http_put(path, post_data=post_data, **kwargs)
+        await self.manager.gitlab.http_put(path, post_data=post_data, **kwargs)
         self._attrs["protected"] = True
 
     @cli.register_custom_action("ProjectBranch")
     @exc.on_http_error(exc.GitlabProtectError)
-    def unprotect(self, **kwargs):
+    async def unprotect(self, **kwargs):
         """Unprotect the branch.
 
         Args:
@@ -1644,7 +1644,7 @@ class ProjectBranch(ObjectDeleteMixin, RESTObject):
         """
         id = self.get_id().replace("/", "%2F")
         path = "%s/%s/unprotect" % (self.manager.path, id)
-        self.manager.gitlab.http_put(path, **kwargs)
+        await self.manager.gitlab.http_put(path, **kwargs)
         self._attrs["protected"] = False
 
 
@@ -1713,7 +1713,7 @@ class ProjectCustomAttributeManager(RetrieveMixin, SetMixin, DeleteMixin, RESTMa
 class ProjectJob(RESTObject, RefreshMixin):
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabJobCancelError)
-    def cancel(self, **kwargs):
+    async def cancel(self, **kwargs):
         """Cancel the job.
 
         Args:
@@ -1724,11 +1724,11 @@ class ProjectJob(RESTObject, RefreshMixin):
             GitlabJobCancelError: If the job could not be canceled
         """
         path = "%s/%s/cancel" % (self.manager.path, self.get_id())
-        self.manager.gitlab.http_post(path)
+        await self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabJobRetryError)
-    def retry(self, **kwargs):
+    async def retry(self, **kwargs):
         """Retry the job.
 
         Args:
@@ -1739,11 +1739,11 @@ class ProjectJob(RESTObject, RefreshMixin):
             GitlabJobRetryError: If the job could not be retried
         """
         path = "%s/%s/retry" % (self.manager.path, self.get_id())
-        self.manager.gitlab.http_post(path)
+        await self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabJobPlayError)
-    def play(self, **kwargs):
+    async def play(self, **kwargs):
         """Trigger a job explicitly.
 
         Args:
@@ -1754,11 +1754,11 @@ class ProjectJob(RESTObject, RefreshMixin):
             GitlabJobPlayError: If the job could not be triggered
         """
         path = "%s/%s/play" % (self.manager.path, self.get_id())
-        self.manager.gitlab.http_post(path)
+        await self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabJobEraseError)
-    def erase(self, **kwargs):
+    async def erase(self, **kwargs):
         """Erase the job (remove job artifacts and trace).
 
         Args:
@@ -1769,11 +1769,11 @@ class ProjectJob(RESTObject, RefreshMixin):
             GitlabJobEraseError: If the job could not be erased
         """
         path = "%s/%s/erase" % (self.manager.path, self.get_id())
-        self.manager.gitlab.http_post(path)
+        await self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabCreateError)
-    def keep_artifacts(self, **kwargs):
+    async def keep_artifacts(self, **kwargs):
         """Prevent artifacts from being deleted when expiration is set.
 
         Args:
@@ -1784,11 +1784,11 @@ class ProjectJob(RESTObject, RefreshMixin):
             GitlabCreateError: If the request could not be performed
         """
         path = "%s/%s/artifacts/keep" % (self.manager.path, self.get_id())
-        self.manager.gitlab.http_post(path)
+        await self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabCreateError)
-    def delete_artifacts(self, **kwargs):
+    async def delete_artifacts(self, **kwargs):
         """Delete artifacts of a job.
 
         Args:
@@ -1799,11 +1799,11 @@ class ProjectJob(RESTObject, RefreshMixin):
             GitlabDeleteError: If the request could not be performed
         """
         path = "%s/%s/artifacts" % (self.manager.path, self.get_id())
-        self.manager.gitlab.http_delete(path)
+        await self.manager.gitlab.http_delete(path)
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabGetError)
-    def artifacts(self, streamed=False, action=None, chunk_size=1024, **kwargs):
+    async def artifacts(self, streamed=False, action=None, chunk_size=1024, **kwargs):
         """Get the job artifacts.
 
         Args:
@@ -1823,14 +1823,14 @@ class ProjectJob(RESTObject, RefreshMixin):
             str: The artifacts if `streamed` is False, None otherwise.
         """
         path = "%s/%s/artifacts" % (self.manager.path, self.get_id())
-        result = self.manager.gitlab.http_get(
+        result = await self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
         return utils.response_content(result, streamed, action, chunk_size)
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabGetError)
-    def artifact(self, path, streamed=False, action=None, chunk_size=1024, **kwargs):
+    async def artifact(self, path, streamed=False, action=None, chunk_size=1024, **kwargs):
         """Get a single artifact file from within the job's artifacts archive.
 
         Args:
@@ -1851,14 +1851,14 @@ class ProjectJob(RESTObject, RefreshMixin):
             str: The artifacts if `streamed` is False, None otherwise.
         """
         path = "%s/%s/artifacts/%s" % (self.manager.path, self.get_id(), path)
-        result = self.manager.gitlab.http_get(
+        result = await self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
         return utils.response_content(result, streamed, action, chunk_size)
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabGetError)
-    def trace(self, streamed=False, action=None, chunk_size=1024, **kwargs):
+    async def trace(self, streamed=False, action=None, chunk_size=1024, **kwargs):
         """Get the job trace.
 
         Args:
@@ -1878,7 +1878,7 @@ class ProjectJob(RESTObject, RefreshMixin):
             str: The trace
         """
         path = "%s/%s/trace" % (self.manager.path, self.get_id())
-        result = self.manager.gitlab.http_get(
+        result = await self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
         return utils.response_content(result, streamed, action, chunk_size)
@@ -1986,7 +1986,7 @@ class ProjectCommit(RESTObject):
 
     @cli.register_custom_action("ProjectCommit")
     @exc.on_http_error(exc.GitlabGetError)
-    def diff(self, **kwargs):
+    async def diff(self, **kwargs):
         """Generate the commit diff.
 
         Args:
@@ -2000,11 +2000,11 @@ class ProjectCommit(RESTObject):
             list: The changes done in this commit
         """
         path = "%s/%s/diff" % (self.manager.path, self.get_id())
-        return self.manager.gitlab.http_get(path, **kwargs)
+        return await self.manager.gitlab.http_get(path, **kwargs)
 
     @cli.register_custom_action("ProjectCommit", ("branch",))
     @exc.on_http_error(exc.GitlabCherryPickError)
-    def cherry_pick(self, branch, **kwargs):
+    async def cherry_pick(self, branch, **kwargs):
         """Cherry-pick a commit into a branch.
 
         Args:
@@ -2017,11 +2017,11 @@ class ProjectCommit(RESTObject):
         """
         path = "%s/%s/cherry_pick" % (self.manager.path, self.get_id())
         post_data = {"branch": branch}
-        self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
+        await self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
 
     @cli.register_custom_action("ProjectCommit", optional=("type",))
     @exc.on_http_error(exc.GitlabGetError)
-    def refs(self, type="all", **kwargs):
+    async def refs(self, type="all", **kwargs):
         """List the references the commit is pushed to.
 
         Args:
@@ -2037,11 +2037,11 @@ class ProjectCommit(RESTObject):
         """
         path = "%s/%s/refs" % (self.manager.path, self.get_id())
         data = {"type": type}
-        return self.manager.gitlab.http_get(path, query_data=data, **kwargs)
+        return await self.manager.gitlab.http_get(path, query_data=data, **kwargs)
 
     @cli.register_custom_action("ProjectCommit")
     @exc.on_http_error(exc.GitlabGetError)
-    def merge_requests(self, **kwargs):
+    async def merge_requests(self, **kwargs):
         """List the merge requests related to the commit.
 
         Args:
@@ -2055,7 +2055,7 @@ class ProjectCommit(RESTObject):
             list: The merge requests related to the commit.
         """
         path = "%s/%s/merge_requests" % (self.manager.path, self.get_id())
-        return self.manager.gitlab.http_get(path, **kwargs)
+        return await self.manager.gitlab.http_get(path, **kwargs)
 
 
 class ProjectCommitManager(RetrieveMixin, CreateMixin, RESTManager):
@@ -2071,7 +2071,7 @@ class ProjectCommitManager(RetrieveMixin, CreateMixin, RESTManager):
 class ProjectEnvironment(SaveMixin, ObjectDeleteMixin, RESTObject):
     @cli.register_custom_action("ProjectEnvironment")
     @exc.on_http_error(exc.GitlabStopError)
-    def stop(self, **kwargs):
+    async def stop(self, **kwargs):
         """Stop the environment.
 
         Args:
@@ -2082,7 +2082,7 @@ class ProjectEnvironment(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabStopError: If the operation failed
         """
         path = "%s/%s/stop" % (self.manager.path, self.get_id())
-        self.manager.gitlab.http_post(path, **kwargs)
+        await self.manager.gitlab.http_post(path, **kwargs)
 
 
 class ProjectEnvironmentManager(
@@ -2108,7 +2108,7 @@ class ProjectKeyManager(CRUDMixin, RESTManager):
 
     @cli.register_custom_action("ProjectKeyManager", ("key_id",))
     @exc.on_http_error(exc.GitlabProjectDeployKeyError)
-    def enable(self, key_id, **kwargs):
+    async def enable(self, key_id, **kwargs):
         """Enable a deploy key for a project.
 
         Args:
@@ -2120,7 +2120,7 @@ class ProjectKeyManager(CRUDMixin, RESTManager):
             GitlabProjectDeployKeyError: If the key could not be enabled
         """
         path = "%s/%s/enable" % (self.path, key_id)
-        self.gitlab.http_post(path, **kwargs)
+        await self.gitlab.http_post(path, **kwargs)
 
 
 class ProjectBadge(SaveMixin, ObjectDeleteMixin, RESTObject):
@@ -2315,7 +2315,7 @@ class ProjectIssueLinkManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
     _create_attrs = (("target_project_id", "target_issue_iid"), tuple())
 
     @exc.on_http_error(exc.GitlabCreateError)
-    def create(self, data, **kwargs):
+    async def create(self, data, **kwargs):
         """Create a new object.
 
         Args:
@@ -2331,7 +2331,7 @@ class ProjectIssueLinkManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
             GitlabCreateError: If the server cannot perform the request
         """
         self._check_missing_create_attrs(data)
-        server_data = self.gitlab.http_post(self.path, post_data=data, **kwargs)
+        server_data = await self.gitlab.http_post(self.path, post_data=data, **kwargs)
         source_issue = ProjectIssue(self._parent.manager, server_data["source_issue"])
         target_issue = ProjectIssue(self._parent.manager, server_data["target_issue"])
         return source_issue, target_issue
@@ -2369,7 +2369,7 @@ class ProjectIssue(
 
     @cli.register_custom_action("ProjectIssue", ("to_project_id",))
     @exc.on_http_error(exc.GitlabUpdateError)
-    def move(self, to_project_id, **kwargs):
+    async def move(self, to_project_id, **kwargs):
         """Move the issue to another project.
 
         Args:
@@ -2382,12 +2382,12 @@ class ProjectIssue(
         """
         path = "%s/%s/move" % (self.manager.path, self.get_id())
         data = {"to_project_id": to_project_id}
-        server_data = self.manager.gitlab.http_post(path, post_data=data, **kwargs)
+        server_data = await self.manager.gitlab.http_post(path, post_data=data, **kwargs)
         self._update_attrs(server_data)
 
     @cli.register_custom_action("ProjectIssue")
     @exc.on_http_error(exc.GitlabGetError)
-    def related_merge_requests(self, **kwargs):
+    async def related_merge_requests(self, **kwargs):
         """List merge requests related to the issue.
 
         Args:
@@ -2401,11 +2401,11 @@ class ProjectIssue(
             list: The list of merge requests.
         """
         path = "%s/%s/related_merge_requests" % (self.manager.path, self.get_id())
-        return self.manager.gitlab.http_get(path, **kwargs)
+        return await self.manager.gitlab.http_get(path, **kwargs)
 
     @cli.register_custom_action("ProjectIssue")
     @exc.on_http_error(exc.GitlabGetError)
-    def closed_by(self, **kwargs):
+    async def closed_by(self, **kwargs):
         """List merge requests that will close the issue when merged.
 
         Args:
@@ -2419,7 +2419,7 @@ class ProjectIssue(
             list: The list of merge requests.
         """
         path = "%s/%s/closed_by" % (self.manager.path, self.get_id())
-        return self.manager.gitlab.http_get(path, **kwargs)
+        return await self.manager.gitlab.http_get(path, **kwargs)
 
 
 class ProjectIssueManager(CRUDMixin, RESTManager):
@@ -2490,7 +2490,7 @@ class ProjectMemberManager(CRUDMixin, RESTManager):
 
     @cli.register_custom_action("ProjectMemberManager")
     @exc.on_http_error(exc.GitlabListError)
-    def all(self, **kwargs):
+    async def all(self, **kwargs):
         """List all the members, included inherited ones.
 
         Args:
@@ -2510,7 +2510,7 @@ class ProjectMemberManager(CRUDMixin, RESTManager):
         """
 
         path = "%s/all" % self.path
-        obj = self.gitlab.http_list(path, **kwargs)
+        obj = await self.gitlab.http_list(path, **kwargs)
         return [self._obj_cls(self, item) for item in obj]
 
 
@@ -2563,7 +2563,7 @@ class ProjectTag(ObjectDeleteMixin, RESTObject):
     _short_print_attr = "name"
 
     @cli.register_custom_action("ProjectTag", ("description",))
-    def set_release_description(self, description, **kwargs):
+    async def set_release_description(self, description, **kwargs):
         """Set the release notes on the tag.
 
         If the release doesn't exist yet, it will be created. If it already
@@ -2583,14 +2583,14 @@ class ProjectTag(ObjectDeleteMixin, RESTObject):
         data = {"description": description}
         if self.release is None:
             try:
-                server_data = self.manager.gitlab.http_post(
+                server_data = await self.manager.gitlab.http_post(
                     path, post_data=data, **kwargs
                 )
             except exc.GitlabHttpError as e:
                 raise exc.GitlabCreateError(e.response_code, e.error_message)
         else:
             try:
-                server_data = self.manager.gitlab.http_put(
+                server_data = await self.manager.gitlab.http_put(
                     path, post_data=data, **kwargs
                 )
             except exc.GitlabHttpError as e:
@@ -2629,7 +2629,7 @@ class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTMan
     _update_uses_post = True
 
     @exc.on_http_error(exc.GitlabUpdateError)
-    def set_approvers(self, approver_ids=None, approver_group_ids=None, **kwargs):
+    async def set_approvers(self, approver_ids=None, approver_group_ids=None, **kwargs):
         """Change MR-level allowed approvers and approver groups.
 
         Args:
@@ -2645,7 +2645,7 @@ class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTMan
 
         path = "%s/%s/approvers" % (self._parent.manager.path, self._parent.get_id())
         data = {"approver_ids": approver_ids, "approver_group_ids": approver_group_ids}
-        self.gitlab.http_put(path, post_data=data, **kwargs)
+        await self.gitlab.http_put(path, post_data=data, **kwargs)
 
 
 class ProjectMergeRequestAwardEmoji(ObjectDeleteMixin, RESTObject):
@@ -2768,7 +2768,7 @@ class ProjectMergeRequest(
 
     @cli.register_custom_action("ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabMROnBuildSuccessError)
-    def cancel_merge_when_pipeline_succeeds(self, **kwargs):
+    async def cancel_merge_when_pipeline_succeeds(self, **kwargs):
         """Cancel merge when the pipeline succeeds.
 
         Args:
@@ -2784,12 +2784,12 @@ class ProjectMergeRequest(
             self.manager.path,
             self.get_id(),
         )
-        server_data = self.manager.gitlab.http_put(path, **kwargs)
+        server_data = await self.manager.gitlab.http_put(path, **kwargs)
         self._update_attrs(server_data)
 
     @cli.register_custom_action("ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabListError)
-    def closes_issues(self, **kwargs):
+    async def closes_issues(self, **kwargs):
         """List issues that will close on merge."
 
         Args:
@@ -2808,13 +2808,13 @@ class ProjectMergeRequest(
             RESTObjectList: List of issues
         """
         path = "%s/%s/closes_issues" % (self.manager.path, self.get_id())
-        data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
+        data_list = await self.manager.gitlab.http_list(path, as_list=False, **kwargs)
         manager = ProjectIssueManager(self.manager.gitlab, parent=self.manager._parent)
         return RESTObjectList(manager, ProjectIssue, data_list)
 
     @cli.register_custom_action("ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabListError)
-    def commits(self, **kwargs):
+    async def commits(self, **kwargs):
         """List the merge request commits.
 
         Args:
@@ -2834,13 +2834,13 @@ class ProjectMergeRequest(
         """
 
         path = "%s/%s/commits" % (self.manager.path, self.get_id())
-        data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
+        data_list = await self.manager.gitlab.http_list(path, as_list=False, **kwargs)
         manager = ProjectCommitManager(self.manager.gitlab, parent=self.manager._parent)
         return RESTObjectList(manager, ProjectCommit, data_list)
 
     @cli.register_custom_action("ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabListError)
-    def changes(self, **kwargs):
+    async def changes(self, **kwargs):
         """List the merge request changes.
 
         Args:
@@ -2854,11 +2854,11 @@ class ProjectMergeRequest(
             RESTObjectList: List of changes
         """
         path = "%s/%s/changes" % (self.manager.path, self.get_id())
-        return self.manager.gitlab.http_get(path, **kwargs)
+        return await self.manager.gitlab.http_get(path, **kwargs)
 
     @cli.register_custom_action("ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabListError)
-    def pipelines(self, **kwargs):
+    async def pipelines(self, **kwargs):
         """List the merge request pipelines.
 
         Args:
@@ -2873,11 +2873,11 @@ class ProjectMergeRequest(
         """
 
         path = "%s/%s/pipelines" % (self.manager.path, self.get_id())
-        return self.manager.gitlab.http_get(path, **kwargs)
+        return await self.manager.gitlab.http_get(path, **kwargs)
 
     @cli.register_custom_action("ProjectMergeRequest", tuple(), ("sha"))
     @exc.on_http_error(exc.GitlabMRApprovalError)
-    def approve(self, sha=None, **kwargs):
+    async def approve(self, sha=None, **kwargs):
         """Approve the merge request.
 
         Args:
@@ -2893,12 +2893,12 @@ class ProjectMergeRequest(
         if sha:
             data["sha"] = sha
 
-        server_data = self.manager.gitlab.http_post(path, post_data=data, **kwargs)
+        server_data = await self.manager.gitlab.http_post(path, post_data=data, **kwargs)
         self._update_attrs(server_data)
 
     @cli.register_custom_action("ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabMRApprovalError)
-    def unapprove(self, **kwargs):
+    async def unapprove(self, **kwargs):
         """Unapprove the merge request.
 
         Args:
@@ -2911,12 +2911,12 @@ class ProjectMergeRequest(
         path = "%s/%s/unapprove" % (self.manager.path, self.get_id())
         data = {}
 
-        server_data = self.manager.gitlab.http_post(path, post_data=data, **kwargs)
+        server_data = await self.manager.gitlab.http_post(path, post_data=data, **kwargs)
         self._update_attrs(server_data)
 
     @cli.register_custom_action("ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabMRRebaseError)
-    def rebase(self, **kwargs):
+    async def rebase(self, **kwargs):
         """Attempt to rebase the source branch onto the target branch
 
         Args:
@@ -2928,7 +2928,7 @@ class ProjectMergeRequest(
         """
         path = "%s/%s/rebase" % (self.manager.path, self.get_id())
         data = {}
-        return self.manager.gitlab.http_put(path, post_data=data, **kwargs)
+        return await self.manager.gitlab.http_put(path, post_data=data, **kwargs)
 
     @cli.register_custom_action(
         "ProjectMergeRequest",
@@ -2940,7 +2940,7 @@ class ProjectMergeRequest(
         ),
     )
     @exc.on_http_error(exc.GitlabMRClosedError)
-    def merge(
+    async def merge(
         self,
         merge_commit_message=None,
         should_remove_source_branch=False,
@@ -2970,7 +2970,7 @@ class ProjectMergeRequest(
         if merge_when_pipeline_succeeds:
             data["merge_when_pipeline_succeeds"] = True
 
-        server_data = self.manager.gitlab.http_put(path, post_data=data, **kwargs)
+        server_data = await self.manager.gitlab.http_put(path, post_data=data, **kwargs)
         self._update_attrs(server_data)
 
 
@@ -3034,7 +3034,7 @@ class ProjectMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
 
     @cli.register_custom_action("ProjectMilestone")
     @exc.on_http_error(exc.GitlabListError)
-    def issues(self, **kwargs):
+    async def issues(self, **kwargs):
         """List issues related to this milestone.
 
         Args:
@@ -3054,14 +3054,14 @@ class ProjectMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
         """
 
         path = "%s/%s/issues" % (self.manager.path, self.get_id())
-        data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
+        data_list = await self.manager.gitlab.http_list(path, as_list=False, **kwargs)
         manager = ProjectIssueManager(self.manager.gitlab, parent=self.manager._parent)
         # FIXME(gpocentek): the computed manager path is not correct
         return RESTObjectList(manager, ProjectIssue, data_list)
 
     @cli.register_custom_action("ProjectMilestone")
     @exc.on_http_error(exc.GitlabListError)
-    def merge_requests(self, **kwargs):
+    async def merge_requests(self, **kwargs):
         """List the merge requests related to this milestone.
 
         Args:
@@ -3080,7 +3080,7 @@ class ProjectMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
             RESTObjectList: The list of merge requests
         """
         path = "%s/%s/merge_requests" % (self.manager.path, self.get_id())
-        data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
+        data_list = await self.manager.gitlab.http_list(path, as_list=False, **kwargs)
         manager = ProjectMergeRequestManager(
             self.manager.gitlab, parent=self.manager._parent
         )
@@ -3151,7 +3151,7 @@ class ProjectLabelManager(
 
     # Delete without ID.
     @exc.on_http_error(exc.GitlabDeleteError)
-    def delete(self, name, **kwargs):
+    async def delete(self, name, **kwargs):
         """Delete a Label on the server.
 
         Args:
@@ -3162,7 +3162,7 @@ class ProjectLabelManager(
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server cannot perform the request
         """
-        self.gitlab.http_delete(self.path, query_data={"name": name}, **kwargs)
+        await self.gitlab.http_delete(self.path, query_data={"name": name}, **kwargs)
 
 
 class ProjectFile(SaveMixin, ObjectDeleteMixin, RESTObject):
@@ -3250,7 +3250,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         ("encoding", "author_email", "author_name"),
     )
     @exc.on_http_error(exc.GitlabCreateError)
-    def create(self, data, **kwargs):
+    async def create(self, data, **kwargs):
         """Create a new object.
 
         Args:
@@ -3271,11 +3271,11 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         new_data = data.copy()
         file_path = new_data.pop("file_path").replace("/", "%2F")
         path = "%s/%s" % (self.path, file_path)
-        server_data = self.gitlab.http_post(path, post_data=new_data, **kwargs)
+        server_data = await self.gitlab.http_post(path, post_data=new_data, **kwargs)
         return self._obj_cls(self, server_data)
 
     @exc.on_http_error(exc.GitlabUpdateError)
-    def update(self, file_path, new_data=None, **kwargs):
+    async def update(self, file_path, new_data=None, **kwargs):
         """Update an object on the server.
 
         Args:
@@ -3296,13 +3296,13 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         data["file_path"] = file_path
         path = "%s/%s" % (self.path, file_path)
         self._check_missing_update_attrs(data)
-        return self.gitlab.http_put(path, post_data=data, **kwargs)
+        return await self.gitlab.http_put(path, post_data=data, **kwargs)
 
     @cli.register_custom_action(
         "ProjectFileManager", ("file_path", "branch", "commit_message")
     )
     @exc.on_http_error(exc.GitlabDeleteError)
-    def delete(self, file_path, branch, commit_message, **kwargs):
+    async def delete(self, file_path, branch, commit_message, **kwargs):
         """Delete a file on the server.
 
         Args:
@@ -3317,11 +3317,11 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         """
         path = "%s/%s" % (self.path, file_path.replace("/", "%2F"))
         data = {"branch": branch, "commit_message": commit_message}
-        self.gitlab.http_delete(path, query_data=data, **kwargs)
+        await self.gitlab.http_delete(path, query_data=data, **kwargs)
 
     @cli.register_custom_action("ProjectFileManager", ("file_path", "ref"))
     @exc.on_http_error(exc.GitlabGetError)
-    def raw(
+    async def raw(
         self, file_path, ref, streamed=False, action=None, chunk_size=1024, **kwargs
     ):
         """Return the content of a file for a commit.
@@ -3347,14 +3347,14 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         file_path = file_path.replace("/", "%2F").replace(".", "%2E")
         path = "%s/%s/raw" % (self.path, file_path)
         query_data = {"ref": ref}
-        result = self.gitlab.http_get(
+        result = await self.gitlab.http_get(
             path, query_data=query_data, streamed=streamed, raw=True, **kwargs
         )
         return utils.response_content(result, streamed, action, chunk_size)
 
     @cli.register_custom_action("ProjectFileManager", ("file_path", "ref"))
     @exc.on_http_error(exc.GitlabListError)
-    def blame(self, file_path, ref, **kwargs):
+    async def blame(self, file_path, ref, **kwargs):
         """Return the content of a file for a commit.
 
         Args:
@@ -3372,7 +3372,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         file_path = file_path.replace("/", "%2F").replace(".", "%2E")
         path = "%s/%s/blame" % (self.path, file_path)
         query_data = {"ref": ref}
-        return self.gitlab.http_list(path, query_data, **kwargs)
+        return await self.gitlab.http_list(path, query_data, **kwargs)
 
 
 class ProjectPipelineJob(RESTObject):
@@ -3404,7 +3404,7 @@ class ProjectPipeline(RESTObject, RefreshMixin, ObjectDeleteMixin):
 
     @cli.register_custom_action("ProjectPipeline")
     @exc.on_http_error(exc.GitlabPipelineCancelError)
-    def cancel(self, **kwargs):
+    async def cancel(self, **kwargs):
         """Cancel the job.
 
         Args:
@@ -3415,11 +3415,11 @@ class ProjectPipeline(RESTObject, RefreshMixin, ObjectDeleteMixin):
             GitlabPipelineCancelError: If the request failed
         """
         path = "%s/%s/cancel" % (self.manager.path, self.get_id())
-        self.manager.gitlab.http_post(path)
+        await self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectPipeline")
     @exc.on_http_error(exc.GitlabPipelineRetryError)
-    def retry(self, **kwargs):
+    async def retry(self, **kwargs):
         """Retry the job.
 
         Args:
@@ -3430,7 +3430,7 @@ class ProjectPipeline(RESTObject, RefreshMixin, ObjectDeleteMixin):
             GitlabPipelineRetryError: If the request failed
         """
         path = "%s/%s/retry" % (self.manager.path, self.get_id())
-        self.manager.gitlab.http_post(path)
+        await self.manager.gitlab.http_post(path)
 
 
 class ProjectPipelineManager(RetrieveMixin, CreateMixin, DeleteMixin, RESTManager):
@@ -3492,7 +3492,7 @@ class ProjectPipelineSchedule(SaveMixin, ObjectDeleteMixin, RESTObject):
 
     @cli.register_custom_action("ProjectPipelineSchedule")
     @exc.on_http_error(exc.GitlabOwnershipError)
-    def take_ownership(self, **kwargs):
+    async def take_ownership(self, **kwargs):
         """Update the owner of a pipeline schedule.
 
         Args:
@@ -3503,7 +3503,7 @@ class ProjectPipelineSchedule(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabOwnershipError: If the request failed
         """
         path = "%s/%s/take_ownership" % (self.manager.path, self.get_id())
-        server_data = self.manager.gitlab.http_post(path, **kwargs)
+        server_data = await self.manager.gitlab.http_post(path, **kwargs)
         self._update_attrs(server_data)
 
 
@@ -3637,7 +3637,7 @@ class ProjectSnippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObj
 
     @cli.register_custom_action("ProjectSnippet")
     @exc.on_http_error(exc.GitlabGetError)
-    def content(self, streamed=False, action=None, chunk_size=1024, **kwargs):
+    async def content(self, streamed=False, action=None, chunk_size=1024, **kwargs):
         """Return the content of a snippet.
 
         Args:
@@ -3657,7 +3657,7 @@ class ProjectSnippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObj
             str: The snippet content
         """
         path = "%s/%s/raw" % (self.manager.path, self.get_id())
-        result = self.manager.gitlab.http_get(
+        result = await self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
         return utils.response_content(result, streamed, action, chunk_size)
@@ -3677,7 +3677,7 @@ class ProjectSnippetManager(CRUDMixin, RESTManager):
 class ProjectTrigger(SaveMixin, ObjectDeleteMixin, RESTObject):
     @cli.register_custom_action("ProjectTrigger")
     @exc.on_http_error(exc.GitlabOwnershipError)
-    def take_ownership(self, **kwargs):
+    async def take_ownership(self, **kwargs):
         """Update the owner of a trigger.
 
         Args:
@@ -3688,7 +3688,7 @@ class ProjectTrigger(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabOwnershipError: If the request failed
         """
         path = "%s/%s/take_ownership" % (self.manager.path, self.get_id())
-        server_data = self.manager.gitlab.http_post(path, **kwargs)
+        server_data = await self.manager.gitlab.http_post(path, **kwargs)
         self._update_attrs(server_data)
 
 
@@ -3862,7 +3862,7 @@ class ProjectApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
     _update_uses_post = True
 
     @exc.on_http_error(exc.GitlabUpdateError)
-    def set_approvers(self, approver_ids=None, approver_group_ids=None, **kwargs):
+    async def set_approvers(self, approver_ids=None, approver_group_ids=None, **kwargs):
         """Change project-level allowed approvers and approver groups.
 
         Args:
@@ -3878,7 +3878,7 @@ class ProjectApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
 
         path = "/projects/%s/approvers" % self._parent.get_id()
         data = {"approver_ids": approver_ids, "approver_group_ids": approver_group_ids}
-        self.gitlab.http_put(path, post_data=data, **kwargs)
+        await self.gitlab.http_put(path, post_data=data, **kwargs)
 
 
 class ProjectApprovalRule(SaveMixin, ObjectDeleteMixin, RESTObject):
@@ -3957,7 +3957,7 @@ class ProjectExport(RefreshMixin, RESTObject):
 
     @cli.register_custom_action("ProjectExport")
     @exc.on_http_error(exc.GitlabGetError)
-    def download(self, streamed=False, action=None, chunk_size=1024, **kwargs):
+    async def download(self, streamed=False, action=None, chunk_size=1024, **kwargs):
         """Download the archive of a project export.
 
         Args:
@@ -3977,7 +3977,7 @@ class ProjectExport(RefreshMixin, RESTObject):
             str: The blob content if streamed is False, None otherwise
         """
         path = "/projects/%s/export/download" % self.project_id
-        result = self.manager.gitlab.http_get(
+        result = await self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
         return utils.response_content(result, streamed, action, chunk_size)
@@ -4071,7 +4071,7 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
 
     @cli.register_custom_action("Project", ("submodule", "branch", "commit_sha"))
     @exc.on_http_error(exc.GitlabUpdateError)
-    def update_submodule(self, submodule, branch, commit_sha, **kwargs):
+    async def update_submodule(self, submodule, branch, commit_sha, **kwargs):
         """Update a project submodule
 
         Args:
@@ -4090,11 +4090,11 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
         data = {"branch": branch, "commit_sha": commit_sha}
         if "commit_message" in kwargs:
             data["commit_message"] = kwargs["commit_message"]
-        return self.manager.gitlab.http_put(path, post_data=data)
+        return await self.manager.gitlab.http_put(path, post_data=data)
 
     @cli.register_custom_action("Project", tuple(), ("path", "ref", "recursive"))
     @exc.on_http_error(exc.GitlabGetError)
-    def repository_tree(self, path="", ref="", recursive=False, **kwargs):
+    async def repository_tree(self, path="", ref="", recursive=False, **kwargs):
         """Return a list of files in the repository.
 
         Args:
@@ -4121,11 +4121,11 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
             query_data["path"] = path
         if ref:
             query_data["ref"] = ref
-        return self.manager.gitlab.http_list(gl_path, query_data=query_data, **kwargs)
+        return await self.manager.gitlab.http_list(gl_path, query_data=query_data, **kwargs)
 
     @cli.register_custom_action("Project", ("sha",))
     @exc.on_http_error(exc.GitlabGetError)
-    def repository_blob(self, sha, **kwargs):
+    async def repository_blob(self, sha, **kwargs):
         """Return a file by blob SHA.
 
         Args:
@@ -4141,11 +4141,11 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
         """
 
         path = "/projects/%s/repository/blobs/%s" % (self.get_id(), sha)
-        return self.manager.gitlab.http_get(path, **kwargs)
+        return await self.manager.gitlab.http_get(path, **kwargs)
 
     @cli.register_custom_action("Project", ("sha",))
     @exc.on_http_error(exc.GitlabGetError)
-    def repository_raw_blob(
+    async def repository_raw_blob(
         self, sha, streamed=False, action=None, chunk_size=1024, **kwargs
     ):
         """Return the raw file contents for a blob.
@@ -4168,14 +4168,14 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
             str: The blob content if streamed is False, None otherwise
         """
         path = "/projects/%s/repository/blobs/%s/raw" % (self.get_id(), sha)
-        result = self.manager.gitlab.http_get(
+        result = await self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
         return utils.response_content(result, streamed, action, chunk_size)
 
     @cli.register_custom_action("Project", ("from_", "to"))
     @exc.on_http_error(exc.GitlabGetError)
-    def repository_compare(self, from_, to, **kwargs):
+    async def repository_compare(self, from_, to, **kwargs):
         """Return a diff between two branches/commits.
 
         Args:
@@ -4192,11 +4192,11 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
         """
         path = "/projects/%s/repository/compare" % self.get_id()
         query_data = {"from": from_, "to": to}
-        return self.manager.gitlab.http_get(path, query_data=query_data, **kwargs)
+        return await self.manager.gitlab.http_get(path, query_data=query_data, **kwargs)
 
     @cli.register_custom_action("Project")
     @exc.on_http_error(exc.GitlabGetError)
-    def repository_contributors(self, **kwargs):
+    async def repository_contributors(self, **kwargs):
         """Return a list of contributors for the project.
 
         Args:
@@ -4215,11 +4215,11 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
             list: The contributors
         """
         path = "/projects/%s/repository/contributors" % self.get_id()
-        return self.manager.gitlab.http_list(path, **kwargs)
+        return await self.manager.gitlab.http_list(path, **kwargs)
 
     @cli.register_custom_action("Project", tuple(), ("sha",))
     @exc.on_http_error(exc.GitlabListError)
-    def repository_archive(
+    async def repository_archive(
         self, sha=None, streamed=False, action=None, chunk_size=1024, **kwargs
     ):
         """Return a tarball of the repository.
@@ -4245,14 +4245,14 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
         query_data = {}
         if sha:
             query_data["sha"] = sha
-        result = self.manager.gitlab.http_get(
+        result = await self.manager.gitlab.http_get(
             path, query_data=query_data, raw=True, streamed=streamed, **kwargs
         )
         return utils.response_content(result, streamed, action, chunk_size)
 
     @cli.register_custom_action("Project", ("forked_from_id",))
     @exc.on_http_error(exc.GitlabCreateError)
-    def create_fork_relation(self, forked_from_id, **kwargs):
+    async def create_fork_relation(self, forked_from_id, **kwargs):
         """Create a forked from/to relation between existing projects.
 
         Args:
@@ -4264,11 +4264,11 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabCreateError: If the relation could not be created
         """
         path = "/projects/%s/fork/%s" % (self.get_id(), forked_from_id)
-        self.manager.gitlab.http_post(path, **kwargs)
+        await self.manager.gitlab.http_post(path, **kwargs)
 
     @cli.register_custom_action("Project")
     @exc.on_http_error(exc.GitlabDeleteError)
-    def delete_fork_relation(self, **kwargs):
+    async def delete_fork_relation(self, **kwargs):
         """Delete a forked relation between existing projects.
 
         Args:
@@ -4279,11 +4279,11 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabDeleteError: If the server failed to perform the request
         """
         path = "/projects/%s/fork" % self.get_id()
-        self.manager.gitlab.http_delete(path, **kwargs)
+        await self.manager.gitlab.http_delete(path, **kwargs)
 
     @cli.register_custom_action("Project")
     @exc.on_http_error(exc.GitlabDeleteError)
-    def delete_merged_branches(self, **kwargs):
+    async def delete_merged_branches(self, **kwargs):
         """Delete merged branches.
 
         Args:
@@ -4294,11 +4294,11 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabDeleteError: If the server failed to perform the request
         """
         path = "/projects/%s/repository/merged_branches" % self.get_id()
-        self.manager.gitlab.http_delete(path, **kwargs)
+        await self.manager.gitlab.http_delete(path, **kwargs)
 
     @cli.register_custom_action("Project")
     @exc.on_http_error(exc.GitlabGetError)
-    def languages(self, **kwargs):
+    async def languages(self, **kwargs):
         """Get languages used in the project with percentage value.
 
         Args:
@@ -4309,11 +4309,11 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabGetError: If the server failed to perform the request
         """
         path = "/projects/%s/languages" % self.get_id()
-        return self.manager.gitlab.http_get(path, **kwargs)
+        return await self.manager.gitlab.http_get(path, **kwargs)
 
     @cli.register_custom_action("Project")
     @exc.on_http_error(exc.GitlabCreateError)
-    def star(self, **kwargs):
+    async def star(self, **kwargs):
         """Star a project.
 
         Args:
@@ -4324,12 +4324,12 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabCreateError: If the server failed to perform the request
         """
         path = "/projects/%s/star" % self.get_id()
-        server_data = self.manager.gitlab.http_post(path, **kwargs)
+        server_data = await self.manager.gitlab.http_post(path, **kwargs)
         self._update_attrs(server_data)
 
     @cli.register_custom_action("Project")
     @exc.on_http_error(exc.GitlabDeleteError)
-    def unstar(self, **kwargs):
+    async def unstar(self, **kwargs):
         """Unstar a project.
 
         Args:
@@ -4340,12 +4340,12 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabDeleteError: If the server failed to perform the request
         """
         path = "/projects/%s/unstar" % self.get_id()
-        server_data = self.manager.gitlab.http_post(path, **kwargs)
+        server_data = await self.manager.gitlab.http_post(path, **kwargs)
         self._update_attrs(server_data)
 
     @cli.register_custom_action("Project")
     @exc.on_http_error(exc.GitlabCreateError)
-    def archive(self, **kwargs):
+    async def archive(self, **kwargs):
         """Archive a project.
 
         Args:
@@ -4356,12 +4356,12 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabCreateError: If the server failed to perform the request
         """
         path = "/projects/%s/archive" % self.get_id()
-        server_data = self.manager.gitlab.http_post(path, **kwargs)
+        server_data = await self.manager.gitlab.http_post(path, **kwargs)
         self._update_attrs(server_data)
 
     @cli.register_custom_action("Project")
     @exc.on_http_error(exc.GitlabDeleteError)
-    def unarchive(self, **kwargs):
+    async def unarchive(self, **kwargs):
         """Unarchive a project.
 
         Args:
@@ -4372,14 +4372,14 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabDeleteError: If the server failed to perform the request
         """
         path = "/projects/%s/unarchive" % self.get_id()
-        server_data = self.manager.gitlab.http_post(path, **kwargs)
+        server_data = await self.manager.gitlab.http_post(path, **kwargs)
         self._update_attrs(server_data)
 
     @cli.register_custom_action(
         "Project", ("group_id", "group_access"), ("expires_at",)
     )
     @exc.on_http_error(exc.GitlabCreateError)
-    def share(self, group_id, group_access, expires_at=None, **kwargs):
+    async def share(self, group_id, group_access, expires_at=None, **kwargs):
         """Share the project with a group.
 
         Args:
@@ -4397,11 +4397,11 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
             "group_access": group_access,
             "expires_at": expires_at,
         }
-        self.manager.gitlab.http_post(path, post_data=data, **kwargs)
+        await self.manager.gitlab.http_post(path, post_data=data, **kwargs)
 
     @cli.register_custom_action("Project", ("group_id",))
     @exc.on_http_error(exc.GitlabDeleteError)
-    def unshare(self, group_id, **kwargs):
+    async def unshare(self, group_id, **kwargs):
         """Delete a shared project link within a group.
 
         Args:
@@ -4413,12 +4413,12 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabDeleteError: If the server failed to perform the request
         """
         path = "/projects/%s/share/%s" % (self.get_id(), group_id)
-        self.manager.gitlab.http_delete(path, **kwargs)
+        await self.manager.gitlab.http_delete(path, **kwargs)
 
     # variables not supported in CLI
     @cli.register_custom_action("Project", ("ref", "token"))
     @exc.on_http_error(exc.GitlabCreateError)
-    def trigger_pipeline(self, ref, token, variables=None, **kwargs):
+    async def trigger_pipeline(self, ref, token, variables=None, **kwargs):
         """Trigger a CI build.
 
         See https://gitlab.com/help/ci/triggers/README.md#trigger-a-build
@@ -4436,12 +4436,12 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
         variables = variables or {}
         path = "/projects/%s/trigger/pipeline" % self.get_id()
         post_data = {"ref": ref, "token": token, "variables": variables}
-        attrs = self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
+        attrs = await self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
         return ProjectPipeline(self.pipelines, attrs)
 
     @cli.register_custom_action("Project")
     @exc.on_http_error(exc.GitlabHousekeepingError)
-    def housekeeping(self, **kwargs):
+    async def housekeeping(self, **kwargs):
         """Start the housekeeping task.
 
         Args:
@@ -4453,12 +4453,12 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
                                      request
         """
         path = "/projects/%s/housekeeping" % self.get_id()
-        self.manager.gitlab.http_post(path, **kwargs)
+        await self.manager.gitlab.http_post(path, **kwargs)
 
     # see #56 - add file attachment features
     @cli.register_custom_action("Project", ("filename", "filepath"))
     @exc.on_http_error(exc.GitlabUploadError)
-    def upload(self, filename, filedata=None, filepath=None, **kwargs):
+    async def upload(self, filename, filedata=None, filepath=None, **kwargs):
         """Upload the specified file into the project.
 
         .. note::
@@ -4496,13 +4496,13 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
 
         url = "/projects/%(id)s/uploads" % {"id": self.id}
         file_info = {"file": (filename, filedata)}
-        data = self.manager.gitlab.http_post(url, files=file_info)
+        data = await self.manager.gitlab.http_post(url, files=file_info)
 
         return {"alt": data["alt"], "url": data["url"], "markdown": data["markdown"]}
 
     @cli.register_custom_action("Project", optional=("wiki",))
     @exc.on_http_error(exc.GitlabGetError)
-    def snapshot(
+    async def snapshot(
         self, wiki=False, streamed=False, action=None, chunk_size=1024, **kwargs
     ):
         """Return a snapshot of the repository.
@@ -4525,14 +4525,14 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
             str: The uncompressed tar archive of the repository
         """
         path = "/projects/%s/snapshot" % self.get_id()
-        result = self.manager.gitlab.http_get(
+        result = await self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
         return utils.response_content(result, streamed, action, chunk_size)
 
     @cli.register_custom_action("Project", ("scope", "search"))
     @exc.on_http_error(exc.GitlabSearchError)
-    def search(self, scope, search, **kwargs):
+    async def search(self, scope, search, **kwargs):
         """Search the project resources matching the provided string.'
 
         Args:
@@ -4549,11 +4549,11 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
         """
         data = {"scope": scope, "search": search}
         path = "/projects/%s/search" % self.get_id()
-        return self.manager.gitlab.http_list(path, query_data=data, **kwargs)
+        return await self.manager.gitlab.http_list(path, query_data=data, **kwargs)
 
     @cli.register_custom_action("Project")
     @exc.on_http_error(exc.GitlabCreateError)
-    def mirror_pull(self, **kwargs):
+    async def mirror_pull(self, **kwargs):
         """Start the pull mirroring process for the project.
 
         Args:
@@ -4564,11 +4564,11 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabCreateError: If the server failed to perform the request
         """
         path = "/projects/%s/mirror/pull" % self.get_id()
-        self.manager.gitlab.http_post(path, **kwargs)
+        await self.manager.gitlab.http_post(path, **kwargs)
 
     @cli.register_custom_action("Project", ("to_namespace",))
     @exc.on_http_error(exc.GitlabTransferProjectError)
-    def transfer_project(self, to_namespace, **kwargs):
+    async def transfer_project(self, to_namespace, **kwargs):
         """Transfer a project to the given namespace ID
 
         Args:
@@ -4581,13 +4581,13 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabTransferProjectError: If the project could not be transfered
         """
         path = "/projects/%s/transfer" % (self.id,)
-        self.manager.gitlab.http_put(
+        await self.manager.gitlab.http_put(
             path, post_data={"namespace": to_namespace}, **kwargs
         )
 
     @cli.register_custom_action("Project", ("ref_name", "artifact_path", "job"))
     @exc.on_http_error(exc.GitlabGetError)
-    def artifact(
+    async def artifact(
         self,
         ref_name,
         artifact_path,
@@ -4625,7 +4625,7 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
             artifact_path,
             job,
         )
-        result = self.manager.gitlab.http_get(
+        result = await self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
         return utils.response_content(result, streamed, action, chunk_size)
@@ -4708,7 +4708,7 @@ class ProjectManager(CRUDMixin, RESTManager):
         "with_custom_attributes",
     )
 
-    def import_project(
+    async def import_project(
         self,
         file,
         path,
@@ -4743,11 +4743,11 @@ class ProjectManager(CRUDMixin, RESTManager):
                 data["override_params[%s]" % k] = v
         if namespace:
             data["namespace"] = namespace
-        return self.gitlab.http_post(
+        return await self.gitlab.http_post(
             "/projects/import", post_data=data, files=files, **kwargs
         )
 
-    def import_github(
+    async def import_github(
         self, personal_access_token, repo_id, target_namespace, new_name=None, **kwargs
     ):
         """Import a project from Github to Gitlab (schedule the import)
@@ -4807,7 +4807,7 @@ class ProjectManager(CRUDMixin, RESTManager):
             # and this is too short for this API command, typically.
             # On the order of 24 seconds has been measured on a typical gitlab instance.
             kwargs["timeout"] = 60.0
-        result = self.gitlab.http_post("/import/github", post_data=data, **kwargs)
+        result = await self.gitlab.http_post("/import/github", post_data=data, **kwargs)
         return result
 
 
@@ -4857,7 +4857,7 @@ class RunnerManager(CRUDMixin, RESTManager):
 
     @cli.register_custom_action("RunnerManager", tuple(), ("scope",))
     @exc.on_http_error(exc.GitlabListError)
-    def all(self, scope=None, **kwargs):
+    async def all(self, scope=None, **kwargs):
         """List all the runners.
 
         Args:
@@ -4881,11 +4881,11 @@ class RunnerManager(CRUDMixin, RESTManager):
         query_data = {}
         if scope is not None:
             query_data["scope"] = scope
-        return self.gitlab.http_list(path, query_data, **kwargs)
+        return await self.gitlab.http_list(path, query_data, **kwargs)
 
     @cli.register_custom_action("RunnerManager", ("token",))
     @exc.on_http_error(exc.GitlabVerifyError)
-    def verify(self, token, **kwargs):
+    async def verify(self, token, **kwargs):
         """Validates authentication credentials for a registered Runner.
 
         Args:
@@ -4898,13 +4898,13 @@ class RunnerManager(CRUDMixin, RESTManager):
         """
         path = "/runners/verify"
         post_data = {"token": token}
-        self.gitlab.http_post(path, post_data=post_data, **kwargs)
+        await self.gitlab.http_post(path, post_data=post_data, **kwargs)
 
 
 class Todo(ObjectDeleteMixin, RESTObject):
     @cli.register_custom_action("Todo")
     @exc.on_http_error(exc.GitlabTodoError)
-    def mark_as_done(self, **kwargs):
+    async def mark_as_done(self, **kwargs):
         """Mark the todo as done.
 
         Args:
@@ -4915,7 +4915,7 @@ class Todo(ObjectDeleteMixin, RESTObject):
             GitlabTodoError: If the server failed to perform the request
         """
         path = "%s/%s/mark_as_done" % (self.manager.path, self.id)
-        server_data = self.manager.gitlab.http_post(path, **kwargs)
+        server_data = await self.manager.gitlab.http_post(path, **kwargs)
         self._update_attrs(server_data)
 
 
@@ -4926,7 +4926,7 @@ class TodoManager(ListMixin, DeleteMixin, RESTManager):
 
     @cli.register_custom_action("TodoManager")
     @exc.on_http_error(exc.GitlabTodoError)
-    def mark_all_as_done(self, **kwargs):
+    async def mark_all_as_done(self, **kwargs):
         """Mark all the todos as done.
 
         Args:
@@ -4939,13 +4939,13 @@ class TodoManager(ListMixin, DeleteMixin, RESTManager):
         Returns:
             int: The number of todos maked done
         """
-        result = self.gitlab.http_post("/todos/mark_as_done", **kwargs)
+        result = await self.gitlab.http_post("/todos/mark_as_done", **kwargs)
 
 
 class GeoNode(SaveMixin, ObjectDeleteMixin, RESTObject):
     @cli.register_custom_action("GeoNode")
     @exc.on_http_error(exc.GitlabRepairError)
-    def repair(self, **kwargs):
+    async def repair(self, **kwargs):
         """Repair the OAuth authentication of the geo node.
 
         Args:
@@ -4956,12 +4956,12 @@ class GeoNode(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabRepairError: If the server failed to perform the request
         """
         path = "/geo_nodes/%s/repair" % self.get_id()
-        server_data = self.manager.gitlab.http_post(path, **kwargs)
+        server_data = await self.manager.gitlab.http_post(path, **kwargs)
         self._update_attrs(server_data)
 
     @cli.register_custom_action("GeoNode")
     @exc.on_http_error(exc.GitlabGetError)
-    def status(self, **kwargs):
+    async def status(self, **kwargs):
         """Get the status of the geo node.
 
         Args:
@@ -4975,7 +4975,7 @@ class GeoNode(SaveMixin, ObjectDeleteMixin, RESTObject):
             dict: The status of the geo node
         """
         path = "/geo_nodes/%s/status" % self.get_id()
-        return self.manager.gitlab.http_get(path, **kwargs)
+        return await self.manager.gitlab.http_get(path, **kwargs)
 
 
 class GeoNodeManager(RetrieveMixin, UpdateMixin, DeleteMixin, RESTManager):
@@ -4988,7 +4988,7 @@ class GeoNodeManager(RetrieveMixin, UpdateMixin, DeleteMixin, RESTManager):
 
     @cli.register_custom_action("GeoNodeManager")
     @exc.on_http_error(exc.GitlabGetError)
-    def status(self, **kwargs):
+    async def status(self, **kwargs):
         """Get the status of all the geo nodes.
 
         Args:
@@ -5001,11 +5001,11 @@ class GeoNodeManager(RetrieveMixin, UpdateMixin, DeleteMixin, RESTManager):
         Returns:
             list: The status of all the geo nodes
         """
-        return self.gitlab.http_list("/geo_nodes/status", **kwargs)
+        return await self.gitlab.http_list("/geo_nodes/status", **kwargs)
 
     @cli.register_custom_action("GeoNodeManager")
     @exc.on_http_error(exc.GitlabGetError)
-    def current_failures(self, **kwargs):
+    async def current_failures(self, **kwargs):
         """Get the list of failures on the current geo node.
 
         Args:
@@ -5018,4 +5018,4 @@ class GeoNodeManager(RetrieveMixin, UpdateMixin, DeleteMixin, RESTManager):
         Returns:
             list: The list of failures
         """
-        return self.gitlab.http_list("/geo_nodes/current/failures", **kwargs)
+        return await self.gitlab.http_list("/geo_nodes/current/failures", **kwargs)

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -22,7 +22,7 @@ import asyncio
 
 from gitlab.base import *  # noqa
 from gitlab import cli
-from gitlab.exceptions import exc  # noqa
+from gitlab.exceptions import *  # noqa
 from gitlab.mixins import *  # noqa
 from gitlab import types
 from gitlab import utils
@@ -3701,7 +3701,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
     def raw(
         self, file_path, ref, streamed=False, action=None, chunk_size=1024, **kwargs
     ):
-        loop = async.get_event_loop()
+        loop = asyncio.get_event_loop()
         return loop.run_until_complete(
             self.async_raw(
                 file_path, ref, streamed=False, action=None, chunck_size=1024, **kwargs

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -728,7 +728,9 @@ class FeatureManager(ListMixin, DeleteMixin, RESTManager):
 
     def set(self, name, value, feature_group=None, user=None, **kwargs):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self.async_set(name, value, feature_group, user, **kwargs))
+        return loop.run_until_complete(
+            self.async_set(name, value, feature_group, user, **kwargs)
+        )
 
 
 class Gitignore(RESTObject):
@@ -1376,7 +1378,9 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
 
     def delete_ldap_group_link(self, cn, provider=None, **kwargs):
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.async_delete_ldap_group_link(cn, provider, **kwargs))
+        loop.run_until_complete(
+            self.async_delete_ldap_group_link(cn, provider, **kwargs)
+        )
 
     @cli.register_custom_action("Group")
     @exc.on_http_error(exc.GitlabCreateError)
@@ -1567,7 +1571,9 @@ class Snippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
 
     @cli.register_custom_action("Snippet")
     @exc.on_http_error(exc.GitlabGetError)
-    async def async_content(self, streamed=False, action=None, chunk_size=1024, **kwargs):
+    async def async_content(
+        self, streamed=False, action=None, chunk_size=1024, **kwargs
+    ):
         """Return the content of a snippet.
 
         Args:
@@ -1594,7 +1600,9 @@ class Snippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
 
     def content(self, streamed=False, action=None, chunk_size=1024, **kwargs):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self.async_content(streamed, action, chunk_size, **kwargs))
+        return loop.run_until_complete(
+            self.async_content(streamed, action, chunk_size, **kwargs)
+        )
 
 
 class SnippetManager(CRUDMixin, RESTManager):
@@ -1716,7 +1724,9 @@ class ProjectBranch(ObjectDeleteMixin, RESTObject):
         "ProjectBranch", tuple(), ("developers_can_push", "developers_can_merge")
     )
     @exc.on_http_error(exc.GitlabProtectError)
-    async def async_protect(self, developers_can_push=False, developers_can_merge=False, **kwargs):
+    async def async_protect(
+        self, developers_can_push=False, developers_can_merge=False, **kwargs
+    ):
         """Protect the branch.
 
         Args:
@@ -1948,7 +1958,9 @@ class ProjectJob(RESTObject, RefreshMixin):
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabGetError)
-    async def async_artifacts(self, streamed=False, action=None, chunk_size=1024, **kwargs):
+    async def async_artifacts(
+        self, streamed=False, action=None, chunk_size=1024, **kwargs
+    ):
         """Get the job artifacts.
 
         Args:
@@ -1975,11 +1987,15 @@ class ProjectJob(RESTObject, RefreshMixin):
 
     async def artifacts(self, streamed=False, action=None, chunk_size=1024, **kwargs):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self.async_artifacts(streamed, action, chunk_size, **kwargs))
+        return loop.run_until_complete(
+            self.async_artifacts(streamed, action, chunk_size, **kwargs)
+        )
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabGetError)
-    async def async_artifact(self, path, streamed=False, action=None, chunk_size=1024, **kwargs):
+    async def async_artifact(
+        self, path, streamed=False, action=None, chunk_size=1024, **kwargs
+    ):
         """Get a single artifact file from within the job's artifacts archive.
 
         Args:
@@ -2007,7 +2023,9 @@ class ProjectJob(RESTObject, RefreshMixin):
 
     def artifact(self, path, streamed=False, action=None, chunk_size=1024, **kwargs):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self.async_artifact(path, streamed, action, chunk_size, **kwargs))
+        return loop.run_until_complete(
+            self.async_artifact(path, streamed, action, chunk_size, **kwargs)
+        )
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabGetError)
@@ -2038,7 +2056,9 @@ class ProjectJob(RESTObject, RefreshMixin):
 
     def trace(self, streamed, action, chunk_size, **kwargs):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self.async_trace(streamed, action, chunk_size, **kwargs))
+        return loop.run_until_complete(
+            self.async_trace(streamed, action, chunk_size, **kwargs)
+        )
 
 
 class ProjectJobManager(RetrieveMixin, RESTManager):
@@ -2575,7 +2595,9 @@ class ProjectIssue(
         """
         path = "%s/%s/move" % (self.manager.path, self.get_id())
         data = {"to_project_id": to_project_id}
-        server_data = await self.manager.gitlab.http_post(path, post_data=data, **kwargs)
+        server_data = await self.manager.gitlab.http_post(
+            path, post_data=data, **kwargs
+        )
         self._update_attrs(server_data)
 
     def move(self, to_project_id, **kwargs):
@@ -2808,7 +2830,9 @@ class ProjectTag(ObjectDeleteMixin, RESTObject):
 
     def set_release_description(self, description, **kwargs):
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.async_set_release_description(description, **kwargs))
+        loop.run_until_complete(
+            self.async_set_release_description(description, **kwargs)
+        )
 
 
 class ProjectTagManager(NoUpdateMixin, RESTManager):
@@ -2842,7 +2866,9 @@ class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTMan
     _update_uses_post = True
 
     @exc.on_http_error(exc.GitlabUpdateError)
-    async def async_set_approvers(self, approver_ids=None, approver_group_ids=None, **kwargs):
+    async def async_set_approvers(
+        self, approver_ids=None, approver_group_ids=None, **kwargs
+    ):
         """Change MR-level allowed approvers and approver groups.
 
         Args:
@@ -2862,7 +2888,9 @@ class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTMan
 
     def set_approvers(self, approver_id=None, approver_group_ids=None, **kwargs):
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.async_set_approvers(approver_id, approver_group_ids, **kwargs))
+        loop.run_until_complete(
+            self.async_set_approvers(approver_id, approver_group_ids, **kwargs)
+        )
 
 
 class ProjectMergeRequestAwardEmoji(ObjectDeleteMixin, RESTObject):
@@ -3006,7 +3034,9 @@ class ProjectMergeRequest(
 
     def cancel_merge_when_pipeline_succeeds(self, **kwargs):
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.async_cancel_merge_when_pipeline_succeeds(**kwargs))
+        loop.run_until_complete(
+            self.async_cancel_merge_when_pipeline_succeeds(**kwargs)
+        )
 
     @cli.register_custom_action("ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabListError)
@@ -3130,7 +3160,9 @@ class ProjectMergeRequest(
         if sha:
             data["sha"] = sha
 
-        server_data = await self.manager.gitlab.http_post(path, post_data=data, **kwargs)
+        server_data = await self.manager.gitlab.http_post(
+            path, post_data=data, **kwargs
+        )
         self._update_attrs(server_data)
 
     def approve(self, sha=None, **kwargs):
@@ -3152,7 +3184,9 @@ class ProjectMergeRequest(
         path = "%s/%s/unapprove" % (self.manager.path, self.get_id())
         data = {}
 
-        server_data = await self.manager.gitlab.http_post(path, post_data=data, **kwargs)
+        server_data = await self.manager.gitlab.http_post(
+            path, post_data=data, **kwargs
+        )
         self._update_attrs(server_data)
 
     def unapprove(self, **kwargs):
@@ -3222,17 +3256,22 @@ class ProjectMergeRequest(
         server_data = await self.manager.gitlab.http_put(path, post_data=data, **kwargs)
         self._update_attrs(server_data)
 
-    def merge(self,
-              merge_commit_message=None,
-              should_remove_source_branch=False,
-              merge_when_pipeline_succeeds=False,
-              **kwargs
+    def merge(
+        self,
+        merge_commit_message=None,
+        should_remove_source_branch=False,
+        merge_when_pipeline_succeeds=False,
+        **kwargs
     ):
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.async_merge(merge_commit_message,
-                                                 should_remove_source_branch,
-                                                 merge_when_pipeline_succeeds,
-                                                 **kwargs))
+        loop.run_until_complete(
+            self.async_merge(
+                merge_commit_message,
+                should_remove_source_branch,
+                merge_when_pipeline_succeeds,
+                **kwargs
+            )
+        )
 
 
 class ProjectMergeRequestManager(CRUDMixin, RESTManager):
@@ -3622,7 +3661,9 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
 
     def delete(self, file_path, branch, commit_message, **kwargs):
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.async_delete(file_path, branch, commit_message, **kwargs))
+        loop.run_until_complete(
+            self.async_delete(file_path, branch, commit_message, **kwargs)
+        )
 
     @cli.register_custom_action("ProjectFileManager", ("file_path", "ref"))
     @exc.on_http_error(exc.GitlabGetError)
@@ -3661,9 +3702,11 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         self, file_path, ref, streamed=False, action=None, chunk_size=1024, **kwargs
     ):
         loop = async.get_event_loop()
-        return loop.run_until_complete(self.async_raw(
-            file_path, ref, streamed=False, action=None, chunck_size=1024, **kwargs
-        ))
+        return loop.run_until_complete(
+            self.async_raw(
+                file_path, ref, streamed=False, action=None, chunck_size=1024, **kwargs
+            )
+        )
 
     @cli.register_custom_action("ProjectFileManager", ("file_path", "ref"))
     @exc.on_http_error(exc.GitlabListError)
@@ -3970,7 +4013,9 @@ class ProjectSnippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObj
 
     @cli.register_custom_action("ProjectSnippet")
     @exc.on_http_error(exc.GitlabGetError)
-    async def async_content(self, streamed=False, action=None, chunk_size=1024, **kwargs):
+    async def async_content(
+        self, streamed=False, action=None, chunk_size=1024, **kwargs
+    ):
         """Return the content of a snippet.
 
         Args:
@@ -3997,7 +4042,9 @@ class ProjectSnippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObj
 
     def content(self, streamed=False, action=None, chunk_size=1024, **kwargs):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self.async_content(streamed, action, chunk_size, **kwargs))
+        return loop.run_until_complete(
+            self.async_content(streamed, action, chunk_size, **kwargs)
+        )
 
 
 class ProjectSnippetManager(CRUDMixin, RESTManager):
@@ -4211,7 +4258,9 @@ class ProjectApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
     _update_uses_post = True
 
     @exc.on_http_error(exc.GitlabUpdateError)
-    async def async_set_approvers(self, approver_ids=None, approver_group_ids=None, **kwargs):
+    async def async_set_approvers(
+        self, approver_ids=None, approver_group_ids=None, **kwargs
+    ):
         """Change project-level allowed approvers and approver groups.
 
         Args:
@@ -4231,7 +4280,9 @@ class ProjectApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
 
     def set_approvers(self, approver_ids=None, approver_group_ids=None, **kwargs):
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.async_set_approvers(approver_ids, approver_group_ids, **kwargs))
+        loop.run_until_complete(
+            self.async_set_approvers(approver_ids, approver_group_ids, **kwargs)
+        )
 
 
 class ProjectApprovalRule(SaveMixin, ObjectDeleteMixin, RESTObject):
@@ -4310,7 +4361,9 @@ class ProjectExport(RefreshMixin, RESTObject):
 
     @cli.register_custom_action("ProjectExport")
     @exc.on_http_error(exc.GitlabGetError)
-    async def async_download(self, streamed=False, action=None, chunk_size=1024, **kwargs):
+    async def async_download(
+        self, streamed=False, action=None, chunk_size=1024, **kwargs
+    ):
         """Download the archive of a project export.
 
         Args:
@@ -4451,7 +4504,9 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
 
     def update_submodule(self, submodule, branch, commit_sha, **kwargs):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self.async_update_submodule(submodule, branch, commit_sha, **kwargs))
+        return loop.run_until_complete(
+            self.async_update_submodule(submodule, branch, commit_sha, **kwargs)
+        )
 
     @cli.register_custom_action("Project", tuple(), ("path", "ref", "recursive"))
     @exc.on_http_error(exc.GitlabGetError)
@@ -4482,11 +4537,15 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
             query_data["path"] = path
         if ref:
             query_data["ref"] = ref
-        return await self.manager.gitlab.http_list(gl_path, query_data=query_data, **kwargs)
+        return await self.manager.gitlab.http_list(
+            gl_path, query_data=query_data, **kwargs
+        )
 
     def repository_tree(self, path="", ref="", recursive=False, **kwargs):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self.async_repository_tree(path, ref, recursive, **kwargs))
+        return loop.run_until_complete(
+            self.async_repository_tree(path, ref, recursive, **kwargs)
+        )
 
     @cli.register_custom_action("Project", ("sha",))
     @exc.on_http_error(exc.GitlabGetError)
@@ -4546,7 +4605,9 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
         self, sha, streamed=False, action=None, chunk_size=1024, **kwargs
     ):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self.async_repository_raw_blob(sha, streamed, action, chunk_size, **kwargs))
+        return loop.run_until_complete(
+            self.async_repository_raw_blob(sha, streamed, action, chunk_size, **kwargs)
+        )
 
     @cli.register_custom_action("Project", ("from_", "to"))
     @exc.on_http_error(exc.GitlabGetError)
@@ -4571,7 +4632,9 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
 
     def repository_compare(self, from_, to, **kwargs):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self.async_repository_compare(from_, to, **kwargs))
+        return loop.run_until_complete(
+            self.async_repository_compare(from_, to, **kwargs)
+        )
 
     @cli.register_custom_action("Project")
     @exc.on_http_error(exc.GitlabGetError)
@@ -4633,9 +4696,13 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
         )
         return utils.response_content(result, streamed, action, chunk_size)
 
-    def repository_archive(self, sha=None, streamed=False, action=None, chunk_size=1024, **kwargs):
+    def repository_archive(
+        self, sha=None, streamed=False, action=None, chunk_size=1024, **kwargs
+    ):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self.async_repository_archive(sha, streamed, action, chunk_size,**kwargs))
+        return loop.run_until_complete(
+            self.async_repository_archive(sha, streamed, action, chunk_size, **kwargs)
+        )
 
     @cli.register_custom_action("Project", ("forked_from_id",))
     @exc.on_http_error(exc.GitlabCreateError)
@@ -4751,7 +4818,7 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
         self._update_attrs(server_data)
 
     def unstar(self, **kwargs):
-        loop =asyncio.get_event_loop()
+        loop = asyncio.get_event_loop()
         loop.run_until_complete(self.async_unstar(**kwargs))
 
     @cli.register_custom_action("Project")
@@ -4790,9 +4857,9 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
         server_data = await self.manager.gitlab.http_post(path, **kwargs)
         self._update_attrs(server_data)
 
-    def unarchive(self, kwargs**):
+    def unarchive(self, **kwargs):
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.async_unarchive(kwargs**))
+        loop.run_until_complete(self.async_unarchive(**kwargs))
 
     @cli.register_custom_action(
         "Project", ("group_id", "group_access"), ("expires_at",)
@@ -4820,7 +4887,9 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
 
     def share(self, group_id, group_access, expires_at=None, **kwargs):
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.async_share(group_id, group_access, expires_at, **kwargs))
+        loop.run_until_complete(
+            self.async_share(group_id, group_access, expires_at, **kwargs)
+        )
 
     @cli.register_custom_action("Project", ("group_id",))
     @exc.on_http_error(exc.GitlabDeleteError)
@@ -4868,7 +4937,9 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
 
     def trigger_pipeline(self, ref, token, variables=None, **kwargs):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self.async_trigger_pipeline(ref, token, variables, **kwargs))
+        return loop.run_until_complete(
+            self.async_trigger_pipeline(ref, token, variables, **kwargs)
+        )
 
     @cli.register_custom_action("Project")
     @exc.on_http_error(exc.GitlabHousekeepingError)
@@ -4937,7 +5008,9 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
 
     def upload(self, filename, filedata=None, filepath=None, **kwargs):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self.async_upload(filename, filedata, filepath, **kwargs))
+        return loop.run_until_complete(
+            self.async_upload(filename, filedata, filepath, **kwargs)
+        )
 
     @cli.register_custom_action("Project", optional=("wiki",))
     @exc.on_http_error(exc.GitlabGetError)
@@ -4973,7 +5046,9 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
         self, wiki=False, streamed=False, action=None, chunk_size=1024, **kwargs
     ):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self.async_snapshot(wiki, streamed, action, chunk_size, **kwargs))
+        return loop.run_until_complete(
+            self.async_snapshot(wiki, streamed, action, chunk_size, **kwargs)
+        )
 
     @cli.register_custom_action("Project", ("scope", "search"))
     @exc.on_http_error(exc.GitlabSearchError)
@@ -5039,8 +5114,8 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
         )
 
     def transfer_project(self, to_namespace, **kwargs):
-            loop = asyncio.get_event_loop()
-            loop.run_until_complete(self.async_transfer_project(to_namespace, **kwargs))
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self.async_transfer_project(to_namespace, **kwargs))
 
     @cli.register_custom_action("Project", ("ref_name", "artifact_path", "job"))
     @exc.on_http_error(exc.GitlabGetError)
@@ -5098,8 +5173,11 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
         **kwargs
     ):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self.async_artifact(ref_name, artifact_path, job, streamed,
-        action, chunk_size, **kwargs))
+        return loop.run_until_complete(
+            self.async_artifact(
+                ref_name, artifact_path, job, streamed, action, chunk_size, **kwargs
+            )
+        )
 
 
 class ProjectManager(CRUDMixin, RESTManager):
@@ -5228,8 +5306,11 @@ class ProjectManager(CRUDMixin, RESTManager):
         **kwargs
     ):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self.async_import_project(file, path, namespace,
-        override, override_params, **kwargs))
+        return loop.run_until_complete(
+            self.async_import_project(
+                file, path, namespace, override, override_params, **kwargs
+            )
+        )
 
     async def async_import_github(
         self, personal_access_token, repo_id, target_namespace, new_name=None, **kwargs
@@ -5298,8 +5379,11 @@ class ProjectManager(CRUDMixin, RESTManager):
         self, personal_access_token, repo_id, target_namespace, new_name=None, **kwargs
     ):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self.async_import_github(personal_access_token,
-        repo_id, target_namespace, new_name, **kwargs))
+        return loop.run_until_complete(
+            self.async_import_github(
+                personal_access_token, repo_id, target_namespace, new_name, **kwargs
+            )
+        )
 
 
 class RunnerJob(RESTObject):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests>=2.22.0
+httpx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-httpx
+httpx>=0.11.1

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     license="LGPLv3",
     url="https://github.com/python-gitlab/python-gitlab",
     packages=find_packages(),
-    install_requires=["requests>=2.22.0"],
+    install_requires=["httpx"],
     python_requires=">=3.6.0",
     entry_points={"console_scripts": ["gitlab = gitlab.cli:main"]},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     license="LGPLv3",
     url="https://github.com/python-gitlab/python-gitlab",
     packages=find_packages(),
-    install_requires=["httpx"],
+    install_requires=["httpx>=0.11.1"],
     python_requires=">=3.6.0",
     entry_points={"console_scripts": ["gitlab = gitlab.cli:main"]},
     classifiers=[


### PR DESCRIPTION
starting to migrate to async while staying compatible to the syncronous versions.

TODO:
* [x] rewrite GitlabList __init__ to be async compatible
* [ ] find all functions that need a async_ version 

which funktions are suposed to be called by the user? if possible i would like to keep all internal funktions async and run the functions that have to be sync with `run_until_complete()`

would it be better to have a centrel event_loop instead of getting it with `get_event_loop` every time and if so where would i put it?

fix #945 