### PR TITLE
chore: disallow incomplete type defs

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,2 +1,6 @@
 [mypy]
 files = gitlab/*.py
+
+# disallow_incomplete_defs: This flag reports an error whenever it encounters a
+# partly annotated function definition.
+disallow_incomplete_defs = True

--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -98,7 +98,7 @@ class RESTObject(object):
                 except KeyError:
                     raise AttributeError(name)
 
-    def __setattr__(self, name: str, value) -> None:
+    def __setattr__(self, name: str, value: Any) -> None:
         self.__dict__["_updated_attrs"][name] = value
 
     def __str__(self) -> str:
@@ -116,12 +116,16 @@ class RESTObject(object):
         else:
             return "<%s>" % self.__class__.__name__
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, RESTObject):
+            return NotImplemented
         if self.get_id() and other.get_id():
             return self.get_id() == other.get_id()
         return super(RESTObject, self) == other
 
-    def __ne__(self, other) -> bool:
+    def __ne__(self, other: object) -> bool:
+        if not isinstance(other, RESTObject):
+            return NotImplemented
         if self.get_id() and other.get_id():
             return self.get_id() != other.get_id()
         return super(RESTObject, self) != other
@@ -144,7 +148,7 @@ class RESTObject(object):
             manager = cls(self.manager.gitlab, parent=self)
             self.__dict__[attr] = manager
 
-    def _update_attrs(self, new_attrs) -> None:
+    def _update_attrs(self, new_attrs: Dict[str, Any]) -> None:
         self.__dict__["_updated_attrs"] = {}
         self.__dict__["_attrs"] = new_attrs
 

--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -21,7 +21,7 @@ import argparse
 import functools
 import re
 import sys
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import gitlab.config
 
@@ -32,21 +32,24 @@ camel_re = re.compile("(.)([A-Z])")
 #        action: (mandatory_args, optional_args, in_obj),
 #    },
 # }
-custom_actions: Dict[str, Dict[str, Tuple[Tuple[Any, ...], Tuple[Any, ...], bool]]] = {}
+custom_actions: Dict[str, Dict[str, Tuple[Tuple[str, ...], Tuple[str, ...], bool]]] = {}
 
 
 def register_custom_action(
-    cls_names, mandatory: Tuple[Any, ...] = tuple(), optional: Tuple[Any, ...] = tuple()
+    cls_names: Union[str, Tuple[str, ...]],
+    mandatory: Tuple[str, ...] = tuple(),
+    optional: Tuple[str, ...] = tuple(),
 ) -> Callable:
-    def wrap(f) -> Callable:
+    def wrap(f: Callable) -> Callable:
         @functools.wraps(f)
         def wrapped_f(*args, **kwargs):
             return f(*args, **kwargs)
 
         # in_obj defines whether the method belongs to the obj or the manager
         in_obj = True
-        classes = cls_names
-        if type(cls_names) != tuple:
+        if isinstance(cls_names, tuple):
+            classes = cls_names
+        else:
             classes = (cls_names,)
 
         for cls_name in classes:
@@ -65,7 +68,7 @@ def register_custom_action(
     return wrap
 
 
-def die(msg: str, e=None) -> None:
+def die(msg: str, e: Optional[Exception] = None) -> None:
     if e:
         msg = "%s (%s)" % (msg, e)
     sys.stderr.write(msg + "\n")
@@ -76,7 +79,7 @@ def what_to_cls(what: str) -> str:
     return "".join([s.capitalize() for s in what.split("-")])
 
 
-def cls_to_what(cls) -> str:
+def cls_to_what(cls: Any) -> str:
     return camel_re.sub(r"\1-\2", cls.__name__).lower()
 
 

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -145,7 +145,7 @@ class Gitlab(object):
     def __enter__(self) -> "Gitlab":
         return self
 
-    def __exit__(self, *args) -> None:
+    def __exit__(self, *args: Any) -> None:
         self.session.close()
 
     def __getstate__(self) -> Dict[str, Any]:
@@ -180,7 +180,9 @@ class Gitlab(object):
         return self._api_version
 
     @classmethod
-    def from_config(cls, gitlab_id=None, config_files=None) -> "Gitlab":
+    def from_config(
+        cls, gitlab_id: Optional[str] = None, config_files: Optional[List[str]] = None
+    ) -> "Gitlab":
         """Create a Gitlab connection from configuration files.
 
         Args:
@@ -247,7 +249,7 @@ class Gitlab(object):
         return cast(str, self._server_version), cast(str, self._server_revision)
 
     @gitlab.exceptions.on_http_error(gitlab.exceptions.GitlabVerifyError)
-    def lint(self, content: str, **kwargs) -> Tuple[bool, List[str]]:
+    def lint(self, content: str, **kwargs: Any) -> Tuple[bool, List[str]]:
         """Validate a gitlab CI configuration.
 
         Args:
@@ -269,7 +271,7 @@ class Gitlab(object):
 
     @gitlab.exceptions.on_http_error(gitlab.exceptions.GitlabMarkdownError)
     def markdown(
-        self, text: str, gfm: bool = False, project: Optional[str] = None, **kwargs
+        self, text: str, gfm: bool = False, project: Optional[str] = None, **kwargs: Any
     ) -> str:
         """Render an arbitrary Markdown document.
 
@@ -296,7 +298,7 @@ class Gitlab(object):
         return data["html"]
 
     @gitlab.exceptions.on_http_error(gitlab.exceptions.GitlabLicenseError)
-    def get_license(self, **kwargs) -> Dict[str, Any]:
+    def get_license(self, **kwargs: Any) -> Dict[str, Any]:
         """Retrieve information about the current license.
 
         Args:
@@ -315,7 +317,7 @@ class Gitlab(object):
         return {}
 
     @gitlab.exceptions.on_http_error(gitlab.exceptions.GitlabLicenseError)
-    def set_license(self, license: str, **kwargs) -> Dict[str, Any]:
+    def set_license(self, license: str, **kwargs: Any) -> Dict[str, Any]:
         """Add a new license.
 
         Args:
@@ -446,7 +448,7 @@ class Gitlab(object):
         post_data: Optional[Dict[str, Any]] = None,
         streamed: bool = False,
         files: Optional[Dict[str, Any]] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> requests.Response:
         """Make an HTTP request to the Gitlab server.
 
@@ -577,7 +579,7 @@ class Gitlab(object):
         query_data: Optional[Dict[str, Any]] = None,
         streamed: bool = False,
         raw: bool = False,
-        **kwargs,
+        **kwargs: Any,
     ) -> Union[Dict[str, Any], requests.Response]:
         """Make a GET request to the Gitlab server.
 
@@ -621,8 +623,8 @@ class Gitlab(object):
         self,
         path: str,
         query_data: Optional[Dict[str, Any]] = None,
-        as_list=None,
-        **kwargs,
+        as_list: Optional[bool] = None,
+        **kwargs: Any,
     ) -> Union["GitlabList", List[Dict[str, Any]]]:
         """Make a GET request to the Gitlab server for list-oriented queries.
 
@@ -670,7 +672,7 @@ class Gitlab(object):
         query_data: Optional[Dict[str, Any]] = None,
         post_data: Optional[Dict[str, Any]] = None,
         files: Optional[Dict[str, Any]] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> Union[Dict[str, Any], requests.Response]:
         """Make a POST request to the Gitlab server.
 
@@ -717,7 +719,7 @@ class Gitlab(object):
         query_data: Optional[Dict[str, Any]] = None,
         post_data: Optional[Dict[str, Any]] = None,
         files: Optional[Dict[str, Any]] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> Union[Dict[str, Any], requests.Response]:
         """Make a PUT request to the Gitlab server.
 
@@ -755,7 +757,7 @@ class Gitlab(object):
                 error_message="Failed to parse the server message"
             ) from e
 
-    def http_delete(self, path: str, **kwargs) -> requests.Response:
+    def http_delete(self, path: str, **kwargs: Any) -> requests.Response:
         """Make a PUT request to the Gitlab server.
 
         Args:
@@ -773,7 +775,7 @@ class Gitlab(object):
 
     @gitlab.exceptions.on_http_error(gitlab.exceptions.GitlabSearchError)
     def search(
-        self, scope: str, search: str, **kwargs
+        self, scope: str, search: str, **kwargs: Any
     ) -> Union["GitlabList", List[Dict[str, Any]]]:
         """Search GitLab resources matching the provided string.'
 
@@ -806,7 +808,7 @@ class GitlabList(object):
         url: str,
         query_data: Dict[str, Any],
         get_next: bool = True,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         self._gl = gl
 
@@ -817,7 +819,7 @@ class GitlabList(object):
         self._get_next = get_next
 
     def _query(
-        self, url: str, query_data: Optional[Dict[str, Any]] = None, **kwargs
+        self, url: str, query_data: Optional[Dict[str, Any]] = None, **kwargs: Any
     ) -> None:
         query_data = query_data or {}
         result = self._gl.http_request("get", url, query_data=query_data, **kwargs)
@@ -842,7 +844,7 @@ class GitlabList(object):
         self._total: Optional[Union[str, int]] = result.headers.get("X-Total")
 
         try:
-            self._data = result.json()
+            self._data: List[Dict[str, Any]] = result.json()
         except Exception as e:
             raise gitlab.exceptions.GitlabParsingError(
                 error_message="Failed to parse the server message"

--- a/gitlab/utils.py
+++ b/gitlab/utils.py
@@ -22,7 +22,7 @@ import requests
 
 
 class _StdoutStream(object):
-    def __call__(self, chunk) -> None:
+    def __call__(self, chunk: Any) -> None:
         print(chunk)
 
 
@@ -31,7 +31,7 @@ def response_content(
     streamed: bool,
     action: Optional[Callable],
     chunk_size: int,
-):
+) -> Optional[bytes]:
     if streamed is False:
         return response.content
 
@@ -41,6 +41,7 @@ def response_content(
     for chunk in response.iter_content(chunk_size=chunk_size):
         if chunk:
             action(chunk)
+    return None
 
 
 def copy_dict(dest: Dict[str, Any], src: Dict[str, Any]) -> None:


### PR DESCRIPTION
Don't allow a partially annotated function definition. Either none of
the function is annotated or all of it must be.

Update code to ensure no-more partially annotated functions.

Update gitlab/cli.py with better type-hints. Changed Tuple[Any, ...]
to Tuple[str, ...]