### PR TITLE
chore: add type-hints for gitlab/mixins.py

### DIFF
--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -327,6 +327,8 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         path = "/projects/%s/trigger/pipeline" % self.get_id()
         post_data = {"ref": ref, "token": token, "variables": variables}
         attrs = self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
+        assert isinstance(attrs, dict)
+        reveal_type(ProjectPipeline)
         return ProjectPipeline(self.pipelines, attrs)
 
     @cli.register_custom_action("Project")


### PR DESCRIPTION
 * Use the Protocol type to make gitlab/base:RESTObject and
   gitlab/base:RESTManager into Protocol classes.
 * Add type-hints to gitlab/mixins.py

Reference on Protocol and mixins:
https://mypy.readthedocs.io/en/latest/more_types.html#mixin-classes