### PR TITLE
Fix wrong project additional statistics example in document

### DIFF
--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -785,7 +785,7 @@ Get all additional statistics of a project::
 
 Get total fetches in last 30 days of a project::
 
-    total_fetches = project.additionalstatistics.get()['fetches']['total']
+    total_fetches = project.additionalstatistics.get().fetches['total']
 
 Project issues statistics
 =========================


### PR DESCRIPTION
Using `get()['fetches']['total']` in the example will raise an error:

```
TypeError: 'ProjectAdditionalStatistics' object is not subscriptable
```

Updated to use new method with `get().fetches['total']`