### PR TITLE
Feat: Project job artifacts for latest successful pipeline

### DIFF
--- a/docs/gl_objects/pipelines_and_jobs.rst
+++ b/docs/gl_objects/pipelines_and_jobs.rst
@@ -292,6 +292,11 @@ Get the artifacts of a job::
 
     build_or_job.artifacts()
 
+Get the artifacts of a job by its name from the latest successful pipeline of
+a branch or tag:
+
+  project.artifacts(ref_name='master', job='build')
+
 .. warning::
 
    Artifacts are entirely stored in memory in this example.

--- a/gitlab/tests/objects/test_commits.py
+++ b/gitlab/tests/objects/test_commits.py
@@ -88,7 +88,13 @@ def test_create_commit(project, resp_create_commit):
     data = {
         "branch": "master",
         "commit_message": "Commit message",
-        "actions": [{"action": "create", "file_path": "README", "content": "",}],
+        "actions": [
+            {
+                "action": "create",
+                "file_path": "README",
+                "content": "",
+            }
+        ],
     }
     commit = project.commits.create(data)
     assert commit.short_id == "ed899a2f"

--- a/gitlab/tests/objects/test_job_artifacts.py
+++ b/gitlab/tests/objects/test_job_artifacts.py
@@ -5,8 +5,6 @@ GitLab API: https://docs.gitlab.com/ee/api/job_artifacts.html
 import pytest
 import responses
 
-from gitlab.v4.objects import Project
-
 
 ref_name = "master"
 job = "build"

--- a/gitlab/tests/objects/test_job_artifacts.py
+++ b/gitlab/tests/objects/test_job_artifacts.py
@@ -1,0 +1,33 @@
+"""
+GitLab API: https://docs.gitlab.com/ee/api/job_artifacts.html
+"""
+
+import pytest
+import responses
+
+from gitlab.v4.objects import Project
+
+
+ref_name = "master"
+job = "build"
+
+
+@pytest.fixture
+def resp_artifacts_by_ref_name(binary_content):
+    url = f"http://localhost/api/v4/projects/1/jobs/artifacts/{ref_name}/download?job={job}"
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.GET,
+            url=url,
+            body=binary_content,
+            content_type="application/octet-stream",
+            status=200,
+        )
+        yield rsps
+
+
+def test_download_artifacts_by_ref_name(gl, binary_content, resp_artifacts_by_ref_name):
+    project = gl.projects.get(1, lazy=True)
+    artifacts = project.artifacts(ref_name=ref_name, job=job)
+    assert artifacts == binary_content

--- a/gitlab/tests/objects/test_runners.py
+++ b/gitlab/tests/objects/test_runners.py
@@ -167,7 +167,9 @@ def resp_runner_delete():
             status=200,
         )
         rsps.add(
-            method=responses.DELETE, url=pattern, status=204,
+            method=responses.DELETE,
+            url=pattern,
+            status=204,
         )
         yield rsps
 
@@ -177,7 +179,9 @@ def resp_runner_disable():
     with responses.RequestsMock() as rsps:
         pattern = re.compile(r".*?/(groups|projects)/1/runners/6")
         rsps.add(
-            method=responses.DELETE, url=pattern, status=204,
+            method=responses.DELETE,
+            url=pattern,
+            status=204,
         )
         yield rsps
 
@@ -187,7 +191,9 @@ def resp_runner_verify():
     with responses.RequestsMock() as rsps:
         pattern = re.compile(r".*?/runners/verify")
         rsps.add(
-            method=responses.POST, url=pattern, status=200,
+            method=responses.POST,
+            url=pattern,
+            status=200,
         )
         yield rsps
 

--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -711,8 +711,14 @@ class ProjectDeployTokenManager(ListMixin, CreateMixin, DeleteMixin, RESTManager
     _from_parent_attrs = {"project_id": "id"}
     _obj_cls = ProjectDeployToken
     _create_attrs = (
-        ("name", "scopes",),
-        ("expires_at", "username",),
+        (
+            "name",
+            "scopes",
+        ),
+        (
+            "expires_at",
+            "username",
+        ),
     )
 
 
@@ -725,8 +731,14 @@ class GroupDeployTokenManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
     _from_parent_attrs = {"group_id": "id"}
     _obj_cls = GroupDeployToken
     _create_attrs = (
-        ("name", "scopes",),
-        ("expires_at", "username",),
+        (
+            "name",
+            "scopes",
+        ),
+        (
+            "expires_at",
+            "username",
+        ),
     )
 
 
@@ -4181,7 +4193,11 @@ class ProjectServiceManager(GetMixin, UpdateMixin, DeleteMixin, ListMixin, RESTM
             ),
         ),
         "jira": (
-            ("url", "username", "password",),
+            (
+                "url",
+                "username",
+                "password",
+            ),
             (
                 "api_url",
                 "active",

--- a/tools/python_test_v4.py
+++ b/tools/python_test_v4.py
@@ -701,7 +701,12 @@ deploy_token_group = gl.groups.create(
 
 # Remove once https://gitlab.com/gitlab-org/gitlab/-/issues/211878 is fixed
 deploy_token = deploy_token_group.deploytokens.create(
-    {"name": "foo", "username": "", "expires_at": "", "scopes": ["read_repository"],}
+    {
+        "name": "foo",
+        "username": "",
+        "expires_at": "",
+        "scopes": ["read_repository"],
+    }
 )
 
 assert len(deploy_token_group.deploytokens.list()) == 1


### PR DESCRIPTION
This adds support for an endpoint that was missing (artifacts from the latest pipeline per branch/tag):
https://docs.gitlab.com/ee/api/job_artifacts.html#download-the-artifacts-archive

The unrelated changes are there to keep black happy :) looks like there was a new release with different behavior