### PR TITLE
chore(ci): deduplicate PR jobs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,12 @@
 name: Docs
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 env:
   PY_COLORS: 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,12 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 env:
   PY_COLORS: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,12 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 env:
   PY_COLORS: 1


### PR DESCRIPTION
Let's save the earth a little CO2 by not triggering 22 jobs every time we push to PR's from this repo :grin: PR checks are safer anyway as they do a pre-merge checkout.

More context here https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012