### PR TITLE
fix: checking if RESTManager._from_parent_attrs is set

### DIFF
--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -290,12 +290,12 @@ class RESTManager(object):
             path = self._path
         if path is None:
             return None
-        if self._parent is None or not hasattr(self, "_from_parent_attrs"):
+        if self._parent is None or not self._from_parent_attrs:
             return path
 
         data = {
             self_attr: getattr(self._parent, parent_attr, None)
-            for self_attr, parent_attr in self._from_parent_attrs.items()  # type: ignore
+            for self_attr, parent_attr in self._from_parent_attrs.items()
         }
         self._parent_attrs = data
         return path % data

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -69,7 +69,7 @@ class GitlabCLI(object):
         # Get the object (lazy), then act
         if in_obj:
             data = {}
-            if hasattr(self.mgr, "_from_parent_attrs"):
+            if self.mgr._from_parent_attrs:
                 for k in self.mgr._from_parent_attrs:
                     data[k] = self.args[k]
             if gitlab.mixins.GetWithoutIdMixin not in inspect.getmro(self.cls):
@@ -138,13 +138,11 @@ def _populate_sub_parser_by_class(cls, sub_parser):
 
         sub_parser_action = sub_parser.add_parser(action_name)
         sub_parser_action.add_argument("--sudo", required=False)
-        if hasattr(mgr_cls, "_from_parent_attrs"):
-            [
+        if mgr_cls._from_parent_attrs:
+            for x in mgr_cls._from_parent_attrs:
                 sub_parser_action.add_argument(
                     "--%s" % x.replace("_", "-"), required=True
                 )
-                for x in mgr_cls._from_parent_attrs
-            ]
 
         if action_name == "list":
             if hasattr(mgr_cls, "_list_filters"):
@@ -221,13 +219,11 @@ def _populate_sub_parser_by_class(cls, sub_parser):
         for action_name in cli.custom_actions[name]:
             sub_parser_action = sub_parser.add_parser(action_name)
             # Get the attributes for URL/path construction
-            if hasattr(mgr_cls, "_from_parent_attrs"):
-                [
+            if mgr_cls._from_parent_attrs:
+                for x in mgr_cls._from_parent_attrs:
                     sub_parser_action.add_argument(
                         "--%s" % x.replace("_", "-"), required=True
                     )
-                    for x in mgr_cls._from_parent_attrs
-                ]
                 sub_parser_action.add_argument("--sudo", required=False)
 
             # We need to get the object somehow
@@ -256,13 +252,11 @@ def _populate_sub_parser_by_class(cls, sub_parser):
         name = mgr_cls.__name__
         for action_name in cli.custom_actions[name]:
             sub_parser_action = sub_parser.add_parser(action_name)
-            if hasattr(mgr_cls, "_from_parent_attrs"):
-                [
+            if mgr_cls._from_parent_attrs:
+                for x in mgr_cls._from_parent_attrs:
                     sub_parser_action.add_argument(
                         "--%s" % x.replace("_", "-"), required=True
                     )
-                    for x in mgr_cls._from_parent_attrs
-                ]
                 sub_parser_action.add_argument("--sudo", required=False)
 
             required, optional, dummy = cli.custom_actions[name][action_name]


### PR DESCRIPTION
Prior to commit 3727cbd21fc40b312573ca8da56e0f6cf9577d08
RESTManager._from_parent_attrs did not exist unless it was explicitly
set. But commit 3727cbd21fc40b312573ca8da56e0f6cf9577d08 set it to a
default value of {}.

So the checks using hasattr() were no longer valid.

Update the checks to check if RESTManager._from_parent_attrs has a
value.