### PR TITLE
feat: Added support in the GroupManager to upload Group avatars.

### DIFF
--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -1513,6 +1513,7 @@ class GroupManager(CRUDMixin, RESTManager):
             "default_branch_protection",
         ),
     )
+    _types = {"avatar": types.ImageAttribute}
 
     @exc.on_http_error(exc.GitlabImportError)
     def import_group(self, file, path, name, parent_id=None, **kwargs):


### PR DESCRIPTION
Similar to the `UserManager` and `ProjectManager` the `GroupManager` now supports uploading avatar images. The `GroupManager` object was missing the `ImageAttribute` type.

The feature to upload avatars to groups was introduced in Gitlab 12.9.
See also https://docs.gitlab.com/ce/api/groups.html#new-group (Attribute "avatar")