### PR TITLE
feat: Add MINIMAL_ACCESS constant

### DIFF
--- a/gitlab/const.py
+++ b/gitlab/const.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 NO_ACCESS = 0
+MINIMAL_ACCESS = 5
 GUEST_ACCESS = 10
 REPORTER_ACCESS = 20
 DEVELOPER_ACCESS = 30


### PR DESCRIPTION
A "minimal access" access level was [introduced](https://gitlab.com/gitlab-org/gitlab/-/issues/220203) in GitLab 13.5.

It's currently undocumented. Its addition to GitLab's docs was approved in [this PR](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/49526).