### PR TITLE
feat(cli): allow options from CLI args or environment variables

### DIFF
--- a/docs/cli-usage.rst
+++ b/docs/cli-usage.rst
@@ -3,17 +3,60 @@
 ####################
 
 ``python-gitlab`` provides a :command:`gitlab` command-line tool to interact
-with GitLab servers. It uses a configuration file to define how to connect to
-the servers. Without a configuration file, ``gitlab`` will default to
-https://gitlab.com and unauthenticated requests.
+with GitLab servers.
+
+This is especially convenient for running quick ad-hoc commands locally, easily
+interacting with the API inside GitLab CI, or with more advanced shell scripting
+when integrating with other tooling.
 
 .. _cli_configuration:
 
 Configuration
 =============
 
-Files
------
+``gitlab`` allows setting configuration options via command-line arguments,
+environment variables, and configuration files.
+
+For a complete list of global CLI options and their environment variable
+equivalents, see :doc:`/cli-objects`.
+
+With no configuration provided, ``gitlab`` will default to unauthenticated
+requests against `GitLab.com <https://gitlab.com>`__.
+
+With no configuration but running inside a GitLab CI job, it will default to
+authenticated requests using the current job token against the current instance
+(via ``CI_SERVER_URL`` and ``CI_JOB_TOKEN`` environment variables).
+
+.. warning::
+   Please note the job token has very limited permissions and can only be used
+   with certain endpoints. You may need to provide a personal access token instead.
+
+When you provide configuration, values are evaluated with the following precedence:
+
+1. Explicitly provided CLI arguments,
+2. Environment variables,
+3. Configuration files:
+
+   a. explicitly defined config files:
+
+      i. via the ``--config-file`` CLI argument,
+      ii. via the ``PYTHON_GITLAB_CFG`` environment variable,
+
+   b. user-specific config file,
+   c. system-level config file,
+
+4. Environment variables always present in CI (``CI_SERVER_URL``, ``CI_JOB_TOKEN``).
+
+Additionally, authentication will take the following precedence
+when multiple options or environment variables are present:
+
+1. Private token,
+2. OAuth token,
+3. CI job token.
+
+
+Configuration files
+-------------------
 
 ``gitlab`` looks up 3 configuration files by default:
 
@@ -35,8 +78,8 @@ You can use a different configuration file with the ``--config-file`` option.
     If the environment variable is defined and the target file cannot be accessed,
     ``gitlab`` will fail explicitly.
 
-Content
--------
+Configuration file format
+-------------------------
 
 The configuration file uses the ``INI`` format. It contains at least a
 ``[global]`` section, and a specific section for each GitLab server. For

--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -19,6 +19,7 @@
 
 import argparse
 import functools
+import os
 import re
 import sys
 from types import ModuleType
@@ -112,17 +113,25 @@ def _get_base_parser(add_help: bool = True) -> argparse.ArgumentParser:
         "-v",
         "--verbose",
         "--fancy",
-        help="Verbose mode (legacy format only)",
+        help="Verbose mode (legacy format only) [env var: GITLAB_VERBOSE]",
         action="store_true",
+        default=os.getenv("GITLAB_VERBOSE"),
     )
     parser.add_argument(
-        "-d", "--debug", help="Debug mode (display HTTP requests)", action="store_true"
+        "-d",
+        "--debug",
+        help="Debug mode (display HTTP requests) [env var: GITLAB_DEBUG]",
+        action="store_true",
+        default=os.getenv("GITLAB_DEBUG"),
     )
     parser.add_argument(
         "-c",
         "--config-file",
         action="append",
-        help="Configuration file to use. Can be used multiple times.",
+        help=(
+            "Configuration file to use. Can be used multiple times. "
+            "[env var: PYTHON_GITLAB_CFG]"
+        ),
     )
     parser.add_argument(
         "-g",
@@ -151,7 +160,86 @@ def _get_base_parser(add_help: bool = True) -> argparse.ArgumentParser:
         ),
         required=False,
     )
