### PR TITLE
fix(merge): parse arguments as query_data

### DIFF
--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -3251,7 +3251,7 @@ class ProjectMergeRequest(
         if merge_when_pipeline_succeeds:
             data["merge_when_pipeline_succeeds"] = True
 
-        server_data = self.manager.gitlab.http_put(path, post_data=data, **kwargs)
+        server_data = self.manager.gitlab.http_put(path, query_data=data, **kwargs)
         self._update_attrs(server_data)
 
 


### PR DESCRIPTION
Refer to #1120 

Merge request requests aren't working, as the request parameters `should_remove_source_branch` and `remove_source_branch` are parsed as `post_data`, when they should be send as query_string, as described in the official GitLab API documentation itself [GitLab API Accept Merge](https://docs.gitlab.com/ee/api/merge_requests.html#accept-mr)