### PR TITLE
feat: Allow an environment variable to specify config location

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -14,7 +14,10 @@ Configuration
 Files
 -----
 
-``gitlab`` looks up 2 configuration files by default:
+``gitlab`` looks up 3 configuration files by default:
+
+``PYTHON_GITLAB_CFG`` environment variable
+    An environment variable that contains the path to a configuration file
 
 ``/etc/python-gitlab.cfg``
     System-wide configuration file

--- a/gitlab/config.py
+++ b/gitlab/config.py
@@ -18,7 +18,17 @@
 import os
 import configparser
 
-_DEFAULT_FILES = ["/etc/python-gitlab.cfg", os.path.expanduser("~/.python-gitlab.cfg")]
+
+def _env_config():
+    if "PYTHON_GITLAB_CFG" in os.environ:
+        return [os.environ["PYTHON_GITLAB_CFG"]]
+    return []
+
+
+_DEFAULT_FILES = _env_config() + [
+    "/etc/python-gitlab.cfg",
+    os.path.expanduser("~/.python-gitlab.cfg"),
+]
 
 
 class ConfigError(Exception):

--- a/gitlab/tests/test_config.py
+++ b/gitlab/tests/test_config.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import unittest
 
 import mock
@@ -70,6 +71,16 @@ url = http://four.url
 private_token = ABCDEF
 per_page = 200
 """
+
+
+class TestEnvConfig(unittest.TestCase):
+    def test_env_present(self):
+        with mock.patch.dict(os.environ, {"PYTHON_GITLAB_CFG": "/some/path"}):
+            self.assertEqual(["/some/path"], config._env_config())
+
+    def test_env_missing(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual([], config._env_config())
 
 
 class TestConfigParser(unittest.TestCase):


### PR DESCRIPTION
It can be useful (especially in scripts) to specify a configuration
location via an environment variable. If the "PYTHON_GITLAB_CFG"
environment variable is defined, treat its value as the path to a
configuration file and include it in the set of default configuration
locations.