### PR TITLE
Feat: cover all audit events

### DIFF
--- a/gitlab/tests/objects/test_audit_events.py
+++ b/gitlab/tests/objects/test_audit_events.py
@@ -8,7 +8,11 @@ import re
 import pytest
 import responses
 
-from gitlab.v4.objects.audit_events import AuditEvent, ProjectAudit
+from gitlab.v4.objects.audit_events import (
+    AuditEvent,
+    GroupAuditEvent,
+    ProjectAuditEvent,
+)
 
 id = 5
 
@@ -79,14 +83,27 @@ def test_get_instance_audit_events(gl, resp_get_audit_event):
     assert audit_event.id == id
 
 
+def test_list_group_audit_events(group, resp_list_audit_events):
+    audit_events = group.audit_events.list()
+    assert isinstance(audit_events, list)
+    assert isinstance(audit_events[0], GroupAuditEvent)
+    assert audit_events[0].id == id
+
+
+def test_get_group_audit_events(group, resp_get_audit_event):
+    audit_event = group.audit_events.get(id)
+    assert isinstance(audit_event, GroupAuditEvent)
+    assert audit_event.id == id
+
+
 def test_list_project_audit_events(project, resp_list_audit_events):
     audit_events = project.audit_events.list()
     assert isinstance(audit_events, list)
-    assert isinstance(audit_events[0], ProjectAudit)
+    assert isinstance(audit_events[0], ProjectAuditEvent)
     assert audit_events[0].id == id
 
 
 def test_get_project_audit_events(project, resp_get_audit_event):
     audit_event = project.audit_events.get(id)
-    assert isinstance(audit_event, ProjectAudit)
+    assert isinstance(audit_event, ProjectAuditEvent)
     assert audit_event.id == id

--- a/gitlab/tests/objects/test_audit_events.py
+++ b/gitlab/tests/objects/test_audit_events.py
@@ -8,7 +8,7 @@ import re
 import pytest
 import responses
 
-from gitlab.v4.objects.audit_events import ProjectAudit
+from gitlab.v4.objects.audit_events import AuditEvent, ProjectAudit
 
 id = 5
 
@@ -32,11 +32,11 @@ audit_events_content = {
 }
 
 audit_events_url = re.compile(
-    r"http://localhost/api/v4/((groups|projects)/1/)audit_events"
+    r"http://localhost/api/v4/((groups|projects)/1/)?audit_events"
 )
 
 audit_events_url_id = re.compile(
-    rf"http://localhost/api/v4/((groups|projects)/1/)audit_events/{id}"
+    rf"http://localhost/api/v4/((groups|projects)/1/)?audit_events/{id}"
 )
 
 
@@ -54,7 +54,7 @@ def resp_list_audit_events():
 
 
 @pytest.fixture
