### PR TITLE
Remove Python 2 code

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -383,10 +383,7 @@ class Gitlab(object):
     def enable_debug(self):
         import logging
 
-        try:
-            from http.client import HTTPConnection  # noqa
-        except ImportError:
-            from httplib import HTTPConnection  # noqa
+        from http.client import HTTPConnection  # noqa
 
         HTTPConnection.debuglevel = 1
         logging.basicConfig()


### PR DESCRIPTION
httplib is a Python 2 library. It was renamed to http.client in Python
3.

https://docs.python.org/2.7/library/httplib.html