### PR TITLE
Fix: ListAttribute get_for_api() splits strings

### DIFF
--- a/gitlab/tests/test_types.py
+++ b/gitlab/tests/test_types.py
@@ -51,10 +51,18 @@ class TestListAttribute(unittest.TestCase):
         o.set_from_cli("  ")
         self.assertEqual([], o.get())
 
-    def test_get_for_api(self):
+    def test_get_for_api_from_cli(self):
         o = types.ListAttribute()
         o.set_from_cli("foo,bar,baz")
         self.assertEqual("foo,bar,baz", o.get_for_api())
+
+    def test_get_for_api_from_list(self):
+        o = types.ListAttribute(["foo", "bar", "baz"])
+        self.assertEqual("foo,bar,baz", o.get_for_api())
+
+    def test_get_for_api_does_not_split_string(self):
+        o = types.ListAttribute("foo")
+        self.assertEqual("foo", o.get_for_api())
 
 
 class TestLowercaseStringAttribute(unittest.TestCase):

--- a/gitlab/types.py
+++ b/gitlab/types.py
@@ -38,6 +38,10 @@ class ListAttribute(GitlabAttribute):
             self._value = [item.strip() for item in cli_value.split(",")]
 
     def get_for_api(self):
+        # Do not comma-split single value passed as string
+        if isinstance(self._value, str):
+            return self._value
+
         return ",".join(self._value)
 
 

--- a/tools/python_test_v4.py
+++ b/tools/python_test_v4.py
@@ -677,10 +677,17 @@ assert issue1.participants()
 assert type(issue1.closed_by()) == list
 assert type(issue1.related_merge_requests()) == list
 
-# issues labels and events
+# issue labels
 label2 = admin_project.labels.create({"name": "label2", "color": "#aabbcc"})
 issue1.labels = ["label2"]
 issue1.save()
+
+assert issue1 in admin_project.issues.list(labels=["label2"])
+assert issue1 in admin_project.issues.list(labels="label2")
+assert issue1 in admin_project.issues.list(labels="Any")
+assert issue1 not in admin_project.issues.list(labels="None")
+
+# issue events
 events = issue1.resourcelabelevents.list()
 assert events
 event = issue1.resourcelabelevents.get(events[0].id)


### PR DESCRIPTION
Closes #1057.

See test https://travis-ci.org/github/python-gitlab/python-gitlab/jobs/668135438#L248-L250 for previous behavior.