### PR TITLE
Add capability to control GitLab features per project or group

### DIFF
--- a/docs/gl_objects/features.rst
+++ b/docs/gl_objects/features.rst
@@ -24,6 +24,8 @@ Create or set a feature::
 
     feature = gl.features.set(feature_name, True)
     feature = gl.features.set(feature_name, 30)
+    feature = gl.features.set(feature_name, True, user=filipowm)
+    feature = gl.features.set(feature_name, 40, group=mygroup)
 
 Delete a feature::
 

--- a/gitlab/utils.py
+++ b/gitlab/utils.py
@@ -55,3 +55,7 @@ def sanitized_url(url):
     parsed = urlparse(url)
     new_path = parsed.path.replace(".", "%2E")
     return parsed._replace(path=new_path).geturl()
+
+
+def remove_none_from_dict(data):
+    return {k: v for k, v in data.items() if v is not None}

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -760,6 +760,7 @@ class FeatureManager(ListMixin, DeleteMixin, RESTManager):
             "group": group,
             "project": project,
         }
+        data = utils.remove_none_from_dict(data)
         server_data = self.gitlab.http_post(path, post_data=data, **kwargs)
         return self._obj_cls(self, server_data)
 

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -724,7 +724,16 @@ class FeatureManager(ListMixin, DeleteMixin, RESTManager):
     _obj_cls = Feature
 
     @exc.on_http_error(exc.GitlabSetError)
-    def set(self, name, value, feature_group=None, user=None, **kwargs):
+    def set(
+        self,
+        name,
+        value,
+        feature_group=None,
+        user=None,
+        group=None,
+        project=None,
+        **kwargs
+    ):
         """Create or update the object.
 
         Args:
@@ -732,6 +741,8 @@ class FeatureManager(ListMixin, DeleteMixin, RESTManager):
             value (bool/int): The value to set for the object
             feature_group (str): A feature group name
             user (str): A GitLab username
+            group (str): A GitLab group
+            project (str): A GitLab project in form group/project
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -742,7 +753,13 @@ class FeatureManager(ListMixin, DeleteMixin, RESTManager):
             obj: The created/updated attribute
         """
         path = "%s/%s" % (self.path, name.replace("/", "%2F"))
-        data = {"value": value, "feature_group": feature_group, "user": user}
+        data = {
+            "value": value,
+            "feature_group": feature_group,
+            "user": user,
+            "group": group,
+            "project": project,
+        }
         server_data = self.gitlab.http_post(path, post_data=data, **kwargs)
         return self._obj_cls(self, server_data)
 


### PR DESCRIPTION
Currently GitLab Features API supports configuring features not only globally or per user, but also per group or project. `python-gitlab` is currently missing this option, thus this PR.

Additionally fixed issue when setting up feature with `None `(null) values, e.g. none `feature_group` or `user`. It caused GitLab to respond with HTTP 500. Thus now we're filtering out `None` values from data.