### PR TITLE
fix: test_update_group() dependency on ordering

### DIFF
--- a/tools/functional/cli/test_cli_v4.py
+++ b/tools/functional/cli/test_cli_v4.py
@@ -42,7 +42,7 @@ def test_update_group(gitlab_cli, gl, group):
 
     assert ret.success
 
-    group = gl.groups.list(description=description)[0]
+    group = gl.groups.get(group.id)
     assert group.description == description
 
 


### PR DESCRIPTION
Since there are two groups we can't depend on the one we changed to
always be the first one returned.

Instead fetch the group we want and then test our assertion against
that group.