### PR TITLE
chore(ci): reduce renovate PR noise

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,4 +1,7 @@
 {
+  "extends": [
+    "config:base"
+  ],
   "regexManagers": [
     {
       "fileMatch": ["^tools/build_test_env.sh$"],
@@ -6,6 +9,12 @@
       "depNameTemplate": "gitlab/gitlab-ce",
       "datasourceTemplate": "docker",
       "versioningTemplate": "loose"
+    }
+  ],
+  "packageRules": [
+    {
+      "packagePatterns": ["^gitlab\/gitlab-.+$"],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
This should get some more sane defaults from the base config for PR frequency, and automerge for gitlab updates should make it more manageable (if status checks are green, so only need to care about failed upgrades).