### PR TITLE
Update objects.py

### DIFF
--- a/gitlab/v4/objects.py
+++ b/gitlab/v4/objects.py
@@ -469,7 +469,7 @@ class UserManager(CRUDMixin, RESTManager):
             "admin",
             "can_create_group",
             "website_url",
-            "skip_confirmation",
+            "skip_reconfirmation",
             "external",
             "organization",
             "location",


### PR DESCRIPTION
Hi !

Since version 10.3 (and later), param to not send (re)confirmation when updating an user is `skip_reconfirmation` (and not `skip_confirmation`).

See:

* https://gitlab.com/gitlab-org/gitlab-foss/-/merge_requests/15175?tab=
* https://docs.gitlab.com/11.11/ee/api/users.html#user-modification
* https://docs.gitlab.com/ee/api/users.html#user-modification
