### PR TITLE
chore(ci): pin gitlab-ce version for renovate

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,0 +1,11 @@
+{
+  "regexManagers": [
+    {
+      "fileMatch": ["^tools/build_test_env.sh$"],
+      "matchStrings": ["DEFAULT_GITLAB_TAG=(?<currentValue>.*?)\n"],
+      "depNameTemplate": "gitlab/gitlab-ce",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "loose"
+    }
+  ]
+}

--- a/tools/build_test_env.sh
+++ b/tools/build_test_env.sh
@@ -28,8 +28,10 @@ try() { "$@" || fatal "'$@' failed"; }
 REUSE_CONTAINER=
 NOVENV=
 API_VER=4
-GITLAB_IMAGE="${GITLAB_IMAGE:-gitlab/gitlab-ce}"
-GITLAB_TAG="${GITLAB_TAG:-latest}"
+DEFAULT_GITLAB_IMAGE=gitlab/gitlab-ce
+DEFAULT_GITLAB_TAG=13.3.0-ce.1
+GITLAB_IMAGE="${GITLAB_IMAGE:-$DEFAULT_GITLAB_IMAGE}"
+GITLAB_TAG="${GITLAB_TAG:-$DEFAULT_GITLAB_TAG}"
 VENV_CMD="python3 -m venv"
 while getopts :knp:a:i:t: opt "$@"; do
     case $opt in


### PR DESCRIPTION
Closes #1148.

This would need the renovate app configured for this repo (https://github.com/apps/renovate).

I left a slightly older version to see if renovate updates properly, although I tested this on my fork: https://github.com/nejch/python-gitlab/commit/d9b7393cd50e2de58f6ed0ff053f548d8120d199