### PR TITLE
feat(api): add support for GitLab OAuth Applications using Applications API

### DIFF
--- a/docs/api-objects.rst
+++ b/docs/api-objects.rst
@@ -7,6 +7,7 @@ API examples
 
    gl_objects/access_requests
    gl_objects/appearance
+   gl_objects/applications
    gl_objects/emojis
    gl_objects/badges
    gl_objects/branches

--- a/docs/gl_objects/applications.rst
+++ b/docs/gl_objects/applications.rst
@@ -1,0 +1,31 @@
+############
+Applications
+############
+
+Reference
+---------
+
+* v4 API:
+
+  + :class:`gitlab.v4.objects.Applications`
+  + :class:`gitlab.v4.objects.ApplicationManager`
+  + :attr:`gitlab.Gitlab.applications`
+
+* GitLab API: https://docs.gitlab.com/ce/api/applications.html
+
+Examples
+--------
+
+List all OAuth applications::
+
+    applications = gl.applications.list()
+
+Create an application::
+
+    gl.applications.create({'name': 'your_app', 'redirect_uri': 'http://application.url', 'scopes': ['api']})
+
+Delete an applications::
+
+    gl.applications.delete(app_id)
+    # or
+    application.delete()

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -144,6 +144,7 @@ class Gitlab(object):
         self.features = objects.FeatureManager(self)
         self.pagesdomains = objects.PagesDomainManager(self)
         self.user_activities = objects.UserActivitiesManager(self)
+        self.applications = objects.ApplicationManager(self)
 
     def __enter__(self):
         return self

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -5141,3 +5141,14 @@ class GeoNodeManager(RetrieveMixin, UpdateMixin, DeleteMixin, RESTManager):
             list: The list of failures
         """
         return self.gitlab.http_list("/geo_nodes/current/failures", **kwargs)
+
+
+class Application(ObjectDeleteMixin, RESTObject):
+    _url = "/applications"
+    _short_print_attr = "name"
+
+
+class ApplicationManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
+    _path = "/applications"
+    _obj_cls = Application
+    _create_attrs = (("name", "redirect_uri", "scopes"), ("confidential",))


### PR DESCRIPTION
GitLab can be used as an OAuth authentication provider. GitLab API allows creating Applications which could benefit from this feature. Currently `python-gitlab` does not support managing OAuth Apps, so I added this here.

Reference: https://docs.gitlab.com/ce/api/applications.html