### PR TITLE
fix(api): add missing GetMixin to ProjectLabelManager

### DIFF
--- a/gitlab/v4/objects/__init__.py
+++ b/gitlab/v4/objects/__init__.py
@@ -3601,7 +3601,7 @@ class ProjectLabel(SubscribableMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectLabelManager(
-    ListMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
+    RetrieveMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
 ):
     _path = "/projects/%(project_id)s/labels"
     _obj_cls = ProjectLabel

--- a/tools/functional/api/test_projects.py
+++ b/tools/functional/api/test_projects.py
@@ -139,8 +139,11 @@ def test_project_housekeeping(project):
 
 def test_project_labels(project):
     label = project.labels.create({"name": "label", "color": "#778899"})
-    label = project.labels.list()[0]
-    assert len(project.labels.list()) == 1
+    labels = project.labels.list()
+    assert len(labels) == 1
+
+    label = project.labels.get("label")
+    assert label == labels[0]
 
     label.new_name = "labelupdated"
     label.save()


### PR DESCRIPTION
The ProjectLabelManager was missing the GetMixin, which made it impossible to get labels by name or ID, even though this is supported by the GitLab API.