### PR TITLE
chore(user): update user attributes

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -30,7 +30,7 @@ from gitlab.exceptions import *  # noqa
 from gitlab import utils  # noqa
 
 __title__ = "python-gitlab"
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __author__ = "Gauvain Pocentek"
 __email__ = "gauvainpocentek@gmail.com"
 __license__ = "LGPL3"

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -414,6 +414,7 @@ class UserManager(CRUDMixin, RESTManager):
         "search",
         "custom_attributes",
         "status",
+        "two_factor",
     )
     _create_attrs = (
         tuple(),
@@ -438,6 +439,8 @@ class UserManager(CRUDMixin, RESTManager):
             "organization",
             "location",
             "avatar",
+            "public_email",
+            "private_profile",
         ),
     )
     _update_attrs = (
@@ -459,6 +462,8 @@ class UserManager(CRUDMixin, RESTManager):
             "organization",
             "location",
             "avatar",
+            "public_email",
+            "private_profile",
         ),
     )
     _types = {"confirm": types.LowercaseStringAttribute, "avatar": types.ImageAttribute}


### PR DESCRIPTION
This also workarounds an GitLab issue, where private_profile, would reset to false if not supplied