### PR TITLE
chore(env): add pre-commit and commit-msg hooks

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@commitlint/config-conventional"]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+default_language_version:
+    python: python3
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v3.0.0
+    hooks:
+      - id: commitlint
+        additional_dependencies: ['@commitlint/config-conventional']
+        stages: [commit-msg]
+
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v3.0.0
+    hooks:
+      - id: commitlint-travis
+        additional_dependencies: ['@commitlint/config-conventional']
+        stages: [manual]

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,13 @@ jobs:
   include:
     - stage: lint
       name: commitlint
+      python: 3.8
       script:
-        - npm install -g @commitlint/cli @commitlint/config-conventional
-        - 'echo "module.exports = {extends: [\"@commitlint/config-conventional\"]}" > commitlint.config.js'
-        - npx commitlint --from=origin/master
+        - pip3 install pre-commit
+        - pre-commit run --hook-stage manual commitlint-travis
+      cache:
+        directories:
+          - $HOME/.cache/pre-commit
     - stage: lint
       name: black_lint
       dist: bionic

--- a/README.rst
+++ b/README.rst
@@ -99,27 +99,42 @@ You can contribute to the project in multiple ways:
 * Add unit and functional tests
 * Everything else you can think of
 
+Development workflow
+--------------------
+
+Before contributing, please make sure you have `pre-commit <https://pre-commit.com>`_
+installed and configured. This will help automate adhering to code style and commit
+message guidelines described below:
+
+.. code-block:: bash
+
+  cd python-gitlab/
+  pip3 install --user pre-commit
+  pre-commit install -t pre-commit -t commit-msg --install-hooks
+
+Please provide your patches as GitHub pull requests. Thanks!
+
+Commit message guidelines
+-------------------------
+
 We enforce commit messages to be formatted using the `conventional-changelog <https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines>`_.
 This leads to more readable messages that are easy to follow when looking through the project history.
-
-Please provide your patches as github pull requests. Thanks!
 
 Code-Style
 ----------
 
 We use black as code formatter, so you'll need to format your changes using the
 `black code formatter
-<https://github.com/python/black>`_.
+<https://github.com/python/black>`_. Pre-commit hooks will validate/format your code
+when committing. You can then stage any changes ``black`` added if the commit failed.
 
-Just run
+To format your code according to our guidelines before committing, run:
 
 .. code-block:: bash
 
   cd python-gitlab/
   pip3 install --user black
   black .
-  
-to format your code according to our guidelines.
 
 Running unit tests
 ------------------


### PR DESCRIPTION
Closes #1128. I was having this issue too sometimes when switching workstations and forgot to format :P

I went with `commitlint` to be consistent with CI but maybe `commitizen` makes sense in the future to keep dev dependencies Python-only.