### PR TITLE
feat: add support for commit GPG signature

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -236,6 +236,18 @@ Create a snippet:
    $ gitlab project-snippet create --project-id 2 --title "the title" \
        --file-name "the name" --code "the code"
 
+Get a specific project commit by its SHA id:
+
+.. code-block:: console
+
+   $ gitlab project-commit get --project-id 2 --id a43290c
+
+Get the GPG signature of a signed commit:
+
+.. code-block:: console
+
+   $ gitlab project-commit signature --project-id 2 --id a43290c
+
 Define the status of a commit (as would be done from a CI tool for example):
 
 .. code-block:: console

--- a/docs/gl_objects/commits.rst
+++ b/docs/gl_objects/commits.rst
@@ -82,6 +82,10 @@ Get the references the commit has been pushed to (branches and tags)::
     commit.refs('tag')  # only tags
     commit.refs('branch')  # only branches
 
+Get the GPG signature of the commit (if the commit was signed)::
+
+    commit.signature()
+
 List the merge requests related to a commit::
 
     commit.merge_requests()

--- a/gitlab/tests/objects/test_commits.py
+++ b/gitlab/tests/objects/test_commits.py
@@ -1,0 +1,79 @@
+from httmock import urlmatch, response, with_httmock
+
+from .test_projects import headers, TestProject
+
+
+@urlmatch(
+    scheme="http",
+    netloc="localhost",
+    path="/api/v4/projects/1/repository/commits/6b2257ea",
+    method="get",
+)
+def resp_get_commit(url, request):
+    """Mock for commit GET response."""
+    content = """{
+    "id": "6b2257eabcec3db1f59dafbd84935e3caea04235",
+    "short_id": "6b2257ea",
+    "title": "Initial commit"
+    }"""
+    content = content.encode("utf-8")
+    return response(200, content, headers, None, 5, request)
+
+
+@urlmatch(
+    scheme="http", path="/api/v4/projects/1/repository/commits", method="post",
+)
+def resp_create_commit(url, request):
+    """Mock for commit create POST response."""
+    content = """{
+    "id": "ed899a2f4b50b4370feeea94676502b42383c746",
+    "short_id": "ed899a2f",
+    "title": "Commit message"
+    }"""
+    content = content.encode("utf-8")
+    return response(200, content, headers, None, 5, request)
+
+
+@urlmatch(
+    scheme="http", path="/api/v4/projects/1/repository/commits/6b2257ea", method="post",
+)
+def resp_revert_commit(url, request):
+    """Mock for commit revert POST response."""
+    content = """{
+    "id": "8b090c1b79a14f2bd9e8a738f717824ff53aebad",
+    "short_id": "8b090c1b",
+    "title":"Revert \\"Initial commit\\""
+    }"""
+    content = content.encode("utf-8")
+    return response(200, content, headers, None, 5, request)
+
+
+class TestCommit(TestProject):
+    """
+    Base class for commit tests. Inherits from TestProject,
+    since currently all commit methods are under projects.
+    """
+
+    @with_httmock(resp_get_commit)
+    def test_get_commit(self):
+        commit = self.project.commits.get("6b2257ea")
+        self.assertEqual(commit.short_id, "6b2257ea")
+        self.assertEqual(commit.title, "Initial commit")
+
+    @with_httmock(resp_create_commit)
+    def test_create_commit(self):
+        data = {
+            "branch": "master",
+            "commit_message": "Commit message",
+            "actions": [{"action": "create", "file_path": "README", "content": "",}],
+        }
+        commit = self.project.commits.create(data)
+        self.assertEqual(commit.short_id, "ed899a2f")
+        self.assertEqual(commit.title, data["commit_message"])
+
+    @with_httmock(resp_revert_commit)
+    def test_revert_commit(self):
+        commit = self.project.commits.get("6b2257ea", lazy=True)
+        revert_commit = commit.revert(branch="master")
+        self.assertEqual(revert_commit["short_id"], "8b090c1b")
+        self.assertEqual(revert_commit["title"], 'Revert "Initial commit"')

--- a/gitlab/tests/test_gitlab.py
+++ b/gitlab/tests/test_gitlab.py
@@ -843,50 +843,6 @@ class TestGitlab(unittest.TestCase):
             self.gl.users.get(1, lazy=True).activate()
             self.gl.users.get(1, lazy=True).deactivate()
 
