### PR TITLE
feat(types): add __dir__ to RESTObject to expose attributes

### DIFF
--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -111,6 +111,9 @@ class RESTObject(object):
             return self.get_id() != other.get_id()
         return super(RESTObject, self) != other
 
+    def __dir__(self):
+        return super(RESTObject, self).__dir__() + list(self.attributes)
+
     def __hash__(self):
         if not self.get_id():
             return super(RESTObject, self).__hash__()


### PR DESCRIPTION
This change adds the `__dir__` magic method to the `RESTObject` class in order to expose and allow introspection on the attributes that the object might have.

This is very useful to me when exploring the API in an interactive console. 

Normally I'll call `dir(obj)` (or `obj?` in iPython shell) to try to discover what methods and attributes exist for the object. However, the attributes in the `.attributes` property are not currently exposed, requiring the extra step of checking `.attributes` on each object I explore this way.


Hope this makes sense and that this change, if accepted, will help others.