### PR TITLE
Added NO_ACCESS const

### DIFF
--- a/gitlab/const.py
+++ b/gitlab/const.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+NO_ACCESS = 0
 GUEST_ACCESS = 10
 REPORTER_ACCESS = 20
 DEVELOPER_ACCESS = 30


### PR DESCRIPTION
This constant is useful for cases where no access is granted, e.g. when creating a protected branch.

The `NO_ACCESS` const corresponds to the definition in https://docs.gitlab.com/ee/api/protected_branches.html