### PR TITLE
Update auth docs

### DIFF
--- a/docs/api-usage.rst
+++ b/docs/api-usage.rst
@@ -23,9 +23,6 @@ To connect to a GitLab server, create a ``gitlab.Gitlab`` object:
    import os
    gl = gitlab.Gitlab('http://10.0.0.1', job_token=os.environ['CI_JOB_TOKEN'])
 
-   # username/password authentication (for GitLab << 10.2)
-   gl = gitlab.Gitlab('http://10.0.0.1', email='jdoe', password='s3cr3t')
-
    # anonymous gitlab instance, read-only for public resources
    gl = gitlab.Gitlab('http://10.0.0.1')
 

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -60,8 +60,6 @@ class Gitlab(object):
         private_token (str): The user private token
         oauth_token (str): An oauth token
         job_token (str): A CI job token
-        email (str): The user email or login.
-        password (str): The user password (associated with email).
         ssl_verify (bool|str): Whether SSL certificates should be validated. If
             the value is a string, it is the path to a CA file used for
             certificate validation.
@@ -203,9 +201,7 @@ class Gitlab(object):
         )
 
     def auth(self):
-        """Performs an authentication.
-
-        Uses either the private token, or the email/password pair.
+        """Performs an authentication using private token.
 
         The `user` attribute will hold a `gitlab.objects.CurrentUser` object on
         success.


### PR DESCRIPTION
Hi, I removed the docs regarding `email/password` auth since it's no longer supported by `python-gitlab`.