### PR TITLE
WIP: Testing refactoring base classes of Mixins

### DIFF
--- a/gitlab/tests/mixins/test_meta_mixins.py
+++ b/gitlab/tests/mixins/test_meta_mixins.py
@@ -12,7 +12,8 @@ from gitlab.mixins import (
 
 def test_retrieve_mixin():
     class M(RetrieveMixin):
-        pass
+        def __init__(self):
+            ...
 
     obj = M()
     assert hasattr(obj, "list")
@@ -26,6 +27,9 @@ def test_retrieve_mixin():
 
 def test_crud_mixin():
     class M(CRUDMixin):
+        def __init__(self):
+            ...
+
         pass
 
     obj = M()
@@ -43,7 +47,8 @@ def test_crud_mixin():
 
 def test_no_update_mixin():
     class M(NoUpdateMixin):
-        pass
+        def __init__(self):
+            ...
 
     obj = M()
     assert hasattr(obj, "get")

--- a/gitlab/tests/mixins/test_object_mixins_attributes.py
+++ b/gitlab/tests/mixins/test_object_mixins_attributes.py
@@ -28,7 +28,8 @@ from gitlab.mixins import (
 
 def test_access_request_mixin():
     class O(AccessRequestMixin):
-        pass
+        def __init__(self):
+            ...
 
     obj = O()
     assert hasattr(obj, "approve")
@@ -36,7 +37,8 @@ def test_access_request_mixin():
 
 def test_subscribable_mixin():
     class O(SubscribableMixin):
-        pass
+        def __init__(self):
+            ...
 
     obj = O()
     assert hasattr(obj, "subscribe")
@@ -45,7 +47,8 @@ def test_subscribable_mixin():
 
 def test_todo_mixin():
     class O(TodoMixin):
-        pass
+        def __init__(self):
+            ...
 
     obj = O()
     assert hasattr(obj, "todo")
@@ -53,7 +56,8 @@ def test_todo_mixin():
 
 def test_time_tracking_mixin():
     class O(TimeTrackingMixin):
-        pass
+        def __init__(self):
+            ...
 
     obj = O()
     assert hasattr(obj, "time_stats")
@@ -65,7 +69,8 @@ def test_time_tracking_mixin():
 
 def test_set_mixin():
     class O(SetMixin):
-        pass
+        def __init__(self):
+            ...
 
     obj = O()
     assert hasattr(obj, "set")
@@ -73,7 +78,8 @@ def test_set_mixin():
 
 def test_user_agent_detail_mixin():
     class O(UserAgentDetailMixin):
-        pass
+        def __init__(self):
+            ...
 
     obj = O()
     assert hasattr(obj, "user_agent_detail")

--- a/gitlab/v4/objects/access_requests.py
+++ b/gitlab/v4/objects/access_requests.py
@@ -1,4 +1,3 @@
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     AccessRequestMixin,
     CreateMixin,
@@ -16,21 +15,21 @@ __all__ = [
 ]
 
 
-class GroupAccessRequest(AccessRequestMixin, ObjectDeleteMixin, RESTObject):
+class GroupAccessRequest(AccessRequestMixin, ObjectDeleteMixin):
     pass
 
 
-class GroupAccessRequestManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
+class GroupAccessRequestManager(ListMixin, CreateMixin, DeleteMixin):
     _path = "/groups/%(group_id)s/access_requests"
     _obj_cls = GroupAccessRequest
     _from_parent_attrs = {"group_id": "id"}
 
 
-class ProjectAccessRequest(AccessRequestMixin, ObjectDeleteMixin, RESTObject):
+class ProjectAccessRequest(AccessRequestMixin, ObjectDeleteMixin):
     pass
 
 
-class ProjectAccessRequestManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
+class ProjectAccessRequestManager(ListMixin, CreateMixin, DeleteMixin):
     _path = "/projects/%(project_id)s/access_requests"
     _obj_cls = ProjectAccessRequest
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/appearance.py
+++ b/gitlab/v4/objects/appearance.py
@@ -1,5 +1,4 @@
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import GetWithoutIdMixin, SaveMixin, UpdateMixin
 
 
@@ -9,11 +8,11 @@ __all__ = [
 ]
 
 
-class ApplicationAppearance(SaveMixin, RESTObject):
+class ApplicationAppearance(SaveMixin):
     _id_attr = None
 
 
-class ApplicationAppearanceManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
+class ApplicationAppearanceManager(GetWithoutIdMixin, UpdateMixin):
     _path = "/application/appearance"
     _obj_cls = ApplicationAppearance
     _update_attrs = (

--- a/gitlab/v4/objects/applications.py
+++ b/gitlab/v4/objects/applications.py
@@ -1,4 +1,3 @@
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CreateMixin, DeleteMixin, ListMixin, ObjectDeleteMixin
 
 __all__ = [
@@ -7,12 +6,12 @@ __all__ = [
 ]
 
 
-class Application(ObjectDeleteMixin, RESTObject):
+class Application(ObjectDeleteMixin):
     _url = "/applications"
     _short_print_attr = "name"
 
 
-class ApplicationManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
+class ApplicationManager(ListMixin, CreateMixin, DeleteMixin):
     _path = "/applications"
     _obj_cls = Application
     _create_attrs = (("name", "redirect_uri", "scopes"), ("confidential",))

--- a/gitlab/v4/objects/audit_events.py
+++ b/gitlab/v4/objects/audit_events.py
@@ -3,7 +3,7 @@ GitLab API:
 https://docs.gitlab.com/ee/api/audit_events.html#project-audit-events
 """
 
-from gitlab.base import RESTManager, RESTObject
+from gitlab.base import RESTObject
 from gitlab.mixins import RetrieveMixin
 
 __all__ = [
@@ -16,7 +16,7 @@ class ProjectAudit(RESTObject):
     _id_attr = "id"
 
 
-class ProjectAuditManager(RetrieveMixin, RESTManager):
+class ProjectAuditManager(RetrieveMixin):
     _path = "/projects/%(project_id)s/audit_events"
     _obj_cls = ProjectAudit
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/award_emojis.py
+++ b/gitlab/v4/objects/award_emojis.py
@@ -1,4 +1,3 @@
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import NoUpdateMixin, ObjectDeleteMixin
 
 
@@ -18,22 +17,22 @@ __all__ = [
 ]
 
 
-class ProjectIssueAwardEmoji(ObjectDeleteMixin, RESTObject):
+class ProjectIssueAwardEmoji(ObjectDeleteMixin):
     pass
 
 
-class ProjectIssueAwardEmojiManager(NoUpdateMixin, RESTManager):
+class ProjectIssueAwardEmojiManager(NoUpdateMixin):
     _path = "/projects/%(project_id)s/issues/%(issue_iid)s/award_emoji"
     _obj_cls = ProjectIssueAwardEmoji
     _from_parent_attrs = {"project_id": "project_id", "issue_iid": "iid"}
     _create_attrs = (("name",), tuple())
 
 
-class ProjectIssueNoteAwardEmoji(ObjectDeleteMixin, RESTObject):
+class ProjectIssueNoteAwardEmoji(ObjectDeleteMixin):
     pass
 
 
-class ProjectIssueNoteAwardEmojiManager(NoUpdateMixin, RESTManager):
+class ProjectIssueNoteAwardEmojiManager(NoUpdateMixin):
     _path = (
         "/projects/%(project_id)s/issues/%(issue_iid)s" "/notes/%(note_id)s/award_emoji"
     )
@@ -46,22 +45,22 @@ class ProjectIssueNoteAwardEmojiManager(NoUpdateMixin, RESTManager):
     _create_attrs = (("name",), tuple())
 
 
-class ProjectMergeRequestAwardEmoji(ObjectDeleteMixin, RESTObject):
+class ProjectMergeRequestAwardEmoji(ObjectDeleteMixin):
     pass
 
 
-class ProjectMergeRequestAwardEmojiManager(NoUpdateMixin, RESTManager):
+class ProjectMergeRequestAwardEmojiManager(NoUpdateMixin):
     _path = "/projects/%(project_id)s/merge_requests/%(mr_iid)s/award_emoji"
     _obj_cls = ProjectMergeRequestAwardEmoji
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}
     _create_attrs = (("name",), tuple())
 
 
-class ProjectMergeRequestNoteAwardEmoji(ObjectDeleteMixin, RESTObject):
+class ProjectMergeRequestNoteAwardEmoji(ObjectDeleteMixin):
     pass
 
 
-class ProjectMergeRequestNoteAwardEmojiManager(NoUpdateMixin, RESTManager):
+class ProjectMergeRequestNoteAwardEmojiManager(NoUpdateMixin):
     _path = (
         "/projects/%(project_id)s/merge_requests/%(mr_iid)s"
         "/notes/%(note_id)s/award_emoji"
@@ -75,22 +74,22 @@ class ProjectMergeRequestNoteAwardEmojiManager(NoUpdateMixin, RESTManager):
     _create_attrs = (("name",), tuple())
 
 
-class ProjectSnippetAwardEmoji(ObjectDeleteMixin, RESTObject):
+class ProjectSnippetAwardEmoji(ObjectDeleteMixin):
     pass
 
 
-class ProjectSnippetAwardEmojiManager(NoUpdateMixin, RESTManager):
+class ProjectSnippetAwardEmojiManager(NoUpdateMixin):
     _path = "/projects/%(project_id)s/snippets/%(snippet_id)s/award_emoji"
     _obj_cls = ProjectSnippetAwardEmoji
     _from_parent_attrs = {"project_id": "project_id", "snippet_id": "id"}
     _create_attrs = (("name",), tuple())
 
 
-class ProjectSnippetNoteAwardEmoji(ObjectDeleteMixin, RESTObject):
+class ProjectSnippetNoteAwardEmoji(ObjectDeleteMixin):
     pass
 
 
-class ProjectSnippetNoteAwardEmojiManager(NoUpdateMixin, RESTManager):
+class ProjectSnippetNoteAwardEmojiManager(NoUpdateMixin):
     _path = (
         "/projects/%(project_id)s/snippets/%(snippet_id)s"
         "/notes/%(note_id)s/award_emoji"

--- a/gitlab/v4/objects/badges.py
+++ b/gitlab/v4/objects/badges.py
@@ -1,4 +1,3 @@
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import BadgeRenderMixin, CRUDMixin, ObjectDeleteMixin, SaveMixin
 
 
@@ -10,11 +9,11 @@ __all__ = [
 ]
 
 
-class GroupBadge(SaveMixin, ObjectDeleteMixin, RESTObject):
+class GroupBadge(SaveMixin, ObjectDeleteMixin):
     pass
 
 
-class GroupBadgeManager(BadgeRenderMixin, CRUDMixin, RESTManager):
+class GroupBadgeManager(BadgeRenderMixin, CRUDMixin):
     _path = "/groups/%(group_id)s/badges"
     _obj_cls = GroupBadge
     _from_parent_attrs = {"group_id": "id"}
@@ -22,11 +21,11 @@ class GroupBadgeManager(BadgeRenderMixin, CRUDMixin, RESTManager):
     _update_attrs = (tuple(), ("link_url", "image_url"))
 
 
-class ProjectBadge(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectBadge(SaveMixin, ObjectDeleteMixin):
     pass
 
 
-class ProjectBadgeManager(BadgeRenderMixin, CRUDMixin, RESTManager):
+class ProjectBadgeManager(BadgeRenderMixin, CRUDMixin):
     _path = "/projects/%(project_id)s/badges"
     _obj_cls = ProjectBadge
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/boards.py
+++ b/gitlab/v4/objects/boards.py
@@ -1,4 +1,3 @@
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
 
 
@@ -14,11 +13,11 @@ __all__ = [
 ]
 
 
-class GroupBoardList(SaveMixin, ObjectDeleteMixin, RESTObject):
+class GroupBoardList(SaveMixin, ObjectDeleteMixin):
     pass
 
 
-class GroupBoardListManager(CRUDMixin, RESTManager):
+class GroupBoardListManager(CRUDMixin):
     _path = "/groups/%(group_id)s/boards/%(board_id)s/lists"
     _obj_cls = GroupBoardList
     _from_parent_attrs = {"group_id": "group_id", "board_id": "id"}
@@ -26,22 +25,22 @@ class GroupBoardListManager(CRUDMixin, RESTManager):
     _update_attrs = (("position",), tuple())
 
 
-class GroupBoard(SaveMixin, ObjectDeleteMixin, RESTObject):
+class GroupBoard(SaveMixin, ObjectDeleteMixin):
     _managers = (("lists", "GroupBoardListManager"),)
 
 
-class GroupBoardManager(CRUDMixin, RESTManager):
+class GroupBoardManager(CRUDMixin):
     _path = "/groups/%(group_id)s/boards"
     _obj_cls = GroupBoard
     _from_parent_attrs = {"group_id": "id"}
     _create_attrs = (("name",), tuple())
 
 
-class ProjectBoardList(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectBoardList(SaveMixin, ObjectDeleteMixin):
     pass
 
 
-class ProjectBoardListManager(CRUDMixin, RESTManager):
+class ProjectBoardListManager(CRUDMixin):
     _path = "/projects/%(project_id)s/boards/%(board_id)s/lists"
     _obj_cls = ProjectBoardList
     _from_parent_attrs = {"project_id": "project_id", "board_id": "id"}
@@ -49,11 +48,11 @@ class ProjectBoardListManager(CRUDMixin, RESTManager):
     _update_attrs = (("position",), tuple())
 
 
-class ProjectBoard(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectBoard(SaveMixin, ObjectDeleteMixin):
     _managers = (("lists", "ProjectBoardListManager"),)
 
 
-class ProjectBoardManager(CRUDMixin, RESTManager):
+class ProjectBoardManager(CRUDMixin):
     _path = "/projects/%(project_id)s/boards"
     _obj_cls = ProjectBoard
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/branches.py
+++ b/gitlab/v4/objects/branches.py
@@ -1,6 +1,5 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import NoUpdateMixin, ObjectDeleteMixin
 
 
@@ -12,7 +11,7 @@ __all__ = [
 ]
 
 
-class ProjectBranch(ObjectDeleteMixin, RESTObject):
+class ProjectBranch(ObjectDeleteMixin):
     _id_attr = "name"
 
     @cli.register_custom_action(
@@ -60,18 +59,18 @@ class ProjectBranch(ObjectDeleteMixin, RESTObject):
         self._attrs["protected"] = False
 
 
-class ProjectBranchManager(NoUpdateMixin, RESTManager):
+class ProjectBranchManager(NoUpdateMixin):
     _path = "/projects/%(project_id)s/repository/branches"
     _obj_cls = ProjectBranch
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = (("branch", "ref"), tuple())
 
 
-class ProjectProtectedBranch(ObjectDeleteMixin, RESTObject):
+class ProjectProtectedBranch(ObjectDeleteMixin):
     _id_attr = "name"
 
 
-class ProjectProtectedBranchManager(NoUpdateMixin, RESTManager):
+class ProjectProtectedBranchManager(NoUpdateMixin):
     _path = "/projects/%(project_id)s/protected_branches"
     _obj_cls = ProjectProtectedBranch
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/broadcast_messages.py
+++ b/gitlab/v4/objects/broadcast_messages.py
@@ -1,4 +1,3 @@
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
 
 
@@ -8,11 +7,11 @@ __all__ = [
 ]
 
 
-class BroadcastMessage(SaveMixin, ObjectDeleteMixin, RESTObject):
+class BroadcastMessage(SaveMixin, ObjectDeleteMixin):
     pass
 
 
-class BroadcastMessageManager(CRUDMixin, RESTManager):
+class BroadcastMessageManager(CRUDMixin):
     _path = "/broadcast_messages"
     _obj_cls = BroadcastMessage
 

--- a/gitlab/v4/objects/clusters.py
+++ b/gitlab/v4/objects/clusters.py
@@ -1,5 +1,4 @@
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, CreateMixin, ObjectDeleteMixin, SaveMixin
 
 
@@ -11,11 +10,11 @@ __all__ = [
 ]
 
 
-class GroupCluster(SaveMixin, ObjectDeleteMixin, RESTObject):
+class GroupCluster(SaveMixin, ObjectDeleteMixin):
     pass
 
 
-class GroupClusterManager(CRUDMixin, RESTManager):
+class GroupClusterManager(CRUDMixin):
     _path = "/groups/%(group_id)s/clusters"
     _obj_cls = GroupCluster
     _from_parent_attrs = {"group_id": "id"}
@@ -56,11 +55,11 @@ class GroupClusterManager(CRUDMixin, RESTManager):
         return CreateMixin.create(self, data, path=path, **kwargs)
 
 
-class ProjectCluster(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectCluster(SaveMixin, ObjectDeleteMixin):
     pass
 
 
-class ProjectClusterManager(CRUDMixin, RESTManager):
+class ProjectClusterManager(CRUDMixin):
     _path = "/projects/%(project_id)s/clusters"
     _obj_cls = ProjectCluster
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/commits.py
+++ b/gitlab/v4/objects/commits.py
@@ -1,6 +1,6 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
+from gitlab.base import RESTObject
 from gitlab.mixins import CreateMixin, ListMixin, RefreshMixin, RetrieveMixin
 from .discussions import ProjectCommitDiscussionManager
 
@@ -135,7 +135,7 @@ class ProjectCommit(RESTObject):
         return self.manager.gitlab.http_get(path, **kwargs)
 
 
-class ProjectCommitManager(RetrieveMixin, CreateMixin, RESTManager):
+class ProjectCommitManager(RetrieveMixin, CreateMixin):
     _path = "/projects/%(project_id)s/repository/commits"
     _obj_cls = ProjectCommit
     _from_parent_attrs = {"project_id": "id"}
@@ -150,18 +150,18 @@ class ProjectCommitComment(RESTObject):
     _short_print_attr = "note"
 
 
-class ProjectCommitCommentManager(ListMixin, CreateMixin, RESTManager):
+class ProjectCommitCommentManager(ListMixin, CreateMixin):
     _path = "/projects/%(project_id)s/repository/commits/%(commit_id)s" "/comments"
     _obj_cls = ProjectCommitComment
     _from_parent_attrs = {"project_id": "project_id", "commit_id": "id"}
     _create_attrs = (("note",), ("path", "line", "line_type"))
 
 
-class ProjectCommitStatus(RESTObject, RefreshMixin):
+class ProjectCommitStatus(RefreshMixin):
     pass
 
 
-class ProjectCommitStatusManager(ListMixin, CreateMixin, RESTManager):
+class ProjectCommitStatusManager(ListMixin, CreateMixin):
     _path = "/projects/%(project_id)s/repository/commits/%(commit_id)s" "/statuses"
     _obj_cls = ProjectCommitStatus
     _from_parent_attrs = {"project_id": "project_id", "commit_id": "id"}

--- a/gitlab/v4/objects/container_registry.py
+++ b/gitlab/v4/objects/container_registry.py
@@ -1,6 +1,5 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import DeleteMixin, ListMixin, ObjectDeleteMixin, RetrieveMixin
 
 
@@ -12,21 +11,21 @@ __all__ = [
 ]
 
 
-class ProjectRegistryRepository(ObjectDeleteMixin, RESTObject):
+class ProjectRegistryRepository(ObjectDeleteMixin):
     _managers = (("tags", "ProjectRegistryTagManager"),)
 
 
-class ProjectRegistryRepositoryManager(DeleteMixin, ListMixin, RESTManager):
+class ProjectRegistryRepositoryManager(DeleteMixin, ListMixin):
     _path = "/projects/%(project_id)s/registry/repositories"
     _obj_cls = ProjectRegistryRepository
     _from_parent_attrs = {"project_id": "id"}
 
 
-class ProjectRegistryTag(ObjectDeleteMixin, RESTObject):
+class ProjectRegistryTag(ObjectDeleteMixin):
     _id_attr = "name"
 
 
-class ProjectRegistryTagManager(DeleteMixin, RetrieveMixin, RESTManager):
+class ProjectRegistryTagManager(DeleteMixin, RetrieveMixin):
     _obj_cls = ProjectRegistryTag
     _from_parent_attrs = {"project_id": "project_id", "repository_id": "id"}
     _path = "/projects/%(project_id)s/registry/repositories/%(repository_id)s/tags"

--- a/gitlab/v4/objects/custom_attributes.py
+++ b/gitlab/v4/objects/custom_attributes.py
@@ -1,4 +1,3 @@
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import DeleteMixin, ObjectDeleteMixin, RetrieveMixin, SetMixin
 
 
@@ -12,31 +11,31 @@ __all__ = [
 ]
 
 
-class GroupCustomAttribute(ObjectDeleteMixin, RESTObject):
+class GroupCustomAttribute(ObjectDeleteMixin):
     _id_attr = "key"
 
 
-class GroupCustomAttributeManager(RetrieveMixin, SetMixin, DeleteMixin, RESTManager):
+class GroupCustomAttributeManager(RetrieveMixin, SetMixin, DeleteMixin):
     _path = "/groups/%(group_id)s/custom_attributes"
     _obj_cls = GroupCustomAttribute
     _from_parent_attrs = {"group_id": "id"}
 
 
-class ProjectCustomAttribute(ObjectDeleteMixin, RESTObject):
+class ProjectCustomAttribute(ObjectDeleteMixin):
     _id_attr = "key"
 
 
-class ProjectCustomAttributeManager(RetrieveMixin, SetMixin, DeleteMixin, RESTManager):
+class ProjectCustomAttributeManager(RetrieveMixin, SetMixin, DeleteMixin):
     _path = "/projects/%(project_id)s/custom_attributes"
     _obj_cls = ProjectCustomAttribute
     _from_parent_attrs = {"project_id": "id"}
 
 
-class UserCustomAttribute(ObjectDeleteMixin, RESTObject):
+class UserCustomAttribute(ObjectDeleteMixin):
     _id_attr = "key"
 
 
-class UserCustomAttributeManager(RetrieveMixin, SetMixin, DeleteMixin, RESTManager):
+class UserCustomAttributeManager(RetrieveMixin, SetMixin, DeleteMixin):
     _path = "/users/%(user_id)s/custom_attributes"
     _obj_cls = UserCustomAttribute
     _from_parent_attrs = {"user_id": "id"}

--- a/gitlab/v4/objects/deploy_keys.py
+++ b/gitlab/v4/objects/deploy_keys.py
@@ -1,6 +1,6 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
+from gitlab.base import RESTObject
 from gitlab.mixins import CRUDMixin, ListMixin, ObjectDeleteMixin, SaveMixin
 
 
@@ -16,16 +16,16 @@ class DeployKey(RESTObject):
     pass
 
 
-class DeployKeyManager(ListMixin, RESTManager):
+class DeployKeyManager(ListMixin):
     _path = "/deploy_keys"
     _obj_cls = DeployKey
 
 
-class ProjectKey(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectKey(SaveMixin, ObjectDeleteMixin):
     pass
 
 
-class ProjectKeyManager(CRUDMixin, RESTManager):
+class ProjectKeyManager(CRUDMixin):
     _path = "/projects/%(project_id)s/deploy_keys"
     _obj_cls = ProjectKey
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/deploy_tokens.py
+++ b/gitlab/v4/objects/deploy_tokens.py
@@ -1,4 +1,3 @@
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CreateMixin, DeleteMixin, ListMixin, ObjectDeleteMixin
 
 
@@ -12,20 +11,20 @@ __all__ = [
 ]
 
 
-class DeployToken(ObjectDeleteMixin, RESTObject):
+class DeployToken(ObjectDeleteMixin):
     pass
 
 
-class DeployTokenManager(ListMixin, RESTManager):
+class DeployTokenManager(ListMixin):
     _path = "/deploy_tokens"
     _obj_cls = DeployToken
 
 
-class GroupDeployToken(ObjectDeleteMixin, RESTObject):
+class GroupDeployToken(ObjectDeleteMixin):
     pass
 
 
-class GroupDeployTokenManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
+class GroupDeployTokenManager(ListMixin, CreateMixin, DeleteMixin):
     _path = "/groups/%(group_id)s/deploy_tokens"
     _from_parent_attrs = {"group_id": "id"}
     _obj_cls = GroupDeployToken
@@ -41,11 +40,11 @@ class GroupDeployTokenManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
     )
 
 
-class ProjectDeployToken(ObjectDeleteMixin, RESTObject):
+class ProjectDeployToken(ObjectDeleteMixin):
     pass
 
 
-class ProjectDeployTokenManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
+class ProjectDeployTokenManager(ListMixin, CreateMixin, DeleteMixin):
     _path = "/projects/%(project_id)s/deploy_tokens"
     _from_parent_attrs = {"project_id": "id"}
     _obj_cls = ProjectDeployToken

--- a/gitlab/v4/objects/deployments.py
+++ b/gitlab/v4/objects/deployments.py
@@ -1,4 +1,3 @@
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CreateMixin, RetrieveMixin, SaveMixin, UpdateMixin
 
 
@@ -8,11 +7,11 @@ __all__ = [
 ]
 
 
-class ProjectDeployment(RESTObject, SaveMixin):
+class ProjectDeployment(SaveMixin):
     pass
 
 
-class ProjectDeploymentManager(RetrieveMixin, CreateMixin, UpdateMixin, RESTManager):
+class ProjectDeploymentManager(RetrieveMixin, CreateMixin, UpdateMixin):
     _path = "/projects/%(project_id)s/deployments"
     _obj_cls = ProjectDeployment
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/discussions.py
+++ b/gitlab/v4/objects/discussions.py
@@ -1,4 +1,4 @@
-from gitlab.base import RESTManager, RESTObject
+from gitlab.base import RESTObject
 from gitlab.mixins import CreateMixin, RetrieveMixin, SaveMixin, UpdateMixin
 from .notes import (
     ProjectCommitDiscussionNoteManager,
@@ -24,7 +24,7 @@ class ProjectCommitDiscussion(RESTObject):
     _managers = (("notes", "ProjectCommitDiscussionNoteManager"),)
 
 
-class ProjectCommitDiscussionManager(RetrieveMixin, CreateMixin, RESTManager):
+class ProjectCommitDiscussionManager(RetrieveMixin, CreateMixin):
     _path = "/projects/%(project_id)s/repository/commits/%(commit_id)s/" "discussions"
     _obj_cls = ProjectCommitDiscussion
     _from_parent_attrs = {"project_id": "project_id", "commit_id": "id"}
@@ -35,20 +35,18 @@ class ProjectIssueDiscussion(RESTObject):
     _managers = (("notes", "ProjectIssueDiscussionNoteManager"),)
 
 
-class ProjectIssueDiscussionManager(RetrieveMixin, CreateMixin, RESTManager):
+class ProjectIssueDiscussionManager(RetrieveMixin, CreateMixin):
     _path = "/projects/%(project_id)s/issues/%(issue_iid)s/discussions"
     _obj_cls = ProjectIssueDiscussion
     _from_parent_attrs = {"project_id": "project_id", "issue_iid": "iid"}
     _create_attrs = (("body",), ("created_at",))
 
 
-class ProjectMergeRequestDiscussion(SaveMixin, RESTObject):
+class ProjectMergeRequestDiscussion(SaveMixin):
     _managers = (("notes", "ProjectMergeRequestDiscussionNoteManager"),)
 
 
-class ProjectMergeRequestDiscussionManager(
-    RetrieveMixin, CreateMixin, UpdateMixin, RESTManager
-):
+class ProjectMergeRequestDiscussionManager(RetrieveMixin, CreateMixin, UpdateMixin):
     _path = "/projects/%(project_id)s/merge_requests/%(mr_iid)s/discussions"
     _obj_cls = ProjectMergeRequestDiscussion
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}
@@ -60,7 +58,7 @@ class ProjectSnippetDiscussion(RESTObject):
     _managers = (("notes", "ProjectSnippetDiscussionNoteManager"),)
 
 
-class ProjectSnippetDiscussionManager(RetrieveMixin, CreateMixin, RESTManager):
+class ProjectSnippetDiscussionManager(RetrieveMixin, CreateMixin):
     _path = "/projects/%(project_id)s/snippets/%(snippet_id)s/discussions"
     _obj_cls = ProjectSnippetDiscussion
     _from_parent_attrs = {"project_id": "project_id", "snippet_id": "id"}

--- a/gitlab/v4/objects/environments.py
+++ b/gitlab/v4/objects/environments.py
@@ -1,6 +1,5 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,
     DeleteMixin,
@@ -17,7 +16,7 @@ __all__ = [
 ]
 
 
-class ProjectEnvironment(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectEnvironment(SaveMixin, ObjectDeleteMixin):
     @cli.register_custom_action("ProjectEnvironment")
     @exc.on_http_error(exc.GitlabStopError)
     def stop(self, **kwargs):
@@ -34,9 +33,7 @@ class ProjectEnvironment(SaveMixin, ObjectDeleteMixin, RESTObject):
         self.manager.gitlab.http_post(path, **kwargs)
 
 
-class ProjectEnvironmentManager(
-    RetrieveMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
-):
+class ProjectEnvironmentManager(RetrieveMixin, CreateMixin, UpdateMixin, DeleteMixin):
     _path = "/projects/%(project_id)s/environments"
     _obj_cls = ProjectEnvironment
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/epics.py
+++ b/gitlab/v4/objects/epics.py
@@ -1,6 +1,5 @@
 from gitlab import types
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CRUDMixin,
     CreateMixin,
@@ -21,7 +20,7 @@ __all__ = [
 ]
 
 
-class GroupEpic(ObjectDeleteMixin, SaveMixin, RESTObject):
+class GroupEpic(ObjectDeleteMixin, SaveMixin):
     _id_attr = "iid"
     _managers = (
         ("issues", "GroupEpicIssueManager"),
@@ -29,7 +28,7 @@ class GroupEpic(ObjectDeleteMixin, SaveMixin, RESTObject):
     )
 
 
-class GroupEpicManager(CRUDMixin, RESTManager):
+class GroupEpicManager(CRUDMixin):
     _path = "/groups/%(group_id)s/epics"
     _obj_cls = GroupEpic
     _from_parent_attrs = {"group_id": "id"}
@@ -42,7 +41,7 @@ class GroupEpicManager(CRUDMixin, RESTManager):
     _types = {"labels": types.ListAttribute}
 
 
-class GroupEpicIssue(ObjectDeleteMixin, SaveMixin, RESTObject):
+class GroupEpicIssue(ObjectDeleteMixin, SaveMixin):
     _id_attr = "epic_issue_id"
 
     def save(self, **kwargs):
@@ -67,9 +66,7 @@ class GroupEpicIssue(ObjectDeleteMixin, SaveMixin, RESTObject):
         self.manager.update(obj_id, updated_data, **kwargs)
 
 
-class GroupEpicIssueManager(
-    ListMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
-):
+class GroupEpicIssueManager(ListMixin, CreateMixin, UpdateMixin, DeleteMixin):
     _path = "/groups/%(group_id)s/epics/%(epic_iid)s/issues"
     _obj_cls = GroupEpicIssue
     _from_parent_attrs = {"group_id": "group_id", "epic_iid": "iid"}

--- a/gitlab/v4/objects/events.py
+++ b/gitlab/v4/objects/events.py
@@ -1,5 +1,5 @@
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
+from gitlab.base import RESTObject
 from gitlab.mixins import ListMixin, RetrieveMixin
 
 
@@ -30,7 +30,7 @@ class Event(RESTObject):
     _short_print_attr = "target_title"
 
 
-class EventManager(ListMixin, RESTManager):
+class EventManager(ListMixin):
     _path = "/events"
     _obj_cls = Event
     _list_filters = ("action", "target_type", "before", "after", "sort")
@@ -40,7 +40,7 @@ class AuditEvent(RESTObject):
     _id_attr = "id"
 
 
-class AuditEventManager(ListMixin, RESTManager):
+class AuditEventManager(ListMixin):
     _path = "/audit_events"
     _obj_cls = AuditEvent
     _list_filters = ("created_after", "created_before", "entity_type", "entity_id")
@@ -50,7 +50,7 @@ class GroupEpicResourceLabelEvent(RESTObject):
     pass
 
 
-class GroupEpicResourceLabelEventManager(RetrieveMixin, RESTManager):
+class GroupEpicResourceLabelEventManager(RetrieveMixin):
     _path = "/groups/%(group_id)s/epics/%(epic_id)s/resource_label_events"
     _obj_cls = GroupEpicResourceLabelEvent
     _from_parent_attrs = {"group_id": "group_id", "epic_id": "id"}
@@ -70,7 +70,7 @@ class ProjectIssueResourceLabelEvent(RESTObject):
     pass
 
 
-class ProjectIssueResourceLabelEventManager(RetrieveMixin, RESTManager):
+class ProjectIssueResourceLabelEventManager(RetrieveMixin):
     _path = "/projects/%(project_id)s/issues/%(issue_iid)s" "/resource_label_events"
     _obj_cls = ProjectIssueResourceLabelEvent
     _from_parent_attrs = {"project_id": "project_id", "issue_iid": "iid"}
@@ -80,7 +80,7 @@ class ProjectIssueResourceMilestoneEvent(RESTObject):
     pass
 
 
-class ProjectIssueResourceMilestoneEventManager(RetrieveMixin, RESTManager):
+class ProjectIssueResourceMilestoneEventManager(RetrieveMixin):
     _path = "/projects/%(project_id)s/issues/%(issue_iid)s/resource_milestone_events"
     _obj_cls = ProjectIssueResourceMilestoneEvent
     _from_parent_attrs = {"project_id": "project_id", "issue_iid": "iid"}
@@ -90,7 +90,7 @@ class ProjectMergeRequestResourceLabelEvent(RESTObject):
     pass
 
 
-class ProjectMergeRequestResourceLabelEventManager(RetrieveMixin, RESTManager):
+class ProjectMergeRequestResourceLabelEventManager(RetrieveMixin):
     _path = (
         "/projects/%(project_id)s/merge_requests/%(mr_iid)s" "/resource_label_events"
     )
@@ -102,7 +102,7 @@ class ProjectMergeRequestResourceMilestoneEvent(RESTObject):
     pass
 
 
-class ProjectMergeRequestResourceMilestoneEventManager(RetrieveMixin, RESTManager):
+class ProjectMergeRequestResourceMilestoneEventManager(RetrieveMixin):
     _path = (
         "/projects/%(project_id)s/merge_requests/%(mr_iid)s/resource_milestone_events"
     )

--- a/gitlab/v4/objects/export_import.py
+++ b/gitlab/v4/objects/export_import.py
@@ -1,4 +1,4 @@
-from gitlab.base import RESTManager, RESTObject
+from gitlab.base import RESTObject
 from gitlab.mixins import CreateMixin, DownloadMixin, GetWithoutIdMixin, RefreshMixin
 
 
@@ -14,11 +14,11 @@ __all__ = [
 ]
 
 
-class GroupExport(DownloadMixin, RESTObject):
+class GroupExport(DownloadMixin):
     _id_attr = None
 
 
-class GroupExportManager(GetWithoutIdMixin, CreateMixin, RESTManager):
+class GroupExportManager(GetWithoutIdMixin, CreateMixin):
     _path = "/groups/%(group_id)s/export"
     _obj_cls = GroupExport
     _from_parent_attrs = {"group_id": "id"}
@@ -28,28 +28,28 @@ class GroupImport(RESTObject):
     _id_attr = None
 
 
-class GroupImportManager(GetWithoutIdMixin, RESTManager):
+class GroupImportManager(GetWithoutIdMixin):
     _path = "/groups/%(group_id)s/import"
     _obj_cls = GroupImport
     _from_parent_attrs = {"group_id": "id"}
 
 
-class ProjectExport(DownloadMixin, RefreshMixin, RESTObject):
+class ProjectExport(DownloadMixin, RefreshMixin):
     _id_attr = None
 
 
-class ProjectExportManager(GetWithoutIdMixin, CreateMixin, RESTManager):
+class ProjectExportManager(GetWithoutIdMixin, CreateMixin):
     _path = "/projects/%(project_id)s/export"
     _obj_cls = ProjectExport
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = (tuple(), ("description",))
 
 
-class ProjectImport(RefreshMixin, RESTObject):
+class ProjectImport(RefreshMixin):
     _id_attr = None
 
 
-class ProjectImportManager(GetWithoutIdMixin, RESTManager):
+class ProjectImportManager(GetWithoutIdMixin):
     _path = "/projects/%(project_id)s/import"
     _obj_cls = ProjectImport
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/features.py
+++ b/gitlab/v4/objects/features.py
@@ -1,6 +1,5 @@
 from gitlab import utils
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import DeleteMixin, ListMixin, ObjectDeleteMixin
 
 
@@ -10,11 +9,11 @@ __all__ = [
 ]
 
 
-class Feature(ObjectDeleteMixin, RESTObject):
+class Feature(ObjectDeleteMixin):
     _id_attr = "name"
 
 
-class FeatureManager(ListMixin, DeleteMixin, RESTManager):
+class FeatureManager(ListMixin, DeleteMixin):
     _path = "/features/"
     _obj_cls = Feature
 

--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -1,7 +1,6 @@
 import base64
 from gitlab import cli, utils
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,
     DeleteMixin,
@@ -18,7 +17,7 @@ __all__ = [
 ]
 
 
-class ProjectFile(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectFile(SaveMixin, ObjectDeleteMixin):
     _id_attr = "file_path"
     _short_print_attr = "file_path"
 
@@ -65,7 +64,7 @@ class ProjectFile(SaveMixin, ObjectDeleteMixin, RESTObject):
         self.manager.delete(file_path, branch, commit_message, **kwargs)
 
 
-class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager):
+class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin):
     _path = "/projects/%(project_id)s/repository/files"
     _obj_cls = ProjectFile
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/geo_nodes.py
+++ b/gitlab/v4/objects/geo_nodes.py
@@ -1,6 +1,5 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     DeleteMixin,
     ObjectDeleteMixin,
@@ -16,7 +15,7 @@ __all__ = [
 ]
 
 
-class GeoNode(SaveMixin, ObjectDeleteMixin, RESTObject):
+class GeoNode(SaveMixin, ObjectDeleteMixin):
     @cli.register_custom_action("GeoNode")
     @exc.on_http_error(exc.GitlabRepairError)
     def repair(self, **kwargs):
@@ -52,7 +51,7 @@ class GeoNode(SaveMixin, ObjectDeleteMixin, RESTObject):
         return self.manager.gitlab.http_get(path, **kwargs)
 
 
-class GeoNodeManager(RetrieveMixin, UpdateMixin, DeleteMixin, RESTManager):
+class GeoNodeManager(RetrieveMixin, UpdateMixin, DeleteMixin):
     _path = "/geo_nodes"
     _obj_cls = GeoNode
     _update_attrs = (

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -1,6 +1,6 @@
 from gitlab import cli, types
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
+from gitlab.base import RESTObject
 from gitlab.mixins import CRUDMixin, ListMixin, ObjectDeleteMixin, SaveMixin
 from .access_requests import GroupAccessRequestManager
 from .badges import GroupBadgeManager
@@ -30,7 +30,7 @@ __all__ = [
 ]
 
 
-class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
+class Group(SaveMixin, ObjectDeleteMixin):
     _short_print_attr = "name"
     _managers = (
         ("accessrequests", "GroupAccessRequestManager"),
@@ -186,7 +186,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
         self.manager.gitlab.http_delete(path, **kwargs)
 
 
-class GroupManager(CRUDMixin, RESTManager):
+class GroupManager(CRUDMixin):
     _path = "/groups"
     _obj_cls = Group
     _list_filters = (
@@ -278,7 +278,7 @@ class GroupSubgroup(RESTObject):
     pass
 
 
-class GroupSubgroupManager(ListMixin, RESTManager):
+class GroupSubgroupManager(ListMixin):
     _path = "/groups/%(group_id)s/subgroups"
     _obj_cls = GroupSubgroup
     _from_parent_attrs = {"group_id": "id"}

--- a/gitlab/v4/objects/hooks.py
+++ b/gitlab/v4/objects/hooks.py
@@ -1,4 +1,3 @@
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, NoUpdateMixin, ObjectDeleteMixin, SaveMixin
 
 
@@ -10,22 +9,22 @@ __all__ = [
 ]
 
 
-class Hook(ObjectDeleteMixin, RESTObject):
+class Hook(ObjectDeleteMixin):
     _url = "/hooks"
     _short_print_attr = "url"
 
 
-class HookManager(NoUpdateMixin, RESTManager):
+class HookManager(NoUpdateMixin):
     _path = "/hooks"
     _obj_cls = Hook
     _create_attrs = (("url",), tuple())
 
 
-class ProjectHook(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectHook(SaveMixin, ObjectDeleteMixin):
     _short_print_attr = "url"
 
 
-class ProjectHookManager(CRUDMixin, RESTManager):
+class ProjectHookManager(CRUDMixin):
     _path = "/projects/%(project_id)s/hooks"
     _obj_cls = ProjectHook
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/issues.py
+++ b/gitlab/v4/objects/issues.py
@@ -1,6 +1,6 @@
 from gitlab import cli, types
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
+from gitlab.base import RESTObject
 from gitlab.mixins import (
     CRUDMixin,
     CreateMixin,
@@ -41,7 +41,7 @@ class Issue(RESTObject):
     _short_print_attr = "title"
 
 
-class IssueManager(RetrieveMixin, RESTManager):
+class IssueManager(RetrieveMixin):
     _path = "/issues"
     _obj_cls = Issue
     _list_filters = (
@@ -68,7 +68,7 @@ class GroupIssue(RESTObject):
     pass
 
 
-class GroupIssueManager(ListMixin, RESTManager):
+class GroupIssueManager(ListMixin):
     _path = "/groups/%(group_id)s/issues"
     _obj_cls = GroupIssue
     _from_parent_attrs = {"group_id": "id"}
@@ -99,7 +99,6 @@ class ProjectIssue(
     ParticipantsMixin,
     SaveMixin,
     ObjectDeleteMixin,
-    RESTObject,
 ):
     _short_print_attr = "title"
     _id_attr = "iid"
@@ -167,7 +166,7 @@ class ProjectIssue(
         return self.manager.gitlab.http_get(path, **kwargs)
 
 
-class ProjectIssueManager(CRUDMixin, RESTManager):
+class ProjectIssueManager(CRUDMixin):
     _path = "/projects/%(project_id)s/issues"
     _obj_cls = ProjectIssue
     _from_parent_attrs = {"project_id": "id"}
@@ -222,11 +221,11 @@ class ProjectIssueManager(CRUDMixin, RESTManager):
     _types = {"labels": types.ListAttribute}
 
 
-class ProjectIssueLink(ObjectDeleteMixin, RESTObject):
+class ProjectIssueLink(ObjectDeleteMixin):
     _id_attr = "issue_link_id"
 
 
-class ProjectIssueLinkManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
+class ProjectIssueLinkManager(ListMixin, CreateMixin, DeleteMixin):
     _path = "/projects/%(project_id)s/issues/%(issue_iid)s/links"
     _obj_cls = ProjectIssueLink
     _from_parent_attrs = {"project_id": "project_id", "issue_iid": "iid"}

--- a/gitlab/v4/objects/jobs.py
+++ b/gitlab/v4/objects/jobs.py
@@ -1,6 +1,5 @@
 from gitlab import cli, utils
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import RefreshMixin, RetrieveMixin
 
 
@@ -10,7 +9,7 @@ __all__ = [
 ]
 
 
-class ProjectJob(RESTObject, RefreshMixin):
+class ProjectJob(RefreshMixin):
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabJobCancelError)
     def cancel(self, **kwargs):
@@ -184,7 +183,7 @@ class ProjectJob(RESTObject, RefreshMixin):
         return utils.response_content(result, streamed, action, chunk_size)
 
 
-class ProjectJobManager(RetrieveMixin, RESTManager):
+class ProjectJobManager(RetrieveMixin):
     _path = "/projects/%(project_id)s/jobs"
     _obj_cls = ProjectJob
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/labels.py
+++ b/gitlab/v4/objects/labels.py
@@ -1,5 +1,4 @@
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,
     DeleteMixin,
@@ -20,7 +19,7 @@ __all__ = [
 ]
 
 
-class GroupLabel(SubscribableMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
+class GroupLabel(SubscribableMixin, SaveMixin, ObjectDeleteMixin):
     _id_attr = "name"
 
     # Update without ID, but we need an ID to get from list.
@@ -44,7 +43,7 @@ class GroupLabel(SubscribableMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
         self._update_attrs(server_data)
 
 
-class GroupLabelManager(ListMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager):
+class GroupLabelManager(ListMixin, CreateMixin, UpdateMixin, DeleteMixin):
     _path = "/groups/%(group_id)s/labels"
     _obj_cls = GroupLabel
     _from_parent_attrs = {"group_id": "id"}
@@ -80,7 +79,7 @@ class GroupLabelManager(ListMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         self.gitlab.http_delete(self.path, query_data={"name": name}, **kwargs)
 
 
-class ProjectLabel(SubscribableMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectLabel(SubscribableMixin, SaveMixin, ObjectDeleteMixin):
     _id_attr = "name"
 
     # Update without ID, but we need an ID to get from list.
@@ -104,9 +103,7 @@ class ProjectLabel(SubscribableMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
         self._update_attrs(server_data)
 
 
-class ProjectLabelManager(
-    RetrieveMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
-):
+class ProjectLabelManager(RetrieveMixin, CreateMixin, UpdateMixin, DeleteMixin):
     _path = "/projects/%(project_id)s/labels"
     _obj_cls = ProjectLabel
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/members.py
+++ b/gitlab/v4/objects/members.py
@@ -1,6 +1,5 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
 
 
@@ -12,11 +11,11 @@ __all__ = [
 ]
 
 
-class GroupMember(SaveMixin, ObjectDeleteMixin, RESTObject):
+class GroupMember(SaveMixin, ObjectDeleteMixin):
     _short_print_attr = "username"
 
 
-class GroupMemberManager(CRUDMixin, RESTManager):
+class GroupMemberManager(CRUDMixin):
     _path = "/groups/%(group_id)s/members"
     _obj_cls = GroupMember
     _from_parent_attrs = {"group_id": "id"}
@@ -49,11 +48,11 @@ class GroupMemberManager(CRUDMixin, RESTManager):
         return [self._obj_cls(self, item) for item in obj]
 
 
-class ProjectMember(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectMember(SaveMixin, ObjectDeleteMixin):
     _short_print_attr = "username"
 
 
-class ProjectMemberManager(CRUDMixin, RESTManager):
+class ProjectMemberManager(CRUDMixin):
     _path = "/projects/%(project_id)s/members"
     _obj_cls = ProjectMember
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -1,5 +1,4 @@
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,
     DeleteMixin,
@@ -23,11 +22,11 @@ __all__ = [
 ]
 
 
-class ProjectApproval(SaveMixin, RESTObject):
+class ProjectApproval(SaveMixin):
     _id_attr = None
 
 
-class ProjectApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
+class ProjectApprovalManager(GetWithoutIdMixin, UpdateMixin):
     _path = "/projects/%(project_id)s/approvals"
     _obj_cls = ProjectApproval
     _from_parent_attrs = {"project_id": "id"}
@@ -63,24 +62,22 @@ class ProjectApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
         self.gitlab.http_put(path, post_data=data, **kwargs)
 
 
-class ProjectApprovalRule(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectApprovalRule(SaveMixin, ObjectDeleteMixin):
     _id_attr = "id"
 
 
-class ProjectApprovalRuleManager(
-    ListMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
-):
+class ProjectApprovalRuleManager(ListMixin, CreateMixin, UpdateMixin, DeleteMixin):
     _path = "/projects/%(project_id)s/approval_rules"
     _obj_cls = ProjectApprovalRule
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = (("name", "approvals_required"), ("user_ids", "group_ids"))
 
 
-class ProjectMergeRequestApproval(SaveMixin, RESTObject):
+class ProjectMergeRequestApproval(SaveMixin):
     _id_attr = None
 
 
-class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
+class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin):
     _path = "/projects/%(project_id)s/merge_requests/%(mr_iid)s/approvals"
     _obj_cls = ProjectMergeRequestApproval
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}
@@ -131,7 +128,7 @@ class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTMan
         return approval_rules.create(data=data)
 
 
-class ProjectMergeRequestApprovalRule(SaveMixin, RESTObject):
+class ProjectMergeRequestApprovalRule(SaveMixin):
     _id_attr = "approval_rule_id"
     _short_print_attr = "approval_rule"
 
@@ -158,9 +155,7 @@ class ProjectMergeRequestApprovalRule(SaveMixin, RESTObject):
         SaveMixin.save(self, **kwargs)
 
 
-class ProjectMergeRequestApprovalRuleManager(
-    ListMixin, UpdateMixin, CreateMixin, RESTManager
-):
+class ProjectMergeRequestApprovalRuleManager(ListMixin, UpdateMixin, CreateMixin):
     _path = "/projects/%(project_id)s/merge_requests/%(mr_iid)s/approval_rules"
     _obj_cls = ProjectMergeRequestApprovalRule
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -1,6 +1,6 @@
 from gitlab import cli, types
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject, RESTObjectList
+from gitlab.base import RESTObject, RESTObjectList
 from gitlab.mixins import (
     CRUDMixin,
     ListMixin,
@@ -43,7 +43,7 @@ class MergeRequest(RESTObject):
     pass
 
 
-class MergeRequestManager(ListMixin, RESTManager):
+class MergeRequestManager(ListMixin):
     _path = "/merge_requests"
     _obj_cls = MergeRequest
     _from_parent_attrs = {"group_id": "id"}
@@ -74,7 +74,7 @@ class GroupMergeRequest(RESTObject):
     pass
 
 
-class GroupMergeRequestManager(ListMixin, RESTManager):
+class GroupMergeRequestManager(ListMixin):
     _path = "/groups/%(group_id)s/merge_requests"
     _obj_cls = GroupMergeRequest
     _from_parent_attrs = {"group_id": "id"}
@@ -108,7 +108,6 @@ class ProjectMergeRequest(
     ParticipantsMixin,
     SaveMixin,
     ObjectDeleteMixin,
-    RESTObject,
 ):
     _id_attr = "iid"
 
@@ -331,7 +330,7 @@ class ProjectMergeRequest(
         self._update_attrs(server_data)
 
 
-class ProjectMergeRequestManager(CRUDMixin, RESTManager):
+class ProjectMergeRequestManager(CRUDMixin):
     _path = "/projects/%(project_id)s/merge_requests"
     _obj_cls = ProjectMergeRequest
     _from_parent_attrs = {"project_id": "id"}
@@ -391,7 +390,7 @@ class ProjectMergeRequestDiff(RESTObject):
     pass
 
 
-class ProjectMergeRequestDiffManager(RetrieveMixin, RESTManager):
+class ProjectMergeRequestDiffManager(RetrieveMixin):
     _path = "/projects/%(project_id)s/merge_requests/%(mr_iid)s/versions"
     _obj_cls = ProjectMergeRequestDiff
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}

--- a/gitlab/v4/objects/milestones.py
+++ b/gitlab/v4/objects/milestones.py
@@ -1,6 +1,6 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject, RESTObjectList
+from gitlab.base import RESTObjectList
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
 from .issues import GroupIssue, GroupIssueManager, ProjectIssue, ProjectIssueManager
 from .merge_requests import (
@@ -19,7 +19,7 @@ __all__ = [
 ]
 
 
-class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
+class GroupMilestone(SaveMixin, ObjectDeleteMixin):
     _short_print_attr = "title"
 
     @cli.register_custom_action("GroupMilestone")
@@ -76,7 +76,7 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
         return RESTObjectList(manager, GroupMergeRequest, data_list)
 
 
-class GroupMilestoneManager(CRUDMixin, RESTManager):
+class GroupMilestoneManager(CRUDMixin):
     _path = "/groups/%(group_id)s/milestones"
     _obj_cls = GroupMilestone
     _from_parent_attrs = {"group_id": "id"}
@@ -88,7 +88,7 @@ class GroupMilestoneManager(CRUDMixin, RESTManager):
     _list_filters = ("iids", "state", "search")
 
 
-class ProjectMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectMilestone(SaveMixin, ObjectDeleteMixin):
     _short_print_attr = "title"
 
     @cli.register_custom_action("ProjectMilestone")
@@ -147,7 +147,7 @@ class ProjectMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
         return RESTObjectList(manager, ProjectMergeRequest, data_list)
 
 
-class ProjectMilestoneManager(CRUDMixin, RESTManager):
+class ProjectMilestoneManager(CRUDMixin):
     _path = "/projects/%(project_id)s/milestones"
     _obj_cls = ProjectMilestone
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/namespaces.py
+++ b/gitlab/v4/objects/namespaces.py
@@ -1,4 +1,4 @@
-from gitlab.base import RESTManager, RESTObject
+from gitlab.base import RESTObject
 from gitlab.mixins import RetrieveMixin
 
 
@@ -12,7 +12,7 @@ class Namespace(RESTObject):
     pass
 
 
-class NamespaceManager(RetrieveMixin, RESTManager):
+class NamespaceManager(RetrieveMixin):
     _path = "/namespaces"
     _obj_cls = Namespace
     _list_filters = ("search",)

--- a/gitlab/v4/objects/notes.py
+++ b/gitlab/v4/objects/notes.py
@@ -1,6 +1,6 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
+from gitlab.base import RESTObject
 from gitlab.mixins import (
     CRUDMixin,
     CreateMixin,
@@ -42,19 +42,19 @@ class ProjectNote(RESTObject):
     pass
 
 
-class ProjectNoteManager(RetrieveMixin, RESTManager):
+class ProjectNoteManager(RetrieveMixin):
     _path = "/projects/%(project_id)s/notes"
     _obj_cls = ProjectNote
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = (("body",), tuple())
 
 
-class ProjectCommitDiscussionNote(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectCommitDiscussionNote(SaveMixin, ObjectDeleteMixin):
     pass
 
 
 class ProjectCommitDiscussionNoteManager(
-    GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
+    GetMixin, CreateMixin, UpdateMixin, DeleteMixin
 ):
     _path = (
         "/projects/%(project_id)s/repository/commits/%(commit_id)s/"
@@ -70,11 +70,11 @@ class ProjectCommitDiscussionNoteManager(
     _update_attrs = (("body",), tuple())
 
 
-class ProjectIssueNote(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectIssueNote(SaveMixin, ObjectDeleteMixin):
     _managers = (("awardemojis", "ProjectIssueNoteAwardEmojiManager"),)
 
 
-class ProjectIssueNoteManager(CRUDMixin, RESTManager):
+class ProjectIssueNoteManager(CRUDMixin):
     _path = "/projects/%(project_id)s/issues/%(issue_iid)s/notes"
     _obj_cls = ProjectIssueNote
     _from_parent_attrs = {"project_id": "project_id", "issue_iid": "iid"}
@@ -82,12 +82,12 @@ class ProjectIssueNoteManager(CRUDMixin, RESTManager):
     _update_attrs = (("body",), tuple())
 
 
-class ProjectIssueDiscussionNote(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectIssueDiscussionNote(SaveMixin, ObjectDeleteMixin):
     pass
 
 
 class ProjectIssueDiscussionNoteManager(
-    GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
+    GetMixin, CreateMixin, UpdateMixin, DeleteMixin
 ):
     _path = (
         "/projects/%(project_id)s/issues/%(issue_iid)s/"
@@ -103,11 +103,11 @@ class ProjectIssueDiscussionNoteManager(
     _update_attrs = (("body",), tuple())
 
 
-class ProjectMergeRequestNote(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectMergeRequestNote(SaveMixin, ObjectDeleteMixin):
     _managers = (("awardemojis", "ProjectMergeRequestNoteAwardEmojiManager"),)
 
 
-class ProjectMergeRequestNoteManager(CRUDMixin, RESTManager):
+class ProjectMergeRequestNoteManager(CRUDMixin):
     _path = "/projects/%(project_id)s/merge_requests/%(mr_iid)s/notes"
     _obj_cls = ProjectMergeRequestNote
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}
@@ -115,12 +115,12 @@ class ProjectMergeRequestNoteManager(CRUDMixin, RESTManager):
     _update_attrs = (("body",), tuple())
 
 
-class ProjectMergeRequestDiscussionNote(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectMergeRequestDiscussionNote(SaveMixin, ObjectDeleteMixin):
     pass
 
 
 class ProjectMergeRequestDiscussionNoteManager(
-    GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
+    GetMixin, CreateMixin, UpdateMixin, DeleteMixin
 ):
     _path = (
         "/projects/%(project_id)s/merge_requests/%(mr_iid)s/"
@@ -136,11 +136,11 @@ class ProjectMergeRequestDiscussionNoteManager(
     _update_attrs = (("body",), tuple())
 
 
-class ProjectSnippetNote(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectSnippetNote(SaveMixin, ObjectDeleteMixin):
     _managers = (("awardemojis", "ProjectSnippetNoteAwardEmojiManager"),)
 
 
-class ProjectSnippetNoteManager(CRUDMixin, RESTManager):
+class ProjectSnippetNoteManager(CRUDMixin):
     _path = "/projects/%(project_id)s/snippets/%(snippet_id)s/notes"
     _obj_cls = ProjectSnippetNote
     _from_parent_attrs = {"project_id": "project_id", "snippet_id": "id"}
@@ -148,12 +148,12 @@ class ProjectSnippetNoteManager(CRUDMixin, RESTManager):
     _update_attrs = (("body",), tuple())
 
 
-class ProjectSnippetDiscussionNote(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectSnippetDiscussionNote(SaveMixin, ObjectDeleteMixin):
     pass
 
 
 class ProjectSnippetDiscussionNoteManager(
-    GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
+    GetMixin, CreateMixin, UpdateMixin, DeleteMixin
 ):
     _path = (
         "/projects/%(project_id)s/snippets/%(snippet_id)s/"

--- a/gitlab/v4/objects/notification_settings.py
+++ b/gitlab/v4/objects/notification_settings.py
@@ -1,4 +1,3 @@
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import GetWithoutIdMixin, SaveMixin, UpdateMixin
 
 
@@ -12,11 +11,11 @@ __all__ = [
 ]
 
 
-class NotificationSettings(SaveMixin, RESTObject):
+class NotificationSettings(SaveMixin):
     _id_attr = None
 
 
-class NotificationSettingsManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
+class NotificationSettingsManager(GetWithoutIdMixin, UpdateMixin):
     _path = "/notification_settings"
     _obj_cls = NotificationSettings
 

--- a/gitlab/v4/objects/packages.py
+++ b/gitlab/v4/objects/packages.py
@@ -1,4 +1,4 @@
-from gitlab.base import RESTManager, RESTObject
+from gitlab.base import RESTObject
 from gitlab.mixins import DeleteMixin, GetMixin, ListMixin, ObjectDeleteMixin
 
 
@@ -14,7 +14,7 @@ class GroupPackage(RESTObject):
     pass
 
 
-class GroupPackageManager(ListMixin, RESTManager):
+class GroupPackageManager(ListMixin):
     _path = "/groups/%(group_id)s/packages"
     _obj_cls = GroupPackage
     _from_parent_attrs = {"group_id": "id"}
@@ -27,11 +27,11 @@ class GroupPackageManager(ListMixin, RESTManager):
     )
 
 
-class ProjectPackage(ObjectDeleteMixin, RESTObject):
+class ProjectPackage(ObjectDeleteMixin):
     pass
 
 
-class ProjectPackageManager(ListMixin, GetMixin, DeleteMixin, RESTManager):
+class ProjectPackageManager(ListMixin, GetMixin, DeleteMixin):
     _path = "/projects/%(project_id)s/packages"
     _obj_cls = ProjectPackage
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/pages.py
+++ b/gitlab/v4/objects/pages.py
@@ -1,4 +1,4 @@
-from gitlab.base import RESTManager, RESTObject
+from gitlab.base import RESTObject
 from gitlab.mixins import CRUDMixin, ListMixin, ObjectDeleteMixin, SaveMixin
 
 
@@ -14,16 +14,16 @@ class PagesDomain(RESTObject):
     _id_attr = "domain"
 
 
-class PagesDomainManager(ListMixin, RESTManager):
+class PagesDomainManager(ListMixin):
     _path = "/pages/domains"
     _obj_cls = PagesDomain
 
 
-class ProjectPagesDomain(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectPagesDomain(SaveMixin, ObjectDeleteMixin):
     _id_attr = "domain"
 
 
-class ProjectPagesDomainManager(CRUDMixin, RESTManager):
+class ProjectPagesDomainManager(CRUDMixin):
     _path = "/projects/%(project_id)s/pages/domains"
     _obj_cls = ProjectPagesDomain
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/personal_access_tokens.py
+++ b/gitlab/v4/objects/personal_access_tokens.py
@@ -1,4 +1,4 @@
-from gitlab.base import RESTManager, RESTObject
+from gitlab.base import RESTObject
 from gitlab.mixins import ListMixin
 
 
@@ -12,7 +12,7 @@ class PersonalAccessToken(RESTObject):
     pass
 
 
-class PersonalAccessTokenManager(ListMixin, RESTManager):
+class PersonalAccessTokenManager(ListMixin):
     _path = "/personal_access_tokens"
     _obj_cls = PersonalAccessToken
     _list_filters = ("user_id",)

--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -1,6 +1,6 @@
 from gitlab import cli, types
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
+from gitlab.base import RESTObject
 from gitlab.mixins import (
     CRUDMixin,
     CreateMixin,
@@ -30,7 +30,7 @@ __all__ = [
 ]
 
 
-class ProjectPipeline(RESTObject, RefreshMixin, ObjectDeleteMixin):
+class ProjectPipeline(RefreshMixin, ObjectDeleteMixin):
     _managers = (
         ("jobs", "ProjectPipelineJobManager"),
         ("bridges", "ProjectPipelineBridgeManager"),
@@ -68,7 +68,7 @@ class ProjectPipeline(RESTObject, RefreshMixin, ObjectDeleteMixin):
         self.manager.gitlab.http_post(path)
 
 
-class ProjectPipelineManager(RetrieveMixin, CreateMixin, DeleteMixin, RESTManager):
+class ProjectPipelineManager(RetrieveMixin, CreateMixin, DeleteMixin):
     _path = "/projects/%(project_id)s/pipelines"
     _obj_cls = ProjectPipeline
     _from_parent_attrs = {"project_id": "id"}
@@ -109,7 +109,7 @@ class ProjectPipelineJob(RESTObject):
     pass
 
 
-class ProjectPipelineJobManager(ListMixin, RESTManager):
+class ProjectPipelineJobManager(ListMixin):
     _path = "/projects/%(project_id)s/pipelines/%(pipeline_id)s/jobs"
     _obj_cls = ProjectPipelineJob
     _from_parent_attrs = {"project_id": "project_id", "pipeline_id": "id"}
@@ -120,7 +120,7 @@ class ProjectPipelineBridge(RESTObject):
     pass
 
 
-class ProjectPipelineBridgeManager(ListMixin, RESTManager):
+class ProjectPipelineBridgeManager(ListMixin):
     _path = "/projects/%(project_id)s/pipelines/%(pipeline_id)s/bridges"
     _obj_cls = ProjectPipelineBridge
     _from_parent_attrs = {"project_id": "project_id", "pipeline_id": "id"}
@@ -131,19 +131,17 @@ class ProjectPipelineVariable(RESTObject):
     _id_attr = "key"
 
 
-class ProjectPipelineVariableManager(ListMixin, RESTManager):
+class ProjectPipelineVariableManager(ListMixin):
     _path = "/projects/%(project_id)s/pipelines/%(pipeline_id)s/variables"
     _obj_cls = ProjectPipelineVariable
     _from_parent_attrs = {"project_id": "project_id", "pipeline_id": "id"}
 
 
-class ProjectPipelineScheduleVariable(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectPipelineScheduleVariable(SaveMixin, ObjectDeleteMixin):
     _id_attr = "key"
 
 
-class ProjectPipelineScheduleVariableManager(
-    CreateMixin, UpdateMixin, DeleteMixin, RESTManager
-):
+class ProjectPipelineScheduleVariableManager(CreateMixin, UpdateMixin, DeleteMixin):
     _path = (
         "/projects/%(project_id)s/pipeline_schedules/"
         "%(pipeline_schedule_id)s/variables"
@@ -154,7 +152,7 @@ class ProjectPipelineScheduleVariableManager(
     _update_attrs = (("key", "value"), tuple())
 
 
-class ProjectPipelineSchedule(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectPipelineSchedule(SaveMixin, ObjectDeleteMixin):
     _managers = (("variables", "ProjectPipelineScheduleVariableManager"),)
 
     @cli.register_custom_action("ProjectPipelineSchedule")
@@ -192,7 +190,7 @@ class ProjectPipelineSchedule(SaveMixin, ObjectDeleteMixin, RESTObject):
         return server_data
 
 
-class ProjectPipelineScheduleManager(CRUDMixin, RESTManager):
+class ProjectPipelineScheduleManager(CRUDMixin):
     _path = "/projects/%(project_id)s/pipeline_schedules"
     _obj_cls = ProjectPipelineSchedule
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/project_access_tokens.py
+++ b/gitlab/v4/objects/project_access_tokens.py
@@ -1,5 +1,4 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.mixins import CreateMixin, DeleteMixin, ListMixin, ObjectDeleteMixin
 
 
 __all__ = [
@@ -8,11 +7,11 @@ __all__ = [
 ]
 
 
-class ProjectAccessToken(ObjectDeleteMixin, RESTObject):
+class ProjectAccessToken(ObjectDeleteMixin):
     pass
 
 
-class ProjectAccessTokenManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
+class ProjectAccessTokenManager(ListMixin, CreateMixin, DeleteMixin):
     _path = "/projects/%(project_id)s/access_tokens"
     _obj_cls = ProjectAccessToken
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -1,6 +1,6 @@
 from gitlab import cli, types, utils
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
+from gitlab.base import RESTObject
 from gitlab.mixins import (
     CRUDMixin,
     CreateMixin,
@@ -78,7 +78,7 @@ class GroupProject(RESTObject):
     pass
 
 
-class GroupProjectManager(ListMixin, RESTManager):
+class GroupProjectManager(ListMixin):
     _path = "/groups/%(group_id)s/projects"
     _obj_cls = GroupProject
     _from_parent_attrs = {"group_id": "id"}
@@ -101,7 +101,7 @@ class GroupProjectManager(ListMixin, RESTManager):
     )
 
 
-class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTObject):
+class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin):
     _short_print_attr = "path"
     _managers = (
         ("access_tokens", "ProjectAccessTokenManager"),
@@ -555,7 +555,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         return utils.response_content(result, streamed, action, chunk_size)
 
 
-class ProjectManager(CRUDMixin, RESTManager):
+class ProjectManager(CRUDMixin):
     _path = "/projects"
     _obj_cls = Project
     _create_attrs = (
@@ -900,7 +900,7 @@ class ProjectFork(RESTObject):
     pass
 
 
-class ProjectForkManager(CreateMixin, ListMixin, RESTManager):
+class ProjectForkManager(CreateMixin, ListMixin):
     _path = "/projects/%(project_id)s/forks"
     _obj_cls = ProjectFork
     _from_parent_attrs = {"project_id": "id"}
@@ -941,11 +941,11 @@ class ProjectForkManager(CreateMixin, ListMixin, RESTManager):
         return CreateMixin.create(self, data, path=path, **kwargs)
 
 
-class ProjectRemoteMirror(SaveMixin, RESTObject):
+class ProjectRemoteMirror(SaveMixin):
     pass
 
 
-class ProjectRemoteMirrorManager(ListMixin, CreateMixin, UpdateMixin, RESTManager):
+class ProjectRemoteMirrorManager(ListMixin, CreateMixin, UpdateMixin):
     _path = "/projects/%(project_id)s/remote_mirrors"
     _obj_cls = ProjectRemoteMirror
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/push_rules.py
+++ b/gitlab/v4/objects/push_rules.py
@@ -1,4 +1,3 @@
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,
     DeleteMixin,
@@ -15,13 +14,11 @@ __all__ = [
 ]
 
 
-class ProjectPushRules(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectPushRules(SaveMixin, ObjectDeleteMixin):
     _id_attr = None
 
 
-class ProjectPushRulesManager(
-    GetWithoutIdMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
-):
+class ProjectPushRulesManager(GetWithoutIdMixin, CreateMixin, UpdateMixin, DeleteMixin):
     _path = "/projects/%(project_id)s/push_rule"
     _obj_cls = ProjectPushRules
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/releases.py
+++ b/gitlab/v4/objects/releases.py
@@ -1,6 +1,6 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
+from gitlab.base import RESTObject
 from gitlab.mixins import CRUDMixin, NoUpdateMixin, ObjectDeleteMixin, SaveMixin
 
 
@@ -17,18 +17,18 @@ class ProjectRelease(RESTObject):
     _managers = (("links", "ProjectReleaseLinkManager"),)
 
 
-class ProjectReleaseManager(NoUpdateMixin, RESTManager):
+class ProjectReleaseManager(NoUpdateMixin):
     _path = "/projects/%(project_id)s/releases"
     _obj_cls = ProjectRelease
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = (("name", "tag_name", "description"), ("ref", "assets"))
 
 
-class ProjectReleaseLink(RESTObject, ObjectDeleteMixin, SaveMixin):
+class ProjectReleaseLink(ObjectDeleteMixin, SaveMixin):
     pass
 
 
-class ProjectReleaseLinkManager(CRUDMixin, RESTManager):
+class ProjectReleaseLinkManager(CRUDMixin):
     _path = "/projects/%(project_id)s/releases/%(tag_name)s/assets/links"
     _obj_cls = ProjectReleaseLink
     _from_parent_attrs = {"project_id": "project_id", "tag_name": "tag_name"}

--- a/gitlab/v4/objects/runners.py
+++ b/gitlab/v4/objects/runners.py
@@ -1,6 +1,6 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
+from gitlab.base import RESTObject
 from gitlab.mixins import (
     CRUDMixin,
     ListMixin,
@@ -26,18 +26,18 @@ class RunnerJob(RESTObject):
     pass
 
 
-class RunnerJobManager(ListMixin, RESTManager):
+class RunnerJobManager(ListMixin):
     _path = "/runners/%(runner_id)s/jobs"
     _obj_cls = RunnerJob
     _from_parent_attrs = {"runner_id": "id"}
     _list_filters = ("status",)
 
 
-class Runner(SaveMixin, ObjectDeleteMixin, RESTObject):
+class Runner(SaveMixin, ObjectDeleteMixin):
     _managers = (("jobs", "RunnerJobManager"),)
 
 
-class RunnerManager(CRUDMixin, RESTManager):
+class RunnerManager(CRUDMixin):
     _path = "/runners"
     _obj_cls = Runner
     _list_filters = ("scope",)
@@ -114,22 +114,22 @@ class RunnerManager(CRUDMixin, RESTManager):
         self.gitlab.http_post(path, post_data=post_data, **kwargs)
 
 
-class GroupRunner(ObjectDeleteMixin, RESTObject):
+class GroupRunner(ObjectDeleteMixin):
     pass
 
 
-class GroupRunnerManager(NoUpdateMixin, RESTManager):
+class GroupRunnerManager(NoUpdateMixin):
     _path = "/groups/%(group_id)s/runners"
     _obj_cls = GroupRunner
     _from_parent_attrs = {"group_id": "id"}
     _create_attrs = (("runner_id",), tuple())
 
 
-class ProjectRunner(ObjectDeleteMixin, RESTObject):
+class ProjectRunner(ObjectDeleteMixin):
     pass
 
 
-class ProjectRunnerManager(NoUpdateMixin, RESTManager):
+class ProjectRunnerManager(NoUpdateMixin):
     _path = "/projects/%(project_id)s/runners"
     _obj_cls = ProjectRunner
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/services.py
+++ b/gitlab/v4/objects/services.py
@@ -1,6 +1,5 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     DeleteMixin,
     GetMixin,
@@ -17,11 +16,11 @@ __all__ = [
 ]
 
 
-class ProjectService(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectService(SaveMixin, ObjectDeleteMixin):
     pass
 
 
-class ProjectServiceManager(GetMixin, UpdateMixin, DeleteMixin, ListMixin, RESTManager):
+class ProjectServiceManager(GetMixin, UpdateMixin, DeleteMixin, ListMixin):
     _path = "/projects/%(project_id)s/services"
     _from_parent_attrs = {"project_id": "id"}
     _obj_cls = ProjectService

--- a/gitlab/v4/objects/settings.py
+++ b/gitlab/v4/objects/settings.py
@@ -1,5 +1,4 @@
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import GetWithoutIdMixin, SaveMixin, UpdateMixin
 
 
@@ -9,11 +8,11 @@ __all__ = [
 ]
 
 
-class ApplicationSettings(SaveMixin, RESTObject):
+class ApplicationSettings(SaveMixin):
     _id_attr = None
 
 
-class ApplicationSettingsManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
+class ApplicationSettingsManager(GetWithoutIdMixin, UpdateMixin):
     _path = "/application/settings"
     _obj_cls = ApplicationSettings
     _update_attrs = (

--- a/gitlab/v4/objects/snippets.py
+++ b/gitlab/v4/objects/snippets.py
@@ -1,6 +1,5 @@
 from gitlab import cli, utils
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin, UserAgentDetailMixin
 
 from .award_emojis import ProjectSnippetAwardEmojiManager
@@ -16,7 +15,7 @@ __all__ = [
 ]
 
 
-class Snippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
+class Snippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin):
     _short_print_attr = "title"
 
     @cli.register_custom_action("Snippet")
@@ -47,7 +46,7 @@ class Snippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
         return utils.response_content(result, streamed, action, chunk_size)
 
 
-class SnippetManager(CRUDMixin, RESTManager):
+class SnippetManager(CRUDMixin):
     _path = "/snippets"
     _obj_cls = Snippet
     _create_attrs = (("title", "file_name", "content"), ("lifetime", "visibility"))
@@ -70,7 +69,7 @@ class SnippetManager(CRUDMixin, RESTManager):
         return self.list(path="/snippets/public", **kwargs)
 
 
-class ProjectSnippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectSnippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin):
     _url = "/projects/%(project_id)s/snippets"
     _short_print_attr = "title"
     _managers = (
@@ -107,7 +106,7 @@ class ProjectSnippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObj
         return utils.response_content(result, streamed, action, chunk_size)
 
 
-class ProjectSnippetManager(CRUDMixin, RESTManager):
+class ProjectSnippetManager(CRUDMixin):
     _path = "/projects/%(project_id)s/snippets"
     _obj_cls = ProjectSnippet
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/statistics.py
+++ b/gitlab/v4/objects/statistics.py
@@ -1,4 +1,3 @@
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import GetWithoutIdMixin, RefreshMixin
 
 
@@ -10,21 +9,21 @@ __all__ = [
 ]
 
 
-class ProjectAdditionalStatistics(RefreshMixin, RESTObject):
+class ProjectAdditionalStatistics(RefreshMixin):
     _id_attr = None
 
 
-class ProjectAdditionalStatisticsManager(GetWithoutIdMixin, RESTManager):
+class ProjectAdditionalStatisticsManager(GetWithoutIdMixin):
     _path = "/projects/%(project_id)s/statistics"
     _obj_cls = ProjectAdditionalStatistics
     _from_parent_attrs = {"project_id": "id"}
 
 
-class ProjectIssuesStatistics(RefreshMixin, RESTObject):
+class ProjectIssuesStatistics(RefreshMixin):
     _id_attr = None
 
 
-class ProjectIssuesStatisticsManager(GetWithoutIdMixin, RESTManager):
+class ProjectIssuesStatisticsManager(GetWithoutIdMixin):
     _path = "/projects/%(project_id)s/issues_statistics"
     _obj_cls = ProjectIssuesStatistics
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/tags.py
+++ b/gitlab/v4/objects/tags.py
@@ -1,6 +1,5 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import NoUpdateMixin, ObjectDeleteMixin
 
 
@@ -12,7 +11,7 @@ __all__ = [
 ]
 
 
-class ProjectTag(ObjectDeleteMixin, RESTObject):
+class ProjectTag(ObjectDeleteMixin):
     _id_attr = "name"
     _short_print_attr = "name"
 
@@ -52,19 +51,19 @@ class ProjectTag(ObjectDeleteMixin, RESTObject):
         self.release = server_data
 
 
-class ProjectTagManager(NoUpdateMixin, RESTManager):
+class ProjectTagManager(NoUpdateMixin):
     _path = "/projects/%(project_id)s/repository/tags"
     _obj_cls = ProjectTag
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = (("tag_name", "ref"), ("message",))
 
 
-class ProjectProtectedTag(ObjectDeleteMixin, RESTObject):
+class ProjectProtectedTag(ObjectDeleteMixin):
     _id_attr = "name"
     _short_print_attr = "name"
 
 
-class ProjectProtectedTagManager(NoUpdateMixin, RESTManager):
+class ProjectProtectedTagManager(NoUpdateMixin):
     _path = "/projects/%(project_id)s/protected_tags"
     _obj_cls = ProjectProtectedTag
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/templates.py
+++ b/gitlab/v4/objects/templates.py
@@ -1,4 +1,4 @@
-from gitlab.base import RESTManager, RESTObject
+from gitlab.base import RESTObject
 from gitlab.mixins import RetrieveMixin
 
 
@@ -18,7 +18,7 @@ class Dockerfile(RESTObject):
     _id_attr = "name"
 
 
-class DockerfileManager(RetrieveMixin, RESTManager):
+class DockerfileManager(RetrieveMixin):
     _path = "/templates/dockerfiles"
     _obj_cls = Dockerfile
 
@@ -27,7 +27,7 @@ class Gitignore(RESTObject):
     _id_attr = "name"
 
 
-class GitignoreManager(RetrieveMixin, RESTManager):
+class GitignoreManager(RetrieveMixin):
     _path = "/templates/gitignores"
     _obj_cls = Gitignore
 
@@ -36,7 +36,7 @@ class Gitlabciyml(RESTObject):
     _id_attr = "name"
 
 
-class GitlabciymlManager(RetrieveMixin, RESTManager):
+class GitlabciymlManager(RetrieveMixin):
     _path = "/templates/gitlab_ci_ymls"
     _obj_cls = Gitlabciyml
 
@@ -45,7 +45,7 @@ class License(RESTObject):
     _id_attr = "key"
 
 
-class LicenseManager(RetrieveMixin, RESTManager):
+class LicenseManager(RetrieveMixin):
     _path = "/templates/licenses"
     _obj_cls = License
     _list_filters = ("popular",)

--- a/gitlab/v4/objects/todos.py
+++ b/gitlab/v4/objects/todos.py
@@ -1,6 +1,5 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import DeleteMixin, ListMixin, ObjectDeleteMixin
 
 
@@ -10,7 +9,7 @@ __all__ = [
 ]
 
 
-class Todo(ObjectDeleteMixin, RESTObject):
+class Todo(ObjectDeleteMixin):
     @cli.register_custom_action("Todo")
     @exc.on_http_error(exc.GitlabTodoError)
     def mark_as_done(self, **kwargs):
@@ -28,7 +27,7 @@ class Todo(ObjectDeleteMixin, RESTObject):
         self._update_attrs(server_data)
 
 
-class TodoManager(ListMixin, DeleteMixin, RESTManager):
+class TodoManager(ListMixin, DeleteMixin):
     _path = "/todos"
     _obj_cls = Todo
     _list_filters = ("action", "author_id", "project_id", "state", "type")

--- a/gitlab/v4/objects/triggers.py
+++ b/gitlab/v4/objects/triggers.py
@@ -1,6 +1,5 @@
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
 
 
@@ -10,7 +9,7 @@ __all__ = [
 ]
 
 
-class ProjectTrigger(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectTrigger(SaveMixin, ObjectDeleteMixin):
     @cli.register_custom_action("ProjectTrigger")
     @exc.on_http_error(exc.GitlabOwnershipError)
     def take_ownership(self, **kwargs):
@@ -28,7 +27,7 @@ class ProjectTrigger(SaveMixin, ObjectDeleteMixin, RESTObject):
         self._update_attrs(server_data)
 
 
-class ProjectTriggerManager(CRUDMixin, RESTManager):
+class ProjectTriggerManager(CRUDMixin):
     _path = "/projects/%(project_id)s/triggers"
     _obj_cls = ProjectTrigger
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -1,6 +1,6 @@
 from gitlab import cli, types
 from gitlab import exceptions as exc
-from gitlab.base import RESTManager, RESTObject
+from gitlab.base import RESTObject
 from gitlab.mixins import (
     CRUDMixin,
     CreateMixin,
@@ -53,42 +53,42 @@ __all__ = [
 ]
 
 
-class CurrentUserEmail(ObjectDeleteMixin, RESTObject):
+class CurrentUserEmail(ObjectDeleteMixin):
     _short_print_attr = "email"
 
 
-class CurrentUserEmailManager(RetrieveMixin, CreateMixin, DeleteMixin, RESTManager):
+class CurrentUserEmailManager(RetrieveMixin, CreateMixin, DeleteMixin):
     _path = "/user/emails"
     _obj_cls = CurrentUserEmail
     _create_attrs = (("email",), tuple())
 
 
-class CurrentUserGPGKey(ObjectDeleteMixin, RESTObject):
+class CurrentUserGPGKey(ObjectDeleteMixin):
     pass
 
 
-class CurrentUserGPGKeyManager(RetrieveMixin, CreateMixin, DeleteMixin, RESTManager):
+class CurrentUserGPGKeyManager(RetrieveMixin, CreateMixin, DeleteMixin):
     _path = "/user/gpg_keys"
     _obj_cls = CurrentUserGPGKey
     _create_attrs = (("key",), tuple())
 
 
-class CurrentUserKey(ObjectDeleteMixin, RESTObject):
+class CurrentUserKey(ObjectDeleteMixin):
     _short_print_attr = "title"
 
 
-class CurrentUserKeyManager(RetrieveMixin, CreateMixin, DeleteMixin, RESTManager):
+class CurrentUserKeyManager(RetrieveMixin, CreateMixin, DeleteMixin):
     _path = "/user/keys"
     _obj_cls = CurrentUserKey
     _create_attrs = (("title", "key"), tuple())
 
 
-class CurrentUserStatus(SaveMixin, RESTObject):
+class CurrentUserStatus(SaveMixin):
     _id_attr = None
     _short_print_attr = "message"
 
 
-class CurrentUserStatusManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
+class CurrentUserStatusManager(GetWithoutIdMixin, UpdateMixin):
     _path = "/user/status"
     _obj_cls = CurrentUserStatus
     _update_attrs = (tuple(), ("emoji", "message"))
@@ -105,12 +105,12 @@ class CurrentUser(RESTObject):
     )
 
 
-class CurrentUserManager(GetWithoutIdMixin, RESTManager):
+class CurrentUserManager(GetWithoutIdMixin):
     _path = "/user"
     _obj_cls = CurrentUser
 
 
-class User(SaveMixin, ObjectDeleteMixin, RESTObject):
+class User(SaveMixin, ObjectDeleteMixin):
     _short_print_attr = "username"
     _managers = (
         ("customattributes", "UserCustomAttributeManager"),
@@ -248,7 +248,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
         return server_data
 
 
-class UserManager(CRUDMixin, RESTManager):
+class UserManager(CRUDMixin):
     _path = "/users"
     _obj_cls = User
 
@@ -325,18 +325,18 @@ class ProjectUser(RESTObject):
     pass
 
 
-class ProjectUserManager(ListMixin, RESTManager):
+class ProjectUserManager(ListMixin):
     _path = "/projects/%(project_id)s/users"
     _obj_cls = ProjectUser
     _from_parent_attrs = {"project_id": "id"}
     _list_filters = ("search",)
 
 
-class UserEmail(ObjectDeleteMixin, RESTObject):
+class UserEmail(ObjectDeleteMixin):
     _short_print_attr = "email"
 
 
-class UserEmailManager(RetrieveMixin, CreateMixin, DeleteMixin, RESTManager):
+class UserEmailManager(RetrieveMixin, CreateMixin, DeleteMixin):
     _path = "/users/%(user_id)s/emails"
     _obj_cls = UserEmail
     _from_parent_attrs = {"user_id": "id"}
@@ -352,40 +352,40 @@ class UserStatus(RESTObject):
     _short_print_attr = "message"
 
 
-class UserStatusManager(GetWithoutIdMixin, RESTManager):
+class UserStatusManager(GetWithoutIdMixin):
     _path = "/users/%(user_id)s/status"
     _obj_cls = UserStatus
     _from_parent_attrs = {"user_id": "id"}
 
 
-class UserActivitiesManager(ListMixin, RESTManager):
+class UserActivitiesManager(ListMixin):
     _path = "/user/activities"
     _obj_cls = UserActivities
 
 
-class UserGPGKey(ObjectDeleteMixin, RESTObject):
+class UserGPGKey(ObjectDeleteMixin):
     pass
 
 
-class UserGPGKeyManager(RetrieveMixin, CreateMixin, DeleteMixin, RESTManager):
+class UserGPGKeyManager(RetrieveMixin, CreateMixin, DeleteMixin):
     _path = "/users/%(user_id)s/gpg_keys"
     _obj_cls = UserGPGKey
     _from_parent_attrs = {"user_id": "id"}
     _create_attrs = (("key",), tuple())
 
 
-class UserKey(ObjectDeleteMixin, RESTObject):
+class UserKey(ObjectDeleteMixin):
     pass
 
 
-class UserKeyManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
+class UserKeyManager(ListMixin, CreateMixin, DeleteMixin):
     _path = "/users/%(user_id)s/keys"
     _obj_cls = UserKey
     _from_parent_attrs = {"user_id": "id"}
     _create_attrs = (("title", "key"), tuple())
 
 
-class UserIdentityProviderManager(DeleteMixin, RESTManager):
+class UserIdentityProviderManager(DeleteMixin):
     """Manager for user identities.
 
     This manager does not actually manage objects but enables
@@ -396,11 +396,11 @@ class UserIdentityProviderManager(DeleteMixin, RESTManager):
     _from_parent_attrs = {"user_id": "id"}
 
 
-class UserImpersonationToken(ObjectDeleteMixin, RESTObject):
+class UserImpersonationToken(ObjectDeleteMixin):
     pass
 
 
-class UserImpersonationTokenManager(NoUpdateMixin, RESTManager):
+class UserImpersonationTokenManager(NoUpdateMixin):
     _path = "/users/%(user_id)s/impersonation_tokens"
     _obj_cls = UserImpersonationToken
     _from_parent_attrs = {"user_id": "id"}
@@ -412,7 +412,7 @@ class UserMembership(RESTObject):
     _id_attr = "source_id"
 
 
-class UserMembershipManager(RetrieveMixin, RESTManager):
+class UserMembershipManager(RetrieveMixin):
     _path = "/users/%(user_id)s/memberships"
     _obj_cls = UserMembership
     _from_parent_attrs = {"user_id": "id"}
@@ -424,7 +424,7 @@ class UserProject(RESTObject):
     pass
 
 
-class UserProjectManager(ListMixin, CreateMixin, RESTManager):
+class UserProjectManager(ListMixin, CreateMixin):
     _path = "/projects/user/%(user_id)s"
     _obj_cls = UserProject
     _from_parent_attrs = {"user_id": "id"}
@@ -493,13 +493,13 @@ class UserProjectManager(ListMixin, CreateMixin, RESTManager):
         return ListMixin.list(self, path=path, **kwargs)
 
 
-class UserFollowersManager(ListMixin, RESTManager):
+class UserFollowersManager(ListMixin):
     _path = "/users/%(user_id)s/followers"
     _obj_cls = User
     _from_parent_attrs = {"user_id": "id"}
 
 
-class UserFollowingManager(ListMixin, RESTManager):
+class UserFollowingManager(ListMixin):
     _path = "/users/%(user_id)s/following"
     _obj_cls = User
     _from_parent_attrs = {"user_id": "id"}

--- a/gitlab/v4/objects/variables.py
+++ b/gitlab/v4/objects/variables.py
@@ -4,7 +4,6 @@ https://docs.gitlab.com/ee/api/instance_level_ci_variables.html
 https://docs.gitlab.com/ee/api/project_level_variables.html
 https://docs.gitlab.com/ee/api/group_level_variables.html
 """
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
 
 
@@ -18,22 +17,22 @@ __all__ = [
 ]
 
 
-class Variable(SaveMixin, ObjectDeleteMixin, RESTObject):
+class Variable(SaveMixin, ObjectDeleteMixin):
     _id_attr = "key"
 
 
-class VariableManager(CRUDMixin, RESTManager):
+class VariableManager(CRUDMixin):
     _path = "/admin/ci/variables"
     _obj_cls = Variable
     _create_attrs = (("key", "value"), ("protected", "variable_type", "masked"))
     _update_attrs = (("key", "value"), ("protected", "variable_type", "masked"))
 
 
-class GroupVariable(SaveMixin, ObjectDeleteMixin, RESTObject):
+class GroupVariable(SaveMixin, ObjectDeleteMixin):
     _id_attr = "key"
 
 
-class GroupVariableManager(CRUDMixin, RESTManager):
+class GroupVariableManager(CRUDMixin):
     _path = "/groups/%(group_id)s/variables"
     _obj_cls = GroupVariable
     _from_parent_attrs = {"group_id": "id"}
@@ -41,11 +40,11 @@ class GroupVariableManager(CRUDMixin, RESTManager):
     _update_attrs = (("key", "value"), ("protected", "variable_type", "masked"))
 
 
-class ProjectVariable(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectVariable(SaveMixin, ObjectDeleteMixin):
     _id_attr = "key"
 
 
-class ProjectVariableManager(CRUDMixin, RESTManager):
+class ProjectVariableManager(CRUDMixin):
     _path = "/projects/%(project_id)s/variables"
     _obj_cls = ProjectVariable
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/wikis.py
+++ b/gitlab/v4/objects/wikis.py
@@ -1,4 +1,3 @@
-from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
 
 
@@ -8,12 +7,12 @@ __all__ = [
 ]
 
 
-class ProjectWiki(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectWiki(SaveMixin, ObjectDeleteMixin):
     _id_attr = "slug"
     _short_print_attr = "slug"
 
 
-class ProjectWikiManager(CRUDMixin, RESTManager):
+class ProjectWikiManager(CRUDMixin):
     _path = "/projects/%(project_id)s/wikis"
     _obj_cls = ProjectWiki
     _from_parent_attrs = {"project_id": "id"}


### PR DESCRIPTION
NOTE: May not be necessary. I think if I change the ordering inside the class definitions I can fix things. This is due to MRO (Method Resolution Order) things. Basically RESTObject appears like it should be the last class in a multiple inheritance declaration.



Use RESTObject and RESTManager as the base classes for all the Mixin
classes.

Benefits are:
  * Simplifies usage of Mixins as don't need to add either RESTObject
    or RESTManager to every gitlab/v4/objects/ class
  * Type checking will work easier. Have attempted two different ways
    of type checking of Mixins and their derived classes and both
    failed :(