### PR TITLE
Fix: remove trailing slash in base URL 

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -90,8 +90,8 @@ class Gitlab(object):
 
         self._api_version = str(api_version)
         self._server_version = self._server_revision = None
-        self._base_url = url
-        self._url = "%s/api/v%s" % (url, api_version)
+        self._base_url = url.rstrip("/")
+        self._url = "%s/api/v%s" % (self._base_url, api_version)
         #: Timeout to use for requests to gitlab server
         self.timeout = timeout
         #: Headers that will be used in request to GitLab

--- a/gitlab/tests/test_gitlab.py
+++ b/gitlab/tests/test_gitlab.py
@@ -376,6 +376,23 @@ class TestGitlabHttpMethods(unittest.TestCase):
             self.assertRaises(GitlabHttpError, self.gl.http_delete, "/not_there")
 
 
+class TestGitlabStripBaseUrl(unittest.TestCase):
+    def setUp(self):
+        self.gl = Gitlab(
+            "http://localhost/", private_token="private_token", api_version=4
+        )
+
+    def test_strip_base_url(self):
+        self.assertEqual(self.gl.url, "http://localhost")
+
+    def test_strip_api_url(self):
+        self.assertEqual(self.gl.api_url, "http://localhost/api/v4")
+
+    def test_build_url(self):
+        r = self.gl._build_url("/projects")
+        self.assertEqual(r, "http://localhost/api/v4/projects")
+
+
 class TestGitlabAuth(unittest.TestCase):
     def test_invalid_auth_args(self):
         self.assertRaises(


### PR DESCRIPTION
Closes #913. This helps with some reverse proxies that return 404 on double slashes.