### PR TITLE
chore(user): update user attributes to 12.8

### DIFF
--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -453,6 +453,8 @@ class UserManager(CRUDMixin, RESTManager):
             "avatar",
             "public_email",
             "private_profile",
+            "color_scheme_id",
+            "theme_id",
         ),
     )
     _update_attrs = (
@@ -476,6 +478,8 @@ class UserManager(CRUDMixin, RESTManager):
             "avatar",
             "public_email",
             "private_profile",
+            "color_scheme_id",
+            "theme_id",
         ),
     )
     _types = {"confirm": types.LowercaseStringAttribute, "avatar": types.ImageAttribute}


### PR DESCRIPTION
This is migating an GitLab issue, which resets the user theme and color scheme, when nothing is provided via the API.