### PR TITLE
[WIP] Switch project import to requests-toolbelt

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -23,6 +23,7 @@ import time
 import warnings
 
 import requests
+from requests_toolbelt.multipart.encoder import MultipartEncoder
 
 import gitlab.config
 from gitlab.const import *  # noqa
@@ -500,9 +501,12 @@ class Gitlab(object):
 
         # We need to deal with json vs. data when uploading files
         if files:
-            data = post_data
+            my_data = post_data
             json = None
-            del opts["headers"]["Content-type"]
+            my_data["file"] = files["file"]
+            files = None
+            data = MultipartEncoder(my_data)
+            opts["headers"]["Content-type"] = data.content_type
         else:
             json = post_data
             data = None

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -4792,8 +4792,8 @@ class ProjectManager(CRUDMixin, RESTManager):
         Returns:
             dict: A representation of the import status.
         """
-        files = {"file": ("file.tar.gz", file)}
-        data = {"path": path, "overwrite": overwrite}
+        files = {"file": ("file.tar.gz", file, 'application/octet-stream')}
+        data = {"path": path, "overwrite": str(overwrite)}
         if override_params:
             for k, v in override_params.items():
                 data["override_params[%s]" % k] = v

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.22.0
+requests-toolbelt>=0.9.1

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     license="LGPLv3",
     url="https://github.com/python-gitlab/python-gitlab",
     packages=find_packages(),
-    install_requires=["requests>=2.22.0"],
+    install_requires=["requests>=2.22.0", "requests-toolbelt>=0.9.1"],
     python_requires=">=3.6.0",
     entry_points={"console_scripts": ["gitlab = gitlab.cli:main"]},
     classifiers=[


### PR DESCRIPTION
Maybe this is of use for anybody. It works for me but I have not tested it thoroughly.
The Gitlab project import has lots of open issues, so your mileage may vary. Also I had to adapt the ProxyTimeout (Apache reverse proxy) and the unicorn['worker_timeout'] values. 