### PR TITLE
feat: add pipeline test report support

### DIFF
--- a/docs/gl_objects/pipelines_and_jobs.rst
+++ b/docs/gl_objects/pipelines_and_jobs.rst
@@ -326,3 +326,26 @@ Examples
 List bridges for the pipeline::
 
     bridges = pipeline.bridges.list()
+
+Pipeline test report
+====================
+
+Get a pipeline's complete test report.
+
+Reference
+---------
+
+* v4 API
+
+  + :class:`gitlab.v4.objects.ProjectPipelineTestReport`
+  + :class:`gitlab.v4.objects.ProjectPipelineTestReportManager`
+  + :attr:`gitlab.v4.objects.ProjectPipeline.test_report`
+
+* GitLab API: https://docs.gitlab.com/ee/api/pipelines.html#get-a-pipelines-test-report
+
+Examples
+--------
+
+Get the test report for a pipeline::
+
+    test_report = pipeline.test_report.get()

--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -5,6 +5,7 @@ from gitlab.mixins import (
     CreateMixin,
     CRUDMixin,
     DeleteMixin,
+    GetWithoutIdMixin,
     ListMixin,
     ObjectDeleteMixin,
     RefreshMixin,
@@ -26,6 +27,8 @@ __all__ = [
     "ProjectPipelineScheduleVariableManager",
     "ProjectPipelineSchedule",
     "ProjectPipelineScheduleManager",
+    "ProjectPipelineTestReport",
+    "ProjectPipelineTestReportManager",
 ]
 
 
@@ -34,6 +37,7 @@ class ProjectPipeline(RefreshMixin, ObjectDeleteMixin, RESTObject):
         ("jobs", "ProjectPipelineJobManager"),
         ("bridges", "ProjectPipelineBridgeManager"),
         ("variables", "ProjectPipelineVariableManager"),
+        ("test_report", "ProjectPipelineTestReportManager"),
     )
 
     @cli.register_custom_action("ProjectPipeline")
@@ -201,3 +205,13 @@ class ProjectPipelineScheduleManager(CRUDMixin, RESTManager):
     _update_attrs = RequiredOptional(
         optional=("description", "ref", "cron", "cron_timezone", "active"),
     )
+
+
+class ProjectPipelineTestReport(RESTObject):
+    _id_attr = None
+
+
+class ProjectPipelineTestReportManager(GetWithoutIdMixin, RESTManager):
+    _path = "/projects/%(project_id)s/pipelines/%(pipeline_id)s/test_report"
+    _obj_cls = ProjectPipelineTestReport
+    _from_parent_attrs = {"project_id": "project_id", "pipeline_id": "id"}


### PR DESCRIPTION
Gitlab (since v13.0) now supports [test reports](https://docs.gitlab.com/ee/ci/unit_test_reports.html#unit-test-reports). Here is [the api description](https://docs.gitlab.com/ee/api/pipelines.html#get-a-pipelines-test-report).