+    parser.add_argument(
+        "--server-url",
+        help=("GitLab server URL [env var: GITLAB_URL]"),
+        required=False,
+        default=os.getenv("GITLAB_URL"),
+    )
+    parser.add_argument(
+        "--ssl-verify",
+        help=(
+            "Whether SSL certificates should be validated. [env var: GITLAB_SSL_VERIFY]"
+        ),
+        required=False,
+        default=os.getenv("GITLAB_SSL_VERIFY"),
+    )
+    parser.add_argument(
+        "--timeout",
+        help=(
+            "Timeout to use for requests to the GitLab server. "
+            "[env var: GITLAB_TIMEOUT]"
+        ),
+        required=False,
+        default=os.getenv("GITLAB_TIMEOUT"),
+    )
+    parser.add_argument(
+        "--api-version",
+        help=("GitLab API version [env var: GITLAB_API_VERSION]"),
+        required=False,
+        default=os.getenv("GITLAB_API_VERSION"),
+    )
+    parser.add_argument(
+        "--per-page",
+        help=(
+            "Number of entries to return per page in the response. "
+            "[env var: GITLAB_PER_PAGE]"
+        ),
+        required=False,
+        default=os.getenv("GITLAB_PER_PAGE"),
+    )
+    parser.add_argument(
+        "--pagination",
+        help=(
+            "Whether to use keyset or offset pagination [env var: GITLAB_PAGINATION]"
+        ),
+        required=False,
+        default=os.getenv("GITLAB_PAGINATION"),
+    )
+    parser.add_argument(
+        "--order-by",
+        help=("Set order_by globally [env var: GITLAB_ORDER_BY]"),
+        required=False,
+        default=os.getenv("GITLAB_ORDER_BY"),
+    )
+    parser.add_argument(
+        "--user-agent",
+        help=(
+            "The user agent to send to GitLab with the HTTP request. "
+            "[env var: GITLAB_USER_AGENT]"
+        ),
+        required=False,
+        default=os.getenv("GITLAB_USER_AGENT"),
+    )
 
+    tokens = parser.add_mutually_exclusive_group()
+    tokens.add_argument(
+        "--private-token",
+        help=("GitLab private access token [env var: GITLAB_PRIVATE_TOKEN]"),
+        required=False,
+        default=os.getenv("GITLAB_PRIVATE_TOKEN"),
+    )
+    tokens.add_argument(
+        "--oauth-token",
+        help=("GitLab OAuth token [env var: GITLAB_OAUTH_TOKEN]"),
+        required=False,
+        default=os.getenv("GITLAB_OAUTH_TOKEN"),
+    )
+    tokens.add_argument(
+        "--job-token",
+        help=("GitLab CI job token [env var: CI_JOB_TOKEN]"),
+        required=False,
+    )
     return parser
 
 
@@ -243,13 +331,23 @@ def main() -> None:
         "whaction",
         "version",
         "output",
+        "fields",
+        "server_url",
+        "ssl_verify",
+        "timeout",
+        "api_version",
+        "pagination",
+        "user_agent",
+        "private_token",
+        "oauth_token",
+        "job_token",
     ):
         args_dict.pop(item)
     args_dict = {k: _parse_value(v) for k, v in args_dict.items() if v is not None}
 
     try:
-        gl = gitlab.Gitlab.from_config(gitlab_id, config_files)
-        if gl.private_token or gl.oauth_token or gl.job_token:
+        gl = gitlab.Gitlab.merge_config(vars(options), gitlab_id, config_files)
+        if gl.private_token or gl.oauth_token:
             gl.auth()
     except Exception as e:
         die(str(e))

--- a/gitlab/config.py
+++ b/gitlab/config.py
@@ -23,7 +23,7 @@ from os.path import expanduser, expandvars
 from pathlib import Path
 from typing import List, Optional, Union
 
