### PR TITLE
Honor parameter value passed

### DIFF
--- a/gitlab/v4/objects/__init__.py
+++ b/gitlab/v4/objects/__init__.py
@@ -3438,7 +3438,7 @@ class ProjectMergeRequest(
         if merge_commit_message:
             data["merge_commit_message"] = merge_commit_message
         if should_remove_source_branch:
-            data["should_remove_source_branch"] = True
+            data["should_remove_source_branch"] = str(should_remove_source_branch).lower() != 'false'
         if merge_when_pipeline_succeeds:
             data["merge_when_pipeline_succeeds"] = True
 


### PR DESCRIPTION
Gitlab allows setting the defaults for MR to delete the source. Also
the inline help of the CLI suggest that a boolean is expected, but no
matter what value you set, it will always delete.

To mimic the existing behavior as good as possible, we check for not false
instead of true. This way the impact on the cli will be minimal.