### PR TITLE
docs: additional project file delete example

### DIFF
--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -376,6 +376,8 @@ encoded text::
 Delete a file::
 
     f.delete(commit_message='Delete testfile', branch='master')
+    # or
+    project.files.delete(file_path='testfile.txt', commit_message='Delete testfile', branch='master')
 
 Get file blame::
 


### PR DESCRIPTION
Showing how to delete without having to pull the file.