### PR TITLE
Use inline anonymous references for external links

### DIFF
--- a/docs/cli-usage.rst
+++ b/docs/cli-usage.rst
@@ -98,22 +98,23 @@ server, with very limited permissions.
    * - ``url``
      - URL for the GitLab server
    * - ``private_token``
-     - Your user token. Login/password is not supported. Refer to `the official
-       documentation`_pat to learn how to obtain a token.
+     - Your user token. Login/password is not supported. Refer to `the
+       official documentation
+       <https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html>`__
+       to learn how to obtain a token.
    * - ``oauth_token``
      - An Oauth token for authentication. The Gitlab server must be configured
        to support this authentication method.
    * - ``job_token``
-     - Your job token. See `the official  documentation`_job-token to learn how to obtain a token.
+     - Your job token. See `the official documentation
+       <https://docs.gitlab.com/ce/api/jobs.html#get-job-artifacts>`__
+       to learn how to obtain a token.
    * - ``api_version``
      - GitLab API version to use. Only ``4`` is available since 1.5.0.
    * - ``http_username``
      - Username for optional HTTP authentication
    * - ``http_password``
      - Password for optional HTTP authentication
-
-.. _pat: https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html
-.. _job-token: https://docs.gitlab.com/ce/api/jobs.html#get-job-artifacts
 
 CLI
 ===


### PR DESCRIPTION
The links to "the official documentation" on tokens are currently broken in the [project documentation](https://python-gitlab.readthedocs.io/en/stable/cli.html).

There doesn't seem to be an obvious way to use an alias for identical text labels that link to different targets. With inline links we can work around this shortcoming. Until we know better.