### PR TITLE
perf: wait for gitlab to reconfigure instead of using hardcoded sleep

### DIFF
--- a/tools/build_test_env.sh
+++ b/tools/build_test_env.sh
@@ -141,19 +141,12 @@ while :; do
     sleep 1
     docker top gitlab-test >/dev/null 2>&1 || fatal "docker failed to start"
     sleep 4
-    # last command started by the container is "gitlab-ctl tail"
-    docker exec gitlab-test pgrep -f 'gitlab-ctl tail' &>/dev/null \
-    && docker exec gitlab-test curl http://localhost/-/health 2>/dev/null \
-        | grep -q 'GitLab OK' \
-    && curl -s http://localhost:8080/users/sign_in 2>/dev/null \
-        | grep -q "GitLab Community Edition" \
+    docker logs gitlab-test 2>&1 | grep "gitlab Reconfigured!" \
     && break
     I=$((I+5))
+    log "Waiting for GitLab to reconfigure.. (${I}s)"
     [ "$I" -lt 180 ] || fatal "timed out"
 done
-
-log "Pausing to give GitLab some time to finish starting up..."
-sleep 200
 
 # Get the token
 TOKEN=$($(dirname $0)/generate_token.py)


### PR DESCRIPTION
I saw this was already tried and discussed in an older PR. I tried to use the readiness endpoint for this, but it turns out gitlab starts reporting OK on all healthchecks before it's fully reconfigured on startup (if you try `docker container logs --follow gitlab-test` in another shell it'll still be restarting services when the script is already at "Pausing to give GitLab some time to finish starting up...".

So it seems waiting for gitlab to report that it's reconfigured might be better. If this isn't enough for CI, then it's when gitlab logs start popping up in the container that it's 100% reliably up and running, so those could be grepped as well.

I can remove the additional log if it's too verbose, I just remember wondering if the script was hanging the first time I ran it so this gives some progress.