### PR TITLE
Add deployment merge request api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ MANIFEST
 coverage.xml
 docs/_build
 .coverage
+.python-version
 .tox
 .venv/
 venv/

--- a/docs/gl_objects/deployments.rst
+++ b/docs/gl_objects/deployments.rst
@@ -39,3 +39,25 @@ Update a deployment::
     deployment = project.deployments.get(42)
     deployment.status = "failed"
     deployment.save()
+
+Merge requests associated with a deployment
+===========================================
+
+Reference
+----------
+
+* v4 API:
+
+  + :class:`gitlab.v4.objects.ProjectDeploymentMergeRequest`
+  + :class:`gitlab.v4.objects.ProjectDeploymentMergeRequestManager`
+  + :attr:`gitlab.v4.objects.ProjectDeployment.mergerequests`
+
+* GitLab API: https://docs.gitlab.com/ee/api/deployments.html#list-of-merge-requests-associated-with-a-deployment
+
+Examples
+--------
+
+List the merge requests associated with a deployment::
+
+    deployment = project.deployments.get(42, lazy=True)
+    mrs = deployment.mergerequests.list()

--- a/gitlab/v4/objects/deployments.py
+++ b/gitlab/v4/objects/deployments.py
@@ -1,6 +1,8 @@
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import CreateMixin, RetrieveMixin, SaveMixin, UpdateMixin
 
+from .merge_requests import ProjectDeploymentMergeRequestManager  # noqa: F401
+
 __all__ = [
     "ProjectDeployment",
     "ProjectDeploymentManager",
@@ -8,14 +10,21 @@ __all__ = [
 
 
 class ProjectDeployment(SaveMixin, RESTObject):
-    pass
+    _managers = (("mergerequests", "ProjectDeploymentMergeRequestManager"),)
 
 
 class ProjectDeploymentManager(RetrieveMixin, CreateMixin, UpdateMixin, RESTManager):
     _path = "/projects/%(project_id)s/deployments"
     _obj_cls = ProjectDeployment
     _from_parent_attrs = {"project_id": "id"}
-    _list_filters = ("order_by", "sort")
+    _list_filters = (
+        "order_by",
+        "sort",
+        "updated_after",
+        "updated_before",
+        "environment",
+        "status",
+    )
     _create_attrs = RequiredOptional(
         required=("sha", "ref", "tag", "status", "environment")
     )

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -36,6 +36,8 @@ __all__ = [
     "GroupMergeRequestManager",
     "ProjectMergeRequest",
     "ProjectMergeRequestManager",
+    "ProjectDeploymentMergeRequest",
+    "ProjectDeploymentMergeRequestManager",
     "ProjectMergeRequestDiff",
     "ProjectMergeRequestDiffManager",
 ]
@@ -48,7 +50,6 @@ class MergeRequest(RESTObject):
 class MergeRequestManager(ListMixin, RESTManager):
     _path = "/merge_requests"
     _obj_cls = MergeRequest
-    _from_parent_attrs = {"group_id": "id"}
     _list_filters = (
         "state",
         "order_by",
@@ -56,24 +57,35 @@ class MergeRequestManager(ListMixin, RESTManager):
         "milestone",
         "view",
         "labels",
+        "with_labels_details",
+        "with_merge_status_recheck",
         "created_after",
         "created_before",
         "updated_after",
         "updated_before",
         "scope",
         "author_id",
+        "author_username",
         "assignee_id",
         "approver_ids",
         "approved_by_ids",
+        "reviewer_id",
+        "reviewer_username",
         "my_reaction_emoji",
         "source_branch",
         "target_branch",
         "search",
+        "in",
         "wip",
+        "not",
+        "environment",
+        "deployed_before",
+        "deployed_after",
     )
     _types = {
         "approver_ids": types.ListAttribute,
         "approved_by_ids": types.ListAttribute,
+        "in": types.ListAttribute,
         "labels": types.ListAttribute,
     }
 
@@ -407,6 +419,16 @@ class ProjectMergeRequestManager(CRUDMixin, RESTManager):
         "iids": types.ListAttribute,
         "labels": types.ListAttribute,
     }
+
+
+class ProjectDeploymentMergeRequest(MergeRequest):
+    pass
+
+
+class ProjectDeploymentMergeRequestManager(MergeRequestManager):
+    _path = "/projects/%(project_id)s/deployments/%(deployment_id)s/merge_requests"
+    _obj_cls = ProjectDeploymentMergeRequest
+    _from_parent_attrs = {"deployment_id": "id", "project_id": "project_id"}
 
 
 class ProjectMergeRequestDiff(RESTObject):

--- a/tests/unit/objects/test_merge_requests.py
+++ b/tests/unit/objects/test_merge_requests.py
@@ -1,0 +1,56 @@
+"""
+GitLab API:
+https://docs.gitlab.com/ce/api/merge_requests.html
+https://docs.gitlab.com/ee/api/deployments.html#list-of-merge-requests-associated-with-a-deployment
+"""
+import re
+
+import pytest
+import responses
+
+from gitlab.v4.objects import ProjectDeploymentMergeRequest, ProjectMergeRequest
+
+mr_content = {
+    "id": 1,
+    "iid": 1,
+    "project_id": 3,
+    "title": "test1",
+    "description": "fixed login page css paddings",
+    "state": "merged",
+    "merged_by": {
+        "id": 87854,
+        "name": "Douwe Maan",
+        "username": "DouweM",
+        "state": "active",
+        "avatar_url": "https://gitlab.example.com/uploads/-/system/user/avatar/87854/avatar.png",
+        "web_url": "https://gitlab.com/DouweM",
+    },
+}
+
+
+@pytest.fixture
+def resp_list_merge_requests():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.GET,
+            url=re.compile(
+                r"http://localhost/api/v4/projects/1/(deployments/1/)?merge_requests"
+            ),
+            json=[mr_content],
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
+def test_list_project_merge_requests(project, resp_list_merge_requests):
+    mrs = project.mergerequests.list()
+    assert isinstance(mrs[0], ProjectMergeRequest)
+    assert mrs[0].iid == mr_content["iid"]
+
+
+def test_list_deployment_merge_requests(project, resp_list_merge_requests):
+    deployment = project.deployments.get(1, lazy=True)
+    mrs = deployment.mergerequests.list()
+    assert isinstance(mrs[0], ProjectDeploymentMergeRequest)
+    assert mrs[0].iid == mr_content["iid"]


### PR DESCRIPTION
Hi,

I added the https://docs.gitlab.com/ee/api/deployments.html#list-of-merge-requests-associated-with-a-deployment API to `objects.py`.

Fixes #995 

Cheers
Ludwig