### PR TITLE
feat(config): option to configure a helper to lookup the token

### DIFF
--- a/docs/cli-usage.rst
+++ b/docs/cli-usage.rst
@@ -48,7 +48,7 @@ example:
 
    [elsewhere]
    url = http://else.whe.re:8080
-   private_token = lookup: pass show path/to/password
+   private_token = lookup: pass show path/to/password | head -n1
    timeout = 1
 
 The ``default`` option of the ``[global]`` section defines the GitLab server to

--- a/docs/cli-usage.rst
+++ b/docs/cli-usage.rst
@@ -123,8 +123,9 @@ For all settings, which contain secrets (``http_password``,
 ``personal_token``, ``oauth_token``, ``job_token``), you can specify
 a helper program to retrieve the secret indicated by ``helper:`` 
 prefix.  You can only specify a path to a program without any 
-parameters.  It is expected, that the program prints the secret to 
-standard output.
+parameters.  You may use ``~`` for expanding your homedir in helper
+program's path.  It is expected, that the program prints the secret 
+to standard output.
 
 Example for a `keyring <https://github.com/jaraco/keyring>`_ helper:
 

--- a/docs/cli-usage.rst
+++ b/docs/cli-usage.rst
@@ -93,6 +93,8 @@ Only one of ``private_token``, ``oauth_token`` or ``job_token`` should be
 defined. If neither are defined an anonymous request will be sent to the Gitlab
 server, with very limited permissions.
 
+We recommend that you use `Credential helpers`_ to securely store your tokens.
+
 .. list-table:: GitLab server options
    :header-rows: 1
 
@@ -119,22 +121,50 @@ server, with very limited permissions.
    * - ``http_password``
      - Password for optional HTTP authentication
 
