### PR TITLE
fix: honor parameter value passed

### DIFF
--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -312,8 +312,8 @@ class ProjectMergeRequest(
         data = {}
         if merge_commit_message:
             data["merge_commit_message"] = merge_commit_message
-        if should_remove_source_branch:
-            data["should_remove_source_branch"] = True
+        if should_remove_source_branch is not None:
+            data["should_remove_source_branch"] = should_remove_source_branch
         if merge_when_pipeline_succeeds:
             data["merge_when_pipeline_succeeds"] = True
 


### PR DESCRIPTION
Gitlab allows setting the defaults for MR to delete the source. Also
the inline help of the CLI suggest that a boolean is expected, but no
matter what value you set, it will always delete.

To mimic the existing behavior as good as possible, we check for not false
instead of true. This way the impact on the cli will be minimal.