### PR TITLE
fix: tox pep8 target, so that it can run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,10 @@ commands =
   pytest gitlab/tests {posargs}
 
 [testenv:pep8]
+basepython = python3
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/test-requirements.txt
+       flake8
 commands =
   flake8 {posargs} gitlab/
 
@@ -48,7 +52,7 @@ commands = {posargs}
 [flake8]
 exclude = .git,.venv,.tox,dist,doc,*egg,build,
 max-line-length = 88
-ignore = H501,H803
+ignore = E501,H501,H803,W503
 
 [testenv:docs]
 deps = -r{toxinidir}/rtd-requirements.txt


### PR DESCRIPTION
Previously running the pep8 target would fail as flake8 was not
installed.

Now install flake8 for the pep8 target.

NOTE: Running the pep8 target fails as there are many warnings/errors.
But it does allow us to run it and possibly work on reducing these
warnings/errors in the future.

In addition, add two checks to the ignore list as black takes care of
formatting. The two checks added to the ignore list are:
  * E501: line too long
  * W503: line break before binary operator