-For all settings, which contain secrets (``http_password``, 
+
+Credential helpers
+------------------
+
+For all configuration options that contain secrets (``http_password``,
 ``personal_token``, ``oauth_token``, ``job_token``), you can specify
-a helper program to retrieve the secret indicated by ``helper:`` 
-prefix.  You can only specify a path to a program without any 
-parameters.  You may use ``~`` for expanding your homedir in helper
-program's path.  It is expected, that the program prints the secret 
-to standard output.
+a helper program to retrieve the secret indicated by a ``helper:``
+prefix. This allows you to fetch values from a local keyring store
+or cloud-hosted vaults such as Bitwarden. Environment variables are
+expanded if they exist and ``~`` expands to your home directory.
+
+It is expected that the helper program prints the secret to standard output.
+To use shell features such as piping to retrieve the value, you will need
+to use a wrapper script; see below.
 
 Example for a `keyring <https://github.com/jaraco/keyring>`_ helper:
 
-.. code-block:: bash
+.. code-block:: ini
 
-    #!/bin/bash
-    keyring get Service Username
+   [global]
+   default = somewhere
+   ssl_verify = true
+   timeout = 5
 
-Example for a `pass <https://www.passwordstore.org>`_ helper:
+   [somewhere]
+   url = http://somewhe.re
+   private_token = helper: keyring get Service Username
+   timeout = 1
+
+Example for a `pass <https://www.passwordstore.org>`_ helper with a wrapper script:
+
+.. code-block:: ini
+
+   [global]
+   default = somewhere
+   ssl_verify = true
+   timeout = 5
+
+   [somewhere]
+   url = http://somewhe.re
+   private_token = helper: /path/to/helper.sh
+   timeout = 1
+
+In `/path/to/helper.sh`:
 
 .. code-block:: bash
 

--- a/docs/cli-usage.rst
+++ b/docs/cli-usage.rst
@@ -48,7 +48,7 @@ example:
 
    [elsewhere]
    url = http://else.whe.re:8080
-   private_token = CkqsjqcQSFH5FQKDccu4
+   private_token = lookup: pass show path/to/password
    timeout = 1
 
 The ``default`` option of the ``[global]`` section defines the GitLab server to

--- a/docs/cli-usage.rst
+++ b/docs/cli-usage.rst
@@ -48,7 +48,7 @@ example:
 
    [elsewhere]
    url = http://else.whe.re:8080
-   private_token = lookup: pass show path/to/password | head -n1
+   private_token = helper: path/to/helper.sh
    timeout = 1
 
 The ``default`` option of the ``[global]`` section defines the GitLab server to
@@ -118,6 +118,27 @@ server, with very limited permissions.
      - Username for optional HTTP authentication
    * - ``http_password``
      - Password for optional HTTP authentication
+
+For all settings, which contain secrets (``http_password``, 
+``personal_token``, ``oauth_token``, ``job_token``), you can specify
+a helper program to retrieve the secret indicated by ``helper:`` 
+prefix.  You can only specify a path to a program without any 
+parameters.  It is expected, that the program prints the secret to 
+standard output.
+
+Example for a `keyring <https://github.com/jaraco/keyring>`_ helper:
+
+.. code-block:: bash
+
+    #!/bin/bash
+    keyring get Service Username
+
+Example for a `pass <https://www.passwordstore.org>`_ helper:
+
+.. code-block:: bash
+
+    #!/bin/bash
+    pass show path/to/password | head -n 1
 
 CLI
 ===

--- a/gitlab/config.py
+++ b/gitlab/config.py
@@ -36,9 +36,7 @@ _DEFAULT_FILES: List[str] = _env_config() + [
 
 HELPER_PREFIX = "helper:"
 
-HELPER_ATTRIBUTES = [
-    "job_token", "http_password", "private_token", "oauth_token"
-]
+HELPER_ATTRIBUTES = ["job_token", "http_password", "private_token", "oauth_token"]
 
 class ConfigError(Exception):
     pass
@@ -202,11 +200,11 @@ class GitlabConfigParser(object):
             pass
 
     def _get_values_from_helper(self):
-        """Update attributes, which may get values from an external helper program
-        """
+        """Update attributes, which may get values from an external helper program"""
         for attr in HELPER_ATTRIBUTES:
             value = getattr(self, attr)
-            if isinstance(value, str) and value.lower().strip().startswith(HELPER_PREFIX):
+            _value_lower = value.lower().strip()
+            if isinstance(value, str) and _value_lower.startswith(HELPER_PREFIX):
                 helper = value[len(HELPER_PREFIX) :].strip()
                 value = subprocess.check_output([helper]).decode("utf-8").strip()
                 setattr(self, attr, value)

--- a/gitlab/config.py
+++ b/gitlab/config.py
@@ -204,8 +204,10 @@ class GitlabConfigParser(object):
         """Update attributes, which may get values from an external helper program"""
         for attr in HELPER_ATTRIBUTES:
             value = getattr(self, attr)
-            _value_lower = value.lower().strip()
-            if isinstance(value, str) and _value_lower.startswith(HELPER_PREFIX):
+            if not isinstance(value, str):
+                continue
+
+            if value.lower().strip().startswith(HELPER_PREFIX):
                 helper = expanduser(value[len(HELPER_PREFIX) :].strip())
                 value = subprocess.check_output([helper]).decode("utf-8").strip()
                 setattr(self, attr, value)

--- a/gitlab/config.py
+++ b/gitlab/config.py
@@ -39,6 +39,7 @@ HELPER_PREFIX = "helper:"
 
 HELPER_ATTRIBUTES = ["job_token", "http_password", "private_token", "oauth_token"]
 
+
 class ConfigError(Exception):
     pass
 

--- a/gitlab/config.py
+++ b/gitlab/config.py
@@ -17,6 +17,7 @@
 
 import os
 import configparser
+import subprocess
 from typing import List, Optional, Union
 
 from gitlab.const import USER_AGENT
@@ -149,6 +150,16 @@ class GitlabConfigParser(object):
             self.http_password = self._config.get(self.gitlab_id, "http_password")
         except Exception:
             pass
+
+        for attr in ("job_token", "http_password", "private_token", "oauth_token"):
+            value = getattr(self, attr)
+            prefix = "lookup:"
+            if isinstance(value, str) and value.lower().strip().startswith(prefix):
+                helper = value[len(prefix) :].strip()
+                value = (
+                    subprocess.check_output(helper, shell=True).decode("utf-8").strip()
+                )
+                setattr(self, attr, value)
 
         self.api_version = "4"
         try:

--- a/gitlab/config.py
+++ b/gitlab/config.py
@@ -19,6 +19,7 @@ import os
 import configparser
 import subprocess
 from typing import List, Optional, Union
+from os.path import expanduser
 
 from gitlab.const import USER_AGENT
 
@@ -205,6 +206,6 @@ class GitlabConfigParser(object):
             value = getattr(self, attr)
             _value_lower = value.lower().strip()
             if isinstance(value, str) and _value_lower.startswith(HELPER_PREFIX):
-                helper = value[len(HELPER_PREFIX) :].strip()
+                helper = expanduser(value[len(HELPER_PREFIX) :].strip())
                 value = subprocess.check_output([helper]).decode("utf-8").strip()
                 setattr(self, attr, value)

--- a/gitlab/tests/test_config.py
+++ b/gitlab/tests/test_config.py
@@ -196,6 +196,9 @@ def test_valid_data(m_open, path_exists):
     assert 2 == cp.timeout
     assert True == cp.ssl_verify
 
+    fd = io.StringIO(valid_config)
+    fd.close = mock.Mock(return_value=None)
+    m_open.return_value = fd
     cp = config.GitlabConfigParser(gitlab_id="five")
     assert "five" == cp.gitlab_id
     assert "https://five.url" == cp.url
@@ -203,6 +206,7 @@ def test_valid_data(m_open, path_exists):
     assert "foobar" == cp.oauth_token
     assert 2 == cp.timeout
     assert True == cp.ssl_verify
+
 
 @mock.patch("os.path.exists")
 @mock.patch("builtins.open")

--- a/gitlab/tests/test_config.py
+++ b/gitlab/tests/test_config.py
@@ -197,21 +197,30 @@ def test_valid_data(m_open, path_exists):
 @mock.patch("os.path.exists")
 @mock.patch("builtins.open")
 def test_data_from_helper(m_open, path_exists, tmp_path):
-    helper = (tmp_path / "helper.sh")
-    helper.write_text(dedent("""\
-        #!/bin/sh
-        echo "secret"
-    """))
+    helper = tmp_path / "helper.sh"
+    helper.write_text(
+        dedent(
+            """\
+            #!/bin/sh
+            echo "secret"
+            """
+        )
+    )
     helper.chmod(0o755)
 
-    fd = io.StringIO(dedent("""\
-        [global]
-        default = helper
+    fd = io.StringIO(
+        dedent(
+            """\
+            [global]
+            default = helper
 
-        [helper]
-        url = https://helper.url
-        oauth_token = helper: %s
-    """) % helper)
+            [helper]
+            url = https://helper.url
+            oauth_token = helper: %s
+            """
+        )
+        % helper
+    )
 
     fd.close = mock.Mock(return_value=None)
     m_open.return_value = fd

--- a/gitlab/tests/test_config.py
+++ b/gitlab/tests/test_config.py
@@ -51,6 +51,10 @@ per_page = 50
 [four]
 url = https://four.url
 oauth_token = STUV
+
+[five]
+url = https://five.url
+oauth_token = lookup: echo "foobar"
 """
 
 custom_user_agent_config = """[global]
@@ -192,6 +196,13 @@ def test_valid_data(m_open, path_exists):
     assert 2 == cp.timeout
     assert True == cp.ssl_verify
 
+    cp = config.GitlabConfigParser(gitlab_id="five")
+    assert "five" == cp.gitlab_id
+    assert "https://five.url" == cp.url
+    assert None == cp.private_token
+    assert "foobar" == cp.oauth_token
+    assert 2 == cp.timeout
+    assert True == cp.ssl_verify
 
 @mock.patch("os.path.exists")
 @mock.patch("builtins.open")


### PR DESCRIPTION
I have stored my personal access token with all other secrets in UNIX password store.  
For not having the token stored on the disk, I have implemented the option to let tokens be
looked up from a helper program.

Example:
```ini
[my_config]
url = https://gitlab.server
private_token = helper: ~/bin/pass-helper.sh
api_version = 4
```
whith a helper script ``~/bin/pass-helper.sh``:
```bash
#!/bin/bash
pass show path/to/token | head -n 1
```