-def resp_get_variable():
+def resp_get_audit_event():
     with responses.RequestsMock() as rsps:
         rsps.add(
             method=responses.GET,
@@ -66,6 +66,19 @@ def resp_get_variable():
         yield rsps
 
 
+def test_list_instance_audit_events(gl, resp_list_audit_events):
+    audit_events = gl.audit_events.list()
+    assert isinstance(audit_events, list)
+    assert isinstance(audit_events[0], AuditEvent)
+    assert audit_events[0].id == id
+
+
+def test_get_instance_audit_events(gl, resp_get_audit_event):
+    audit_event = gl.audit_events.get(id)
+    assert isinstance(audit_event, AuditEvent)
+    assert audit_event.id == id
+
+
 def test_list_project_audit_events(project, resp_list_audit_events):
     audit_events = project.audit_events.list()
     assert isinstance(audit_events, list)
@@ -73,7 +86,7 @@ def test_list_project_audit_events(project, resp_list_audit_events):
     assert audit_events[0].id == id
 
 
-def test_get_project_audit_events(project, resp_get_variable):
+def test_get_project_audit_events(project, resp_get_audit_event):
     audit_event = project.audit_events.get(id)
     assert isinstance(audit_event, ProjectAudit)
     assert audit_event.id == id

--- a/gitlab/v4/objects/__init__.py
+++ b/gitlab/v4/objects/__init__.py
@@ -18,6 +18,7 @@
 from .access_requests import *
 from .appearance import *
 from .applications import *
+from .audit_events import *
 from .award_emojis import *
 from .badges import *
 from .boards import *

--- a/gitlab/v4/objects/audit_events.py
+++ b/gitlab/v4/objects/audit_events.py
@@ -18,7 +18,7 @@ class AuditEvent(RESTObject):
     _id_attr = "id"
 
 
-class AuditEventManager(ListMixin, RESTManager):
+class AuditEventManager(RetrieveMixin, RESTManager):
     _path = "/audit_events"
     _obj_cls = AuditEvent
     _list_filters = ("created_after", "created_before", "entity_type", "entity_id")

--- a/gitlab/v4/objects/audit_events.py
+++ b/gitlab/v4/objects/audit_events.py
@@ -2,6 +2,7 @@
 GitLab API:
 https://docs.gitlab.com/ee/api/audit_events.html
 """
+import warnings
 
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import RetrieveMixin
@@ -9,6 +10,10 @@ from gitlab.mixins import RetrieveMixin
 __all__ = [
     "AuditEvent",
     "AuditEventManager",
+    "GroupAuditEvent",
+    "GroupAuditEventManager",
+    "ProjectAuditEvent",
+    "ProjectAuditEventManager",
     "ProjectAudit",
     "ProjectAuditManager",
 ]
@@ -24,12 +29,47 @@ class AuditEventManager(RetrieveMixin, RESTManager):
     _list_filters = ("created_after", "created_before", "entity_type", "entity_id")
 
 
-class ProjectAudit(RESTObject):
+class GroupAuditEvent(RESTObject):
     _id_attr = "id"
 
 
-class ProjectAuditManager(RetrieveMixin, RESTManager):
+class GroupAuditEventManager(RetrieveMixin, RESTManager):
+    _path = "/groups/%(group_id)s/audit_events"
+    _obj_cls = GroupAuditEvent
+    _from_parent_attrs = {"group_id": "id"}
+    _list_filters = ("created_after", "created_before")
+
+
+class ProjectAuditEvent(RESTObject):
+    _id_attr = "id"
+
+    def __init_subclass__(self):
+        warnings.warn(
+            "This class has been renamed to ProjectAuditEvent "
+            "and will be removed in a future release.",
+            DeprecationWarning,
+            2,
+        )
+
+
+class ProjectAuditEventManager(RetrieveMixin, RESTManager):
     _path = "/projects/%(project_id)s/audit_events"
-    _obj_cls = ProjectAudit
+    _obj_cls = ProjectAuditEvent
     _from_parent_attrs = {"project_id": "id"}
     _list_filters = ("created_after", "created_before")
+
+    def __init_subclass__(self):
+        warnings.warn(
+            "This class has been renamed to ProjectAuditEventManager "
+            "and will be removed in a future release.",
+            DeprecationWarning,
+            2,
+        )
+
+
+class ProjectAudit(ProjectAuditEvent):
+    pass
+
+
+class ProjectAuditManager(ProjectAuditEventManager):
+    pass

--- a/gitlab/v4/objects/audit_events.py
+++ b/gitlab/v4/objects/audit_events.py
@@ -1,15 +1,27 @@
 """
 GitLab API:
-https://docs.gitlab.com/ee/api/audit_events.html#project-audit-events
+https://docs.gitlab.com/ee/api/audit_events.html
 """
 
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import RetrieveMixin
 
 __all__ = [
+    "AuditEvent",
+    "AuditEventManager",
     "ProjectAudit",
     "ProjectAuditManager",
 ]
+
+
+class AuditEvent(RESTObject):
+    _id_attr = "id"
+
+
+class AuditEventManager(ListMixin, RESTManager):
+    _path = "/audit_events"
+    _obj_cls = AuditEvent
+    _list_filters = ("created_after", "created_before", "entity_type", "entity_id")
 
 
 class ProjectAudit(RESTObject):

--- a/gitlab/v4/objects/events.py
+++ b/gitlab/v4/objects/events.py
@@ -6,8 +6,6 @@ from gitlab.mixins import ListMixin, RetrieveMixin
 __all__ = [
     "Event",
     "EventManager",
-    "AuditEvent",
-    "AuditEventManager",
     "GroupEpicResourceLabelEvent",
     "GroupEpicResourceLabelEventManager",
     "ProjectEvent",
@@ -34,16 +32,6 @@ class EventManager(ListMixin, RESTManager):
     _path = "/events"
     _obj_cls = Event
     _list_filters = ("action", "target_type", "before", "after", "sort")
-
-
-class AuditEvent(RESTObject):
-    _id_attr = "id"
-
-
-class AuditEventManager(ListMixin, RESTManager):
-    _path = "/audit_events"
-    _obj_cls = AuditEvent
-    _list_filters = ("created_after", "created_before", "entity_type", "entity_id")
 
 
 class GroupEpicResourceLabelEvent(RESTObject):

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -3,6 +3,7 @@ from gitlab import exceptions as exc
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ListMixin, ObjectDeleteMixin, SaveMixin
 from .access_requests import GroupAccessRequestManager
+from .audit_events import GroupAuditEventManager
 from .badges import GroupBadgeManager
 from .boards import GroupBoardManager
 from .custom_attributes import GroupCustomAttributeManager
@@ -34,6 +35,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
     _short_print_attr = "name"
     _managers = (
         ("accessrequests", "GroupAccessRequestManager"),
+        ("audit_events", "GroupAuditEventManager"),
         ("badges", "GroupBadgeManager"),
         ("boards", "GroupBoardManager"),
         ("customattributes", "GroupCustomAttributeManager"),

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -25,7 +25,7 @@ from .deploy_tokens import ProjectDeployTokenManager
 from .deployments import ProjectDeploymentManager
 from .environments import ProjectEnvironmentManager
 from .events import ProjectEventManager
-from .audit_events import ProjectAuditManager
+from .audit_events import ProjectAuditEventManager
 from .export_import import ProjectExportManager, ProjectImportManager
 from .files import ProjectFileManager
 from .hooks import ProjectHookManager
@@ -117,7 +117,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         ("deployments", "ProjectDeploymentManager"),
         ("environments", "ProjectEnvironmentManager"),
         ("events", "ProjectEventManager"),
-        ("audit_events", "ProjectAuditManager"),
+        ("audit_events", "ProjectAuditEventManager"),
         ("exports", "ProjectExportManager"),
         ("files", "ProjectFileManager"),
         ("forks", "ProjectForkManager"),


### PR DESCRIPTION
This adds group audit events, moves all audit events into one module and makes the class naming consistent.

Closes https://github.com/python-gitlab/python-gitlab/issues/1107, closes https://github.com/python-gitlab/python-gitlab/issues/948.