### PR TITLE
chore: del 'import *' in gitlab/v4/objects/project_access_tokens.py

### DIFF
--- a/gitlab/v4/objects/project_access_tokens.py
+++ b/gitlab/v4/objects/project_access_tokens.py
@@ -1,5 +1,5 @@
-from gitlab.base import *  # noqa
-from gitlab.mixins import *  # noqa
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CreateMixin, DeleteMixin, ListMixin, ObjectDeleteMixin
 
 
 __all__ = [


### PR DESCRIPTION
Remove usage of 'import *' in
gitlab/v4/objects/project_access_tokens.py.