### PR TITLE
feat(api): add support for user identity provider deletion

### DIFF
--- a/docs/gl_objects/users.rst
+++ b/docs/gl_objects/users.rst
@@ -80,6 +80,10 @@ Set an external identity for a user::
     user.extern_uid = '3'
     user.save()
 
+Delete an external identity by provider name::
+
+    user.identityproviders.delete('oauth2_generic')
+
 User custom attributes
 ======================
 

--- a/gitlab/tests/objects/test_users.py
+++ b/gitlab/tests/objects/test_users.py
@@ -95,6 +95,19 @@ def resp_get_user_status():
         yield rsps
 
 
+@pytest.fixture
+def resp_delete_user_identity(no_content):
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.DELETE,
+            url="http://localhost/api/v4/users/1/identities/test_provider",
+            json=no_content,
+            content_type="application/json",
+            status=204,
+        )
+        yield rsps
+
+
 def test_get_user(gl, resp_get_user):
     user = gl.users.get(1)
     assert isinstance(user, User)
@@ -118,3 +131,7 @@ def test_user_status(user, resp_get_user_status):
 def test_user_activate_deactivate(user, resp_activate):
     user.activate()
     user.deactivate()
+
+
+def test_delete_user_identity(user, resp_delete_user_identity):
+    user.identityproviders.delete("test_provider")

--- a/gitlab/v4/objects/__init__.py
+++ b/gitlab/v4/objects/__init__.py
@@ -217,6 +217,17 @@ class UserStatusManager(GetWithoutIdMixin, RESTManager):
     _from_parent_attrs = {"user_id": "id"}
 
 
+class UserIdentityProviderManager(DeleteMixin, RESTManager):
+    """Manager for user identities.
+
+    This manager does not actually manage objects but enables
+    functionality for deletion of user identities by provider.
+    """
+
+    _path = "/users/%(user_id)s/identities"
+    _from_parent_attrs = {"user_id": "id"}
+
+
 class UserImpersonationToken(ObjectDeleteMixin, RESTObject):
     pass
 
@@ -320,6 +331,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
         ("emails", "UserEmailManager"),
         ("events", "UserEventManager"),
         ("gpgkeys", "UserGPGKeyManager"),
+        ("identityproviders", "UserIdentityProviderManager"),
         ("impersonationtokens", "UserImpersonationTokenManager"),
         ("keys", "UserKeyManager"),
         ("memberships", "UserMembershipManager"),

--- a/tools/functional/api/test_users.py
+++ b/tools/functional/api/test_users.py
@@ -1,0 +1,20 @@
+"""
+GitLab API:
+https://docs.gitlab.com/ee/api/users.html
+https://docs.gitlab.com/ee/api/users.html#delete-authentication-identity-from-user
+"""
+
+
+def test_user_identities(gl, user):
+    provider = "test_provider"
+
+    user.provider = provider
+    user.extern_uid = "1"
+    user.save()
+
+    assert provider in [item["provider"] for item in user.identities]
+
+    user.identityproviders.delete(provider)
+    user = gl.users.get(user.id)
+
+    assert provider not in [item["provider"] for item in user.identities]


### PR DESCRIPTION
Closes #1070.

This one is weird because the endpoint is kind of special (only supports delete, plus the creation of identities is inconsistent with this endpoint).

https://docs.gitlab.com/ee/api/users.html#delete-authentication-identity-from-user

I couldn't do `user.identities` for the manager because that's the attribute returned in the nested JSON. Maybe this could be done by having a `__repr__()` that returns that list from the attribute of the parent manager? But it felt like I would just be adding to the inconsistency, not sure. I didn't find any other examples that solved it for nested json.

I opted for `user.identityproviders.delete()` since its explicit and the provider is a required param. I also considered `user.identity.delete()`, `user.delete_identity()` (custom method) and `user.providers.delete()`, I'm open to any other suggestions here :grin: 