### PR TITLE
chore(ci): add codecov integration to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,8 +87,11 @@ jobs:
       dist: bionic
       name: coverage
       python: 3.8
+      install:
+        - pip3 install tox codecov
       script:
-        - pip3 install tox
         - tox -e cover
+      after_success:
+        - codecov
   allow_failures:
     - env: GITLAB_TAG=nightly

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,9 @@
 .. image:: https://readthedocs.org/projects/python-gitlab/badge/?version=latest
    :target: https://python-gitlab.readthedocs.org/en/latest/?badge=latest
 
+.. image:: https://codecov.io/github/python-gitlab/python-gitlab/coverage.svg?branch=master
+    :target: https://codecov.io/github/python-gitlab/python-gitlab?branch=master
+
 .. image:: https://img.shields.io/pypi/pyversions/python-gitlab.svg
    :target: https://pypi.python.org/pypi/python-gitlab
 


### PR DESCRIPTION
We discussed adding some kind of coverage reporting, codecov seemed to be the easiest to add. After this is merged, codecov should also start reporting PR comments with a summary (on successful builds):
https://docs.codecov.io/docs/pull-request-comments

Edit: ah the summary is already here :) If this comment style is too intrusive, we can probably customize this to make it smaller with `codecov.yml`. Looks like there was an initial run a few years ago, since this reports against an old master commit. I'll look into adding this as a separate check as well. Seems like we can later split unit and functional tests into separate checks with flags.