-    def test_commit_revert(self):
-        @urlmatch(
-            scheme="http",
-            netloc="localhost",
-            path="/api/v4/projects/1/repository/commits/6b2257ea",
-            method="get",
-        )
-        def resp_get_commit(url, request):
-            headers = {"content-type": "application/json"}
-            content = """{
-            "id": "6b2257eabcec3db1f59dafbd84935e3caea04235",
-            "short_id": "6b2257ea",
-            "title": "Initial commit"
-            }"""
-            content = content.encode("utf-8")
-            return response(200, content, headers, None, 5, request)
-
-        @urlmatch(
-            scheme="http",
-            netloc="localhost",
-            path="/api/v4/projects/1/repository/commits/6b2257ea",
-            method="post",
-        )
-        def resp_revert_commit(url, request):
-            headers = {"content-type": "application/json"}
-            content = """{
-            "id": "8b090c1b79a14f2bd9e8a738f717824ff53aebad",
-            "short_id": "8b090c1b",
-            "title":"Revert \\"Initial commit\\""
-            }"""
-            content = content.encode("utf-8")
-            return response(200, content, headers, None, 5, request)
-
-        with HTTMock(resp_get_commit):
-            project = self.gl.projects.get(1, lazy=True)
-            commit = project.commits.get("6b2257ea")
-            self.assertEqual(commit.short_id, "6b2257ea")
-            self.assertEqual(commit.title, "Initial commit")
-
-        with HTTMock(resp_revert_commit):
-            revert_commit = commit.revert(branch="master")
-            self.assertEqual(revert_commit["short_id"], "8b090c1b")
-            self.assertEqual(revert_commit["title"], 'Revert "Initial commit"')
-
     def test_update_submodule(self):
         @urlmatch(
             scheme="http", netloc="localhost", path="/api/v4/projects/1$", method="get"

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -2172,6 +2172,24 @@ class ProjectCommit(RESTObject):
         post_data = {"branch": branch}
         return self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
 
+    @cli.register_custom_action("ProjectCommit")
+    @exc.on_http_error(exc.GitlabGetError)
+    def signature(self, **kwargs):
+        """Get the GPG signature of the commit.
+
+        Args:
+            **kwargs: Extra options to send to the server (e.g. sudo)
+
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabGetError: If the signature could not be retrieved
+
+        Returns:
+            dict: The commit's GPG signature data
+        """
+        path = "%s/%s/signature" % (self.manager.path, self.get_id())
+        return self.manager.gitlab.http_get(path, **kwargs)
+
 
 class ProjectCommitManager(RetrieveMixin, CreateMixin, RESTManager):
     _path = "/projects/%(project_id)s/repository/commits"

--- a/tools/cli_test_v4.sh
+++ b/tools/cli_test_v4.sh
@@ -113,6 +113,13 @@ testcase "revert commit" '
         --id "$COMMIT_ID" --branch master
 '
 
+# Test commit GPG signature
+testcase "attempt to get GPG signature of unsigned commit" '
+    OUTPUT=$(GITLAB project-commit signature --project-id "$PROJECT_ID" \
+        --id "$COMMIT_ID" 2>&1 || exit 0)
+    echo "$OUTPUT" | grep -q "404 GPG Signature Not Found"
+'
+
 # Test project labels
 testcase "create project label" '
     OUTPUT=$(GITLAB -v project-label create --project-id $PROJECT_ID \

--- a/tools/python_test_v4.py
+++ b/tools/python_test_v4.py
@@ -473,6 +473,14 @@ commit = admin_project.commits.list()[0]
 # assert commit.refs()
 # assert commit.merge_requests()
 
+# commit GPG signature (for unsigned commits)
+# TODO: reasonable tests for signed commits?
+try:
+    signature = commit.signature()
+except gitlab.GitlabGetError as e:
+    error_message = e.error_message
+assert error_message == "404 GPG Signature Not Found"
+
 # commit comment
 commit.comments.create({"note": "This is a commit comment"})
 # assert len(commit.comments.list()) == 1


### PR DESCRIPTION
Closes #1050.

The functional tests currently only test that the server returns the correct 404 response for unsigned commits, since creating signed commits without the API would be a bit convoluted, maybe this can be added later? https://gitlab.com/gitlab-org/gitlab/-/issues/19185 might also help with this.

However, I've tested this against real signed and unsigned commits on gitlab.com:

```python
>>> import gitlab
>>> gl = gitlab.Gitlab("https://gitlab.com")
>>> project = gl.projects.get("gitlab-org/gitlab")
>>> signed_commit = project.commits.get("387572e7aa7768e2be539215e453d474d067e20d")
>>> signed_commit.signature()
{'gpg_key_id': None, 'gpg_key_primary_keyid': 'B89F5B74C808CB29', 'gpg_key_user_name': 'Daniel Paul Searles', 'gpg_key_user_email': 'dsearles@gitlab.com', 'verification_status': 'verified', 'gpg_key_subkey_id': 61400}
```
```python
>>> unsigned_commit = project.commits.get("86b82a8ca235a886788581b0ff5bb24f4e4bfaa2")
>>> unsigned_commit.signature()
Traceback (most recent call last):
  File "/home/z003wwtz/repos/python-gitlab/gitlab/exceptions.py", line 271, in wrapped_f
    return f(*args, **kwargs)
  File "/home/z003wwtz/repos/python-gitlab/gitlab/v4/objects.py", line 2191, in signature
    return self.manager.gitlab.http_get(path, **kwargs)
  File "/home/z003wwtz/repos/python-gitlab/gitlab/__init__.py", line 598, in http_get
    "get", path, query_data=query_data, streamed=streamed, **kwargs
  File "/home/z003wwtz/repos/python-gitlab/gitlab/__init__.py", line 573, in http_request
    response_body=result.content,
gitlab.exceptions.GitlabHttpError: 404: 404 GPG Signature Not Found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/z003wwtz/repos/python-gitlab/gitlab/cli.py", line 43, in wrapped_f
    return f(*args, **kwargs)
  File "/home/z003wwtz/repos/python-gitlab/gitlab/exceptions.py", line 273, in wrapped_f
    raise error(e.error_message, e.response_code, e.response_body)
gitlab.exceptions.GitlabGetError: 404: 404 GPG Signature Not Found
```