### PR TITLE
chore: remove usage of 'from ... import *'

### DIFF
--- a/gitlab/v4/objects/access_requests.py
+++ b/gitlab/v4/objects/access_requests.py
@@ -1,5 +1,11 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import (
+    AccessRequestMixin,
+    CreateMixin,
+    DeleteMixin,
+    ListMixin,
+    ObjectDeleteMixin,
+)
 
 
 __all__ = [

--- a/gitlab/v4/objects/appearance.py
+++ b/gitlab/v4/objects/appearance.py
@@ -1,6 +1,6 @@
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import GetWithoutIdMixin, SaveMixin, UpdateMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/applications.py
+++ b/gitlab/v4/objects/applications.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CreateMixin, DeleteMixin, ListMixin, ObjectDeleteMixin
 
 __all__ = [
     "Application",

--- a/gitlab/v4/objects/audit_events.py
+++ b/gitlab/v4/objects/audit_events.py
@@ -3,8 +3,8 @@ GitLab API:
 https://docs.gitlab.com/ee/api/audit_events.html#project-audit-events
 """
 
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import RetrieveMixin
 
 __all__ = [
     "ProjectAudit",

--- a/gitlab/v4/objects/award_emojis.py
+++ b/gitlab/v4/objects/award_emojis.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import NoUpdateMixin, ObjectDeleteMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/badges.py
+++ b/gitlab/v4/objects/badges.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import BadgeRenderMixin, CRUDMixin, ObjectDeleteMixin, SaveMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/boards.py
+++ b/gitlab/v4/objects/boards.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/branches.py
+++ b/gitlab/v4/objects/branches.py
@@ -1,7 +1,7 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import NoUpdateMixin, ObjectDeleteMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/broadcast_messages.py
+++ b/gitlab/v4/objects/broadcast_messages.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/clusters.py
+++ b/gitlab/v4/objects/clusters.py
@@ -1,6 +1,6 @@
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CRUDMixin, CreateMixin, ObjectDeleteMixin, SaveMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/commits.py
+++ b/gitlab/v4/objects/commits.py
@@ -1,7 +1,7 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CreateMixin, ListMixin, RefreshMixin, RetrieveMixin
 from .discussions import ProjectCommitDiscussionManager
 
 

--- a/gitlab/v4/objects/container_registry.py
+++ b/gitlab/v4/objects/container_registry.py
@@ -1,7 +1,7 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import DeleteMixin, ListMixin, ObjectDeleteMixin, RetrieveMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/custom_attributes.py
+++ b/gitlab/v4/objects/custom_attributes.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import DeleteMixin, ObjectDeleteMixin, RetrieveMixin, SetMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/deploy_keys.py
+++ b/gitlab/v4/objects/deploy_keys.py
@@ -1,7 +1,7 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CRUDMixin, ListMixin, ObjectDeleteMixin, SaveMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/deploy_tokens.py
+++ b/gitlab/v4/objects/deploy_tokens.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CreateMixin, DeleteMixin, ListMixin, ObjectDeleteMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/deployments.py
+++ b/gitlab/v4/objects/deployments.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CreateMixin, RetrieveMixin, SaveMixin, UpdateMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/discussions.py
+++ b/gitlab/v4/objects/discussions.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CreateMixin, RetrieveMixin, SaveMixin, UpdateMixin
 from .notes import (
     ProjectCommitDiscussionNoteManager,
     ProjectIssueDiscussionNoteManager,

--- a/gitlab/v4/objects/environments.py
+++ b/gitlab/v4/objects/environments.py
@@ -1,7 +1,14 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import (
+    CreateMixin,
+    DeleteMixin,
+    ObjectDeleteMixin,
+    RetrieveMixin,
+    SaveMixin,
+    UpdateMixin,
+)
 
 
 __all__ = [

--- a/gitlab/v4/objects/epics.py
+++ b/gitlab/v4/objects/epics.py
@@ -1,7 +1,15 @@
 from gitlab import types
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import (
+    CRUDMixin,
+    CreateMixin,
+    DeleteMixin,
+    ListMixin,
+    ObjectDeleteMixin,
+    SaveMixin,
+    UpdateMixin,
+)
 from .events import GroupEpicResourceLabelEventManager
 
 

--- a/gitlab/v4/objects/events.py
+++ b/gitlab/v4/objects/events.py
@@ -1,6 +1,6 @@
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import ListMixin, RetrieveMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/export_import.py
+++ b/gitlab/v4/objects/export_import.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CreateMixin, DownloadMixin, GetWithoutIdMixin, RefreshMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/features.py
+++ b/gitlab/v4/objects/features.py
@@ -1,7 +1,7 @@
 from gitlab import utils
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import DeleteMixin, ListMixin, ObjectDeleteMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -1,8 +1,15 @@
 import base64
 from gitlab import cli, utils
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import (
+    CreateMixin,
+    DeleteMixin,
+    GetMixin,
+    ObjectDeleteMixin,
+    SaveMixin,
+    UpdateMixin,
+)
 
 
 __all__ = [

--- a/gitlab/v4/objects/geo_nodes.py
+++ b/gitlab/v4/objects/geo_nodes.py
@@ -1,7 +1,13 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import (
+    DeleteMixin,
+    ObjectDeleteMixin,
+    RetrieveMixin,
+    SaveMixin,
+    UpdateMixin,
+)
 
 
 __all__ = [

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -1,7 +1,7 @@
 from gitlab import cli, types
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CRUDMixin, ListMixin, ObjectDeleteMixin, SaveMixin
 from .access_requests import GroupAccessRequestManager
 from .badges import GroupBadgeManager
 from .boards import GroupBoardManager

--- a/gitlab/v4/objects/hooks.py
+++ b/gitlab/v4/objects/hooks.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CRUDMixin, NoUpdateMixin, ObjectDeleteMixin, SaveMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/issues.py
+++ b/gitlab/v4/objects/issues.py
@@ -1,7 +1,20 @@
 from gitlab import cli, types
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import (
+    CRUDMixin,
+    CreateMixin,
+    DeleteMixin,
+    ListMixin,
+    ObjectDeleteMixin,
+    ParticipantsMixin,
+    RetrieveMixin,
+    SaveMixin,
+    SubscribableMixin,
+    TimeTrackingMixin,
+    TodoMixin,
+    UserAgentDetailMixin,
+)
 from .award_emojis import ProjectIssueAwardEmojiManager
 from .discussions import ProjectIssueDiscussionManager
 from .events import (

--- a/gitlab/v4/objects/jobs.py
+++ b/gitlab/v4/objects/jobs.py
@@ -1,7 +1,7 @@
 from gitlab import cli, utils
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import RefreshMixin, RetrieveMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/labels.py
+++ b/gitlab/v4/objects/labels.py
@@ -1,6 +1,15 @@
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import (
+    CreateMixin,
+    DeleteMixin,
+    ListMixin,
+    ObjectDeleteMixin,
+    RetrieveMixin,
+    SaveMixin,
+    SubscribableMixin,
+    UpdateMixin,
+)
 
 
 __all__ = [

--- a/gitlab/v4/objects/ldap.py
+++ b/gitlab/v4/objects/ldap.py
@@ -1,6 +1,5 @@
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject, RESTObjectList
 
 
 __all__ = [

--- a/gitlab/v4/objects/members.py
+++ b/gitlab/v4/objects/members.py
@@ -1,7 +1,7 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -1,6 +1,14 @@
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import (
+    CreateMixin,
+    DeleteMixin,
+    GetWithoutIdMixin,
+    ListMixin,
+    ObjectDeleteMixin,
+    SaveMixin,
+    UpdateMixin,
+)
 
 
 __all__ = [

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -1,7 +1,17 @@
 from gitlab import cli, types
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject, RESTObjectList
+from gitlab.mixins import (
+    CRUDMixin,
+    ListMixin,
+    ObjectDeleteMixin,
+    ParticipantsMixin,
+    RetrieveMixin,
+    SaveMixin,
+    SubscribableMixin,
+    TimeTrackingMixin,
+    TodoMixin,
+)
 from .commits import ProjectCommit, ProjectCommitManager
 from .issues import ProjectIssue, ProjectIssueManager
 from .merge_request_approvals import (

--- a/gitlab/v4/objects/milestones.py
+++ b/gitlab/v4/objects/milestones.py
@@ -1,7 +1,7 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject, RESTObjectList
+from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
 from .issues import GroupIssue, GroupIssueManager, ProjectIssue, ProjectIssueManager
 from .merge_requests import (
     ProjectMergeRequest,

--- a/gitlab/v4/objects/namespaces.py
+++ b/gitlab/v4/objects/namespaces.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import RetrieveMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/notes.py
+++ b/gitlab/v4/objects/notes.py
@@ -1,7 +1,16 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import (
+    CRUDMixin,
+    CreateMixin,
+    DeleteMixin,
+    GetMixin,
+    ObjectDeleteMixin,
+    RetrieveMixin,
+    SaveMixin,
+    UpdateMixin,
+)
 from .award_emojis import (
     ProjectIssueNoteAwardEmojiManager,
     ProjectMergeRequestNoteAwardEmojiManager,

--- a/gitlab/v4/objects/notification_settings.py
+++ b/gitlab/v4/objects/notification_settings.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import GetWithoutIdMixin, SaveMixin, UpdateMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/packages.py
+++ b/gitlab/v4/objects/packages.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import DeleteMixin, GetMixin, ListMixin, ObjectDeleteMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/pages.py
+++ b/gitlab/v4/objects/pages.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CRUDMixin, ListMixin, ObjectDeleteMixin, SaveMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/personal_access_tokens.py
+++ b/gitlab/v4/objects/personal_access_tokens.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import ListMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -1,7 +1,17 @@
 from gitlab import cli, types
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import (
+    CRUDMixin,
+    CreateMixin,
+    DeleteMixin,
+    ListMixin,
+    ObjectDeleteMixin,
+    RefreshMixin,
+    RetrieveMixin,
+    SaveMixin,
+    UpdateMixin,
+)
 
 
 __all__ = [

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -1,7 +1,15 @@
 from gitlab import cli, types, utils
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import (
+    CRUDMixin,
+    CreateMixin,
+    ListMixin,
+    ObjectDeleteMixin,
+    RefreshMixin,
+    SaveMixin,
+    UpdateMixin,
+)
 
 from .access_requests import ProjectAccessRequestManager
 from .badges import ProjectBadgeManager

--- a/gitlab/v4/objects/push_rules.py
+++ b/gitlab/v4/objects/push_rules.py
@@ -1,5 +1,12 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import (
+    CreateMixin,
+    DeleteMixin,
+    GetWithoutIdMixin,
+    ObjectDeleteMixin,
+    SaveMixin,
+    UpdateMixin,
+)
 
 
 __all__ = [

--- a/gitlab/v4/objects/releases.py
+++ b/gitlab/v4/objects/releases.py
@@ -1,7 +1,7 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CRUDMixin, NoUpdateMixin, ObjectDeleteMixin, SaveMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/runners.py
+++ b/gitlab/v4/objects/runners.py
@@ -1,7 +1,13 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import (
+    CRUDMixin,
+    ListMixin,
+    NoUpdateMixin,
+    ObjectDeleteMixin,
+    SaveMixin,
+)
 
 
 __all__ = [

--- a/gitlab/v4/objects/services.py
+++ b/gitlab/v4/objects/services.py
@@ -1,7 +1,14 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import (
+    DeleteMixin,
+    GetMixin,
+    ListMixin,
+    ObjectDeleteMixin,
+    SaveMixin,
+    UpdateMixin,
+)
 
 
 __all__ = [

--- a/gitlab/v4/objects/settings.py
+++ b/gitlab/v4/objects/settings.py
@@ -1,6 +1,6 @@
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import GetWithoutIdMixin, SaveMixin, UpdateMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/sidekiq.py
+++ b/gitlab/v4/objects/sidekiq.py
@@ -1,7 +1,6 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager
 
 
 __all__ = [

--- a/gitlab/v4/objects/snippets.py
+++ b/gitlab/v4/objects/snippets.py
@@ -1,7 +1,7 @@
 from gitlab import cli, utils
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin, UserAgentDetailMixin
 
 from .award_emojis import ProjectSnippetAwardEmojiManager
 from .discussions import ProjectSnippetDiscussionManager

--- a/gitlab/v4/objects/statistics.py
+++ b/gitlab/v4/objects/statistics.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import GetWithoutIdMixin, RefreshMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/tags.py
+++ b/gitlab/v4/objects/tags.py
@@ -1,7 +1,7 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import NoUpdateMixin, ObjectDeleteMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/templates.py
+++ b/gitlab/v4/objects/templates.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import RetrieveMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/todos.py
+++ b/gitlab/v4/objects/todos.py
@@ -1,7 +1,7 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import DeleteMixin, ListMixin, ObjectDeleteMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/triggers.py
+++ b/gitlab/v4/objects/triggers.py
@@ -1,7 +1,7 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -1,7 +1,18 @@
 from gitlab import cli, types
 from gitlab import exceptions as exc
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import (
+    CRUDMixin,
+    CreateMixin,
+    DeleteMixin,
+    GetWithoutIdMixin,
+    ListMixin,
+    NoUpdateMixin,
+    ObjectDeleteMixin,
+    RetrieveMixin,
+    SaveMixin,
+    UpdateMixin,
+)
 
 from .custom_attributes import UserCustomAttributeManager
 from .events import UserEventManager

--- a/gitlab/v4/objects/variables.py
+++ b/gitlab/v4/objects/variables.py
@@ -4,8 +4,8 @@ https://docs.gitlab.com/ee/api/instance_level_ci_variables.html
 https://docs.gitlab.com/ee/api/project_level_variables.html
 https://docs.gitlab.com/ee/api/group_level_variables.html
 """
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
 
 
 __all__ = [

--- a/gitlab/v4/objects/wikis.py
+++ b/gitlab/v4/objects/wikis.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
 
 
 __all__ = [


### PR DESCRIPTION
In gitlab/v4/objects/*.py remove usage of:
  * from gitlab.base import *
  * from gitlab.mixins import *

    Change them to:
      * from gitlab.base import CLASS_NAME
      * from gitlab.mixins import CLASS_NAME

    Programmatically update code to explicitly import needed classes only.

After the change the output of:
  $ flake8 gitlab/v4/objects/*py | grep 'REST\|Mixin'

Is empty. Before many messages about unable to determine if it was a
valid name.