### PR TITLE
fix(cli): fix parsing CLI objects to classnames 

### DIFF
--- a/gitlab/tests/test_cli.py
+++ b/gitlab/tests/test_cli.py
@@ -34,6 +34,9 @@ from gitlab import cli
         ("class", "Class"),
         ("test-class", "TestClass"),
         ("test-longer-class", "TestLongerClass"),
+        ("current-user-gpg-key", "CurrentUserGPGKey"),
+        ("user-gpg-key", "UserGPGKey"),
+        ("ldap-group", "LDAPGroup"),
     ],
 )
 def test_what_to_cls(what, expected_class):
@@ -53,6 +56,9 @@ def test_what_to_cls(what, expected_class):
         ("TestClass", "test-class"),
         ("TestUPPERCASEClass", "test-uppercase-class"),
         ("UPPERCASETestClass", "uppercase-test-class"),
+        ("CurrentUserGPGKey", "current-user-gpg-key"),
+        ("UserGPGKey", "user-gpg-key"),
+        ("LDAPGroup", "ldap-group"),
     ],
 )
 def test_cls_to_what(class_name, expected_what):

--- a/gitlab/tests/test_cli.py
+++ b/gitlab/tests/test_cli.py
@@ -28,20 +28,37 @@ import pytest
 from gitlab import cli
 
 
-def test_what_to_cls():
-    assert "Foo" == cli.what_to_cls("foo")
-    assert "FooBar" == cli.what_to_cls("foo-bar")
-
-
-def test_cls_to_what():
-    class Class(object):
+@pytest.mark.parametrize(
+    "what,expected_class",
+    [
+        ("class", "Class"),
+        ("test-class", "TestClass"),
+        ("test-longer-class", "TestLongerClass"),
+    ],
+)
+def test_what_to_cls(what, expected_class):
+    def _namespace():
         pass
 
-    class TestClass(object):
-        pass
+    ExpectedClass = type(expected_class, (), {})
+    _namespace.__dict__[expected_class] = ExpectedClass
 
-    assert "test-class" == cli.cls_to_what(TestClass)
-    assert "class" == cli.cls_to_what(Class)
+    assert cli.what_to_cls(what, _namespace) == ExpectedClass
+
+
+@pytest.mark.parametrize(
+    "class_name,expected_what",
+    [
+        ("Class", "class"),
+        ("TestClass", "test-class"),
+        ("TestUPPERCASEClass", "test-uppercase-class"),
+        ("UPPERCASETestClass", "uppercase-test-class"),
+    ],
+)
+def test_cls_to_what(class_name, expected_what):
+    TestClass = type(class_name, (), {})
+
+    assert cli.cls_to_what(TestClass) == expected_what
 
 
 def test_die():

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -28,8 +28,8 @@ import gitlab.v4.objects
 
 class GitlabCLI(object):
     def __init__(self, gl, what, action, args):
-        self.cls_name = cli.what_to_cls(what)
-        self.cls = gitlab.v4.objects.__dict__[self.cls_name]
+        self.cls = cli.what_to_cls(what, namespace=gitlab.v4.objects)
+        self.cls_name = self.cls.__name__
         self.what = what.replace("-", "_")
         self.action = action.lower()
         self.gl = gl


### PR DESCRIPTION
Closes https://github.com/python-gitlab/python-gitlab/issues/1289. Not sure if relying on requests' internal `CaseInsensitiveDict` for this is the best idea here but I didn't want to reinvent the wheel. But it's needed since proper camelcase -> kebab-case conversions are not fully reversible (see https://stackoverflow.com/a/1176023)

Fixes the issue for:
CurrentUserGPGKey
LDAPGroup
UserGPGKey
