### PR TITLE
docs(cli): add auto-generated CLI reference

### DIFF
--- a/docs/api/gitlab.rst
+++ b/docs/api/gitlab.rst
@@ -1,5 +1,5 @@
-gitlab package
-==============
+API reference (``gitlab`` package)
+==================================
 
 Subpackages
 -----------

--- a/docs/cli-objects.rst
+++ b/docs/cli-objects.rst
@@ -1,0 +1,17 @@
+##################################
+CLI reference (``gitlab`` command)
+##################################
+
+.. warning::
+
+    The following is a complete, auto-generated list of subcommands available
+    via the :command:`gitlab` command-line tool. Some of the actions may
+    currently not work as expected or lack functionality available via the API.
+
+    Please see the existing `list of CLI related issues`_, or open a new one if
+    it is not already listed there.
+
+.. _list of CLI related issues: https://github.com/python-gitlab/python-gitlab/issues?q=is%3Aopen+is%3Aissue+label%3Acli
+
+.. autoprogram:: gitlab.cli:docs()
+   :prog: gitlab

--- a/docs/cli-usage.rst
+++ b/docs/cli-usage.rst
@@ -180,6 +180,10 @@ Example:
 Examples
 ========
 
+    **Notice:**
+
+        For a complete list of objects and actions available, see :doc:`/cli-objects`.
+
 List the projects (paginated):
 
 .. code-block:: console

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,12 @@ sys.path.insert(0, os.path.abspath(".."))
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.autosummary", "ext.docstrings"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "ext.docstrings",
+    "sphinxcontrib.autoprogram",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,14 +12,15 @@ Contents:
    :maxdepth: 2
 
    install
-   cli
+   cli-usage
    api-usage
    faq
-   switching-to-v4
    api-objects
    api/gitlab
+   cli-objects
    release_notes
    changelog
+   switching-to-v4
 
 
 Indices and tables

--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -149,6 +149,20 @@ def _parse_value(v):
     return v
 
 
+def docs():
+    """
+    Provide a statically generated parser for sphinx only, so we don't need
+    to provide dummy gitlab config for readthedocs.
+    """
+    if "sphinx" not in sys.modules:
+        sys.exit("Docs parser is only intended for build_sphinx")
+
+    parser = _get_base_parser(add_help=False)
+    cli_module = importlib.import_module("gitlab.v4.cli")
+
+    return _get_parser(cli_module)
+
+
 def main():
     if "--version" in sys.argv:
         print(gitlab.__version__)

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -1,3 +1,5 @@
 -r requirements.txt
 jinja2
 sphinx==3.2.1
+sphinx_rtd_theme
+sphinxcontrib-autoprogram

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,9 +1,6 @@
 coverage
 httmock
-jinja2
 mock
 pytest
 pytest-cov
-sphinx==3.2.1
-sphinx_rtd_theme
 responses

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ max-line-length = 88
 ignore = H501,H803
 
 [testenv:docs]
+deps = -r{toxinidir}/rtd-requirements.txt
 commands = python setup.py build_sphinx
 
 [testenv:cover]


### PR DESCRIPTION
This adds a generated page similar to the API reference, including all the possible commands. It's a _long_ list, but better than nothing. 😁 I wasn't able to group them into sections due to the way they are currently dynamically generated, but maybe there's a way.

I've noticed a lot of people still use the CLI even though it has some issues. I'm hoping this can help people/prevent opening issues that are simply due to missing docs (recent example: https://github.com/python-gitlab/python-gitlab/issues/1197), or at least we can more quickly close those by providing the link rather than providing examples every time.

Also means no more manual examples for the CLI are needed, hopefully.

Click also has a [drop-in replacement](https://sphinx-click.readthedocs.io) for the sphinx extension used for this PR, so switching at a later point should be easy.

Closes #1197.