### PR TITLE
docs(groups): add example for creating subgroups

### DIFF
--- a/docs/gl_objects/groups.rst
+++ b/docs/gl_objects/groups.rst
@@ -56,6 +56,10 @@ Create a group::
 
     group = gl.groups.create({'name': 'group1', 'path': 'group1'})
 
+Create a subgroup under an existing group::
+
+    subgroup = gl.groups.create({'name': 'subgroup1', 'path': 'subgroup1', 'parent_id': parent_group_id})
+
 Update a group::
 
     group.description = 'My awesome group'


### PR DESCRIPTION
Follows the [GitLab API example](https://docs.gitlab.com/ee/api/groups.html#new-subgroup)