-from gitlab.const import DEFAULT_URL, USER_AGENT
+from gitlab.const import USER_AGENT
 
 _DEFAULT_FILES: List[str] = [
     "/etc/python-gitlab.cfg",
@@ -119,7 +119,7 @@ class GitlabConfigParser(object):
         self.retry_transient_errors: bool = False
         self.ssl_verify: Union[bool, str] = True
         self.timeout: int = 60
-        self.url: str = DEFAULT_URL
+        self.url: Optional[str] = None
         self.user_agent: str = USER_AGENT
 
         self._files = _get_config_files(config_files)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -150,7 +150,7 @@ def test_default_config(mock_clean_env, monkeypatch):
     assert cp.retry_transient_errors is False
     assert cp.ssl_verify is True
     assert cp.timeout == 60
-    assert cp.url == const.DEFAULT_URL
+    assert cp.url is None
     assert cp.user_agent == const.USER_AGENT
 
 

--- a/tests/unit/test_gitlab_auth.py
+++ b/tests/unit/test_gitlab_auth.py
@@ -2,6 +2,7 @@ import pytest
 import requests
 
 from gitlab import Gitlab
+from gitlab.config import GitlabConfigParser
 
 
 def test_invalid_auth_args():
@@ -83,3 +84,116 @@ def test_http_auth():
     assert isinstance(gl._http_auth, requests.auth.HTTPBasicAuth)
     assert gl.headers["PRIVATE-TOKEN"] == "private_token"
     assert "Authorization" not in gl.headers
+
+
+@pytest.mark.parametrize(
+    "options,config,expected_private_token,expected_oauth_token,expected_job_token",
+    [
+        (
+            {
+                "private_token": "options-private-token",
+                "oauth_token": "options-oauth-token",
+                "job_token": "options-job-token",
+            },
+            {
+                "private_token": "config-private-token",
+                "oauth_token": "config-oauth-token",
+                "job_token": "config-job-token",
+            },
+            "options-private-token",
+            None,
+            None,
+        ),
+        (
+            {
+                "private_token": None,
+                "oauth_token": "options-oauth-token",
+                "job_token": "options-job-token",
+            },
+            {
+                "private_token": "config-private-token",
+                "oauth_token": "config-oauth-token",
+                "job_token": "config-job-token",
+            },
+            "config-private-token",
+            None,
+            None,
+        ),
+        (
+            {
+                "private_token": None,
+                "oauth_token": None,
+                "job_token": "options-job-token",
+            },
+            {
+                "private_token": "config-private-token",
+                "oauth_token": "config-oauth-token",
+                "job_token": "config-job-token",
+            },
+            "config-private-token",
+            None,
+            None,
+        ),
+        (
+            {
+                "private_token": None,
+                "oauth_token": None,
+                "job_token": None,
+            },
+            {
+                "private_token": "config-private-token",
+                "oauth_token": "config-oauth-token",
+                "job_token": "config-job-token",
+            },
+            "config-private-token",
+            None,
+            None,
+        ),
+        (
+            {
+                "private_token": None,
+                "oauth_token": None,
+                "job_token": None,
+            },
+            {
+                "private_token": None,
+                "oauth_token": "config-oauth-token",
+                "job_token": "config-job-token",
+            },
+            None,
+            "config-oauth-token",
+            None,
+        ),
+        (
+            {
+                "private_token": None,
+                "oauth_token": None,
+                "job_token": None,
+            },
+            {
+                "private_token": None,
+                "oauth_token": None,
+                "job_token": "config-job-token",
+            },
+            None,
+            None,
+            "config-job-token",
+        ),
+    ],
+)
+def test_merge_auth(
+    options,
+    config,
+    expected_private_token,
+    expected_oauth_token,
+    expected_job_token,
+):
+    cp = GitlabConfigParser()
+    cp.private_token = config["private_token"]
+    cp.oauth_token = config["oauth_token"]
+    cp.job_token = config["job_token"]
+
+    private_token, oauth_token, job_token = Gitlab._merge_auth(options, cp)
+    assert private_token == expected_private_token
+    assert oauth_token == expected_oauth_token
+    assert job_token == expected_job_token


### PR DESCRIPTION
Closes https://github.com/python-gitlab/python-gitlab/issues/960
Closes https://github.com/python-gitlab/python-gitlab/issues/893

Makes it easier to later introduce https://github.com/python-gitlab/python-gitlab/issues/715 hopefully, and maybe https://github.com/python-gitlab/python-gitlab/issues/1195.

BREAKING-CHANGE: The gitlab CLI will now accept CLI arguments
and environment variables for its global options in addition
to configuration file options. This may change behavior for
some workflows such as running inside GitLab CI and with
certain environment variables configured.