### PR TITLE
chore: bring commit signatures up to date with 12.10

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -258,7 +258,7 @@ Get a specific project commit by its SHA id:
 
    $ gitlab project-commit get --project-id 2 --id a43290c
 
-Get the GPG signature of a signed commit:
+Get the signature (e.g. GPG or x509) of a signed commit:
 
 .. code-block:: console
 

--- a/docs/gl_objects/commits.rst
+++ b/docs/gl_objects/commits.rst
@@ -82,7 +82,7 @@ Get the references the commit has been pushed to (branches and tags)::
     commit.refs('tag')  # only tags
     commit.refs('branch')  # only branches
 
-Get the GPG signature of the commit (if the commit was signed)::
+Get the signature of the commit (if the commit was signed, e.g. with GPG or x509)::
 
     commit.signature()
 

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -2299,7 +2299,7 @@ class ProjectCommit(RESTObject):
     @cli.register_custom_action("ProjectCommit")
     @exc.on_http_error(exc.GitlabGetError)
     def signature(self, **kwargs):
-        """Get the GPG signature of the commit.
+        """Get the signature of the commit.
 
         Args:
             **kwargs: Extra options to send to the server (e.g. sudo)
@@ -2309,7 +2309,7 @@ class ProjectCommit(RESTObject):
             GitlabGetError: If the signature could not be retrieved
 
         Returns:
-            dict: The commit's GPG signature data
+            dict: The commit's signature data
         """
         path = "%s/%s/signature" % (self.manager.path, self.get_id())
         return self.manager.gitlab.http_get(path, **kwargs)

--- a/tools/cli_test_v4.sh
+++ b/tools/cli_test_v4.sh
@@ -113,11 +113,11 @@ testcase "revert commit" '
         --id "$COMMIT_ID" --branch master
 '
 
-# Test commit GPG signature
-testcase "attempt to get GPG signature of unsigned commit" '
+# Test commit signature
+testcase "attempt to get signature of unsigned commit" '
     OUTPUT=$(GITLAB project-commit signature --project-id "$PROJECT_ID" \
         --id "$COMMIT_ID" 2>&1 || exit 0)
-    echo "$OUTPUT" | grep -q "404 GPG Signature Not Found"
+    echo "$OUTPUT" | grep -q "404 Signature Not Found"
 '
 
 # Test project labels

--- a/tools/cli_test_v4.sh
+++ b/tools/cli_test_v4.sh
@@ -218,23 +218,18 @@ testcase "values from files" '
 CREATE_PROJECT_DEPLOY_TOKEN_OUTPUT=$(GITLAB -v project-deploy-token create --project-id $PROJECT_ID \
         --name foo --username root --expires-at "2021-09-09" --scopes "read_registry")
 CREATED_DEPLOY_TOKEN_ID=$(echo "$CREATE_PROJECT_DEPLOY_TOKEN_OUTPUT" | grep ^id: | cut -d" " -f2)
-testcase "create project deploy token" '
+testcase "create project deploy token (name)" '
     echo $CREATE_PROJECT_DEPLOY_TOKEN_OUTPUT | grep -q "name: foo"
 '
-testcase "create project deploy token" '
+testcase "create project deploy token (expires-at)" '
     echo $CREATE_PROJECT_DEPLOY_TOKEN_OUTPUT | grep -q "expires-at: 2021-09-09T00:00:00.000Z"
 '
-testcase "create project deploy token" '
+testcase "create project deploy token (scopes)" '
     echo $CREATE_PROJECT_DEPLOY_TOKEN_OUTPUT | grep "scopes: " | grep -q "read_registry"
 '
-# Uncomment once https://gitlab.com/gitlab-org/gitlab/-/issues/211963 is fixed
-#testcase "create project deploy token" '
-#    echo $CREATE_PROJECT_DEPLOY_TOKEN_OUTPUT | grep -q "username: root"
-#'
 
-# Remove once https://gitlab.com/gitlab-org/gitlab/-/issues/211963 is fixed
-testcase "create project deploy token" '
-    echo $CREATE_PROJECT_DEPLOY_TOKEN_OUTPUT | grep -q "gitlab+deploy-token"
+testcase "create project deploy token (username)" '
+   echo $CREATE_PROJECT_DEPLOY_TOKEN_OUTPUT | grep -q "username: root"
 '
 
 LIST_DEPLOY_TOKEN_OUTPUT=$(GITLAB -v deploy-token list)

--- a/tools/python_test_v4.py
+++ b/tools/python_test_v4.py
@@ -500,13 +500,13 @@ commit = admin_project.commits.list()[0]
 # assert commit.refs()
 # assert commit.merge_requests()
 
-# commit GPG signature (for unsigned commits)
+# commit signature (for unsigned commits)
 # TODO: reasonable tests for signed commits?
 try:
     signature = commit.signature()
 except gitlab.GitlabGetError as e:
     error_message = e.error_message
-assert error_message == "404 GPG Signature Not Found"
+assert error_message == "404 Signature Not Found"
 
 # commit comment
 commit.comments.create({"note": "This is a commit comment"})


### PR DESCRIPTION
The commit signature test was failing against nightly after some changes to commit signatures (https://gitlab.com/gitlab-org/gitlab/-/merge_requests/27327). This fixes the test and some minor docs, since with 12.10 released we'll be getting failed builds without this (it was just a silly assert for the 404 :D).

I only left the unit test as is since the GPG response is one of the possible options.