### PR TITLE
chore: remove unused ALLOWED_KEYSET_ENDPOINTS variable

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -45,8 +45,6 @@ REDIRECT_MSG = (
     "must update your GitLab URL to use https:// to avoid issues."
 )
 
-ALLOWED_KEYSET_ENDPOINTS = ["/projects"]
-
 
 class Gitlab(object):
     """Represents a GitLab server connection.


### PR DESCRIPTION
The variable ALLOWED_KEYSET_ENDPOINTS was added in commit
f86ef3bbdb5bffa1348a802e62b281d3f31d33ad.

Then most of that commit was removed in commit
e71fe16b47835aa4db2834e98c7ffc6bdec36723, but ALLOWED_KEYSET_ENDPOINTS
was missed.