### PR TITLE
feat: add create from template args to ProjectManager

### DIFF
--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -4788,6 +4788,10 @@ class ProjectManager(CRUDMixin, RESTManager):
             "avatar",
             "printing_merge_request_link_enabled",
             "ci_config_path",
+            "template_name",
+            "template_project_id",
+            "use_custom_template",
+            "group_with_project_templates_id",
         ),
     )
     _update_attrs = (


### PR DESCRIPTION
This commit adds the v4 Create project attributes necessary to create a
project from a project, instance, or group level template as documented
in https://docs.gitlab.com/ee/api/projects.html#create-project