### PR TITLE
chore: remove import of gitlab.utils from __init__.py

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -30,7 +30,6 @@ from gitlab.__version__ import (
 from gitlab.client import Gitlab, GitlabList
 from gitlab.const import *  # noqa
 from gitlab.exceptions import *  # noqa
-from gitlab import utils  # noqa
 
 
 warnings.filterwarnings("default", category=DeprecationWarning, module="^gitlab")


### PR DESCRIPTION
Initially when extracting out the gitlab/client.py code we tried to
remove this but functional tests failed.

Later we fixed the functional test that was failing, so now remove the
unneeded import.