### PR TITLE
feat: add project audit endpoint

### DIFF
--- a/gitlab/tests/objects/test_audit_events.py
+++ b/gitlab/tests/objects/test_audit_events.py
@@ -1,0 +1,79 @@
+"""
+GitLab API:
+https://docs.gitlab.com/ee/api/audit_events.html#project-audit-events
+"""
+
+import re
+
+import pytest
+import responses
+
+from gitlab.v4.objects.audit_events import ProjectAudit
+
+id = 5
+
+audit_events_content = {
+    "id": 5,
+    "author_id": 1,
+    "entity_id": 7,
+    "entity_type": "Project",
+    "details": {
+        "change": "prevent merge request approval from reviewers",
+        "from": "",
+        "to": "true",
+        "author_name": "Administrator",
+        "target_id": 7,
+        "target_type": "Project",
+        "target_details": "twitter/typeahead-js",
+        "ip_address": "127.0.0.1",
+        "entity_path": "twitter/typeahead-js",
+    },
+    "created_at": "2020-05-26T22:55:04.230Z",
+}
+
+audit_events_url = re.compile(
+    r"http://localhost/api/v4/(((groups|projects)/1)|(admin/ci))/audit_events"
+)
+
+audit_events_url_id = re.compile(
+    rf"http://localhost/api/v4/(((groups|projects)/1)|(admin/ci))/audit_events/{id}"
+)
+
+
+@pytest.fixture
+def resp_list_audit_events():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.GET,
+            url=audit_events_url,
+            json=[audit_events_content],
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
+@pytest.fixture
+def resp_get_variable():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.GET,
+            url=audit_events_url_id,
+            json=audit_events_content,
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
+def test_list_project_audit_events(project, resp_list_audit_events):
+    audit_events = project.audit_events.list()
+    assert isinstance(audit_events, list)
+    assert isinstance(audit_events[0], ProjectAudit)
+    assert audit_events[0].id == id
+
+
+def test_get_project_audit_events(project, resp_get_variable):
+    audit_event = project.audit_events.get(id)
+    assert isinstance(audit_event, ProjectAudit)
+    assert audit_event.id == id

--- a/gitlab/tests/objects/test_audit_events.py
+++ b/gitlab/tests/objects/test_audit_events.py
@@ -32,11 +32,11 @@ audit_events_content = {
 }
 
 audit_events_url = re.compile(
-    r"http://localhost/api/v4/(((groups|projects)/1)|(admin/ci))/audit_events"
+    r"http://localhost/api/v4/((groups|projects)/1/)audit_events"
 )
 
 audit_events_url_id = re.compile(
-    rf"http://localhost/api/v4/(((groups|projects)/1)|(admin/ci))/audit_events/{id}"
+    rf"http://localhost/api/v4/((groups|projects)/1/)audit_events/{id}"
 )
 
 

--- a/gitlab/v4/objects/audit_events.py
+++ b/gitlab/v4/objects/audit_events.py
@@ -1,0 +1,23 @@
+"""
+GitLab API:
+https://docs.gitlab.com/ee/api/audit_events.html#project-audit-events
+"""
+
+from gitlab.base import *  # noqa
+from gitlab.mixins import *  # noqa
+
+__all__ = [
+    "ProjectAudit",
+    "ProjectAuditManager",
+]
+
+
+class ProjectAudit(RESTObject):
+    _id_attr = "id"
+
+
+class ProjectAuditManager(RetrieveMixin, RESTManager):
+    _path = "/projects/%(project_id)s/audit_events"
+    _obj_cls = ProjectAudit
+    _from_parent_attrs = {"project_id": "id"}
+    _list_filters = ("created_after", "created_before")

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -16,6 +16,7 @@ from .deploy_tokens import ProjectDeployTokenManager
 from .deployments import ProjectDeploymentManager
 from .environments import ProjectEnvironmentManager
 from .events import ProjectEventManager
+from .audit_events import ProjectAuditManager
 from .export_import import ProjectExportManager, ProjectImportManager
 from .files import ProjectFileManager
 from .hooks import ProjectHookManager
@@ -100,6 +101,7 @@ class Project(SaveMixin, ObjectDeleteMixin, RESTObject):
         ("deployments", "ProjectDeploymentManager"),
         ("environments", "ProjectEnvironmentManager"),
         ("events", "ProjectEventManager"),
+        ("audit_events", "ProjectAuditManager"),
         ("exports", "ProjectExportManager"),
         ("files", "ProjectFileManager"),
         ("forks", "ProjectForkManager"),


### PR DESCRIPTION
Similar to #949 but specific to [project audit events](https://docs.gitlab.com/ee/api/audit_events.html#project-audit-events).

No previous issues for this exist.

The code was tested to verify it works.