### PR TITLE
chore: make _types always present in RESTManager

### DIFF
--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -20,6 +20,7 @@ from types import ModuleType
 from typing import Any, Dict, Optional, Type
 
 from .client import Gitlab, GitlabList
+from gitlab import types as g_types
 
 __all__ = [
     "RESTObject",
@@ -260,6 +261,7 @@ class RESTManager(object):
     _path: Optional[str] = None
     _obj_cls: Optional[Type[RESTObject]] = None
     _from_parent_attrs: Dict[str, Any] = {}
+    _types: Dict[str, Type[g_types.GitlabAttribute]] = {}
 
     _computed_path: Optional[str]
     _parent: Optional[RESTObject]

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -226,9 +226,8 @@ class ListMixin(_RestManagerBase):
             data.setdefault("order_by", self.gitlab.order_by)
 
         # We get the attributes that need some special transformation
-        types = getattr(self, "_types", {})
-        if types:
-            for attr_name, type_cls in types.items():
+        if self._types:
+            for attr_name, type_cls in self._types.items():
                 if attr_name in data.keys():
                     type_obj = type_cls(data[attr_name])
                     data[attr_name] = type_obj.get_for_api()
@@ -311,17 +310,16 @@ class CreateMixin(_RestManagerBase):
         files = {}
 
         # We get the attributes that need some special transformation
-        types = getattr(self, "_types", {})
-        if types:
+        if self._types:
             # Duplicate data to avoid messing with what the user sent us
             data = data.copy()
-            for attr_name, type_cls in types.items():
+            for attr_name, type_cls in self._types.items():
                 if attr_name in data.keys():
                     type_obj = type_cls(data[attr_name])
 
                     # if the type if FileAttribute we need to pass the data as
                     # file
-                    if issubclass(type_cls, g_types.FileAttribute):
+                    if isinstance(type_obj, g_types.FileAttribute):
                         k = type_obj.get_file_name(attr_name)
                         files[attr_name] = (k, data.pop(attr_name))
                     else:
@@ -414,17 +412,16 @@ class UpdateMixin(_RestManagerBase):
         files = {}
 
         # We get the attributes that need some special transformation
-        types = getattr(self, "_types", {})
-        if types:
+        if self._types:
             # Duplicate data to avoid messing with what the user sent us
             new_data = new_data.copy()
-            for attr_name, type_cls in types.items():
+            for attr_name, type_cls in self._types.items():
                 if attr_name in new_data.keys():
                     type_obj = type_cls(new_data[attr_name])
 
                     # if the type if FileAttribute we need to pass the data as
                     # file
-                    if issubclass(type_cls, g_types.FileAttribute):
+                    if isinstance(type_obj, g_types.FileAttribute):
                         k = type_obj.get_file_name(attr_name)
                         files[attr_name] = (k, new_data.pop(attr_name))
                     else:

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -42,9 +42,8 @@ class GitlabCLI(object):
         self.mgr_cls._path = self.mgr_cls._path % self.args
         self.mgr = self.mgr_cls(gl)
 
-        types = getattr(self.mgr_cls, "_types", {})
-        if types:
-            for attr_name, type_cls in types.items():
+        if self.mgr_cls._types:
+            for attr_name, type_cls in self.mgr_cls._types.items():
                 if attr_name in self.args.keys():
                     obj = type_cls()
                     obj.set_from_cli(self.args[attr_name])


### PR DESCRIPTION
We now create _types = {} in RESTManager class.

By making _types always present in RESTManager it makes the code
simpler. We no longer have to do:
   types = getattr(self, "_types", {})

And the type checker now understands the type.