### PR TITLE
chore: add _create_attrs & _update_attrs to RESTManager

### DIFF
--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -17,7 +17,7 @@
 
 import importlib
 from types import ModuleType
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Optional, Tuple, Type
 
 from .client import Gitlab, GitlabList
 from gitlab import types as g_types
@@ -258,6 +258,8 @@ class RESTManager(object):
     ``_obj_cls``: The class of objects that will be created
     """
 
+    _create_attrs: Tuple[Tuple[str, ...], Tuple[str, ...]] = (tuple(), tuple())
+    _update_attrs: Tuple[Tuple[str, ...], Tuple[str, ...]] = (tuple(), tuple())
     _path: Optional[str] = None
     _obj_cls: Optional[Type[RESTObject]] = None
     _from_parent_attrs: Dict[str, Any] = {}

--- a/gitlab/tests/mixins/test_mixin_methods.py
+++ b/gitlab/tests/mixins/test_mixin_methods.py
@@ -129,27 +129,6 @@ def test_list_other_url(gl):
             obj_list.next()
 
 
-def test_create_mixin_get_attrs(gl):
-    class M1(CreateMixin, FakeManager):
-        pass
-
-    class M2(CreateMixin, FakeManager):
-        _create_attrs = (("foo",), ("bar", "baz"))
-        _update_attrs = (("foo",), ("bam",))
-
-    mgr = M1(gl)
-    required, optional = mgr.get_create_attrs()
-    assert len(required) == 0
-    assert len(optional) == 0
-
-    mgr = M2(gl)
-    required, optional = mgr.get_create_attrs()
-    assert "foo" in required
-    assert "bar" in optional
-    assert "baz" in optional
-    assert "bam" not in optional
-
-
 def test_create_mixin_missing_attrs(gl):
     class M(CreateMixin, FakeManager):
         _create_attrs = (("foo",), ("bar", "baz"))
@@ -200,27 +179,6 @@ def test_create_mixin_custom_path(gl):
         assert isinstance(obj, FakeObject)
         assert obj.id == 42
         assert obj.foo == "bar"
-
-
-def test_update_mixin_get_attrs(gl):
-    class M1(UpdateMixin, FakeManager):
-        pass
-
-    class M2(UpdateMixin, FakeManager):
-        _create_attrs = (("foo",), ("bar", "baz"))
-        _update_attrs = (("foo",), ("bam",))
-
-    mgr = M1(gl)
-    required, optional = mgr.get_update_attrs()
-    assert len(required) == 0
-    assert len(optional) == 0
-
-    mgr = M2(gl)
-    required, optional = mgr.get_update_attrs()
-    assert "foo" in required
-    assert "bam" in optional
-    assert "bar" not in optional
-    assert "baz" not in optional
 
 
 def test_update_mixin_missing_attrs(gl):

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -177,42 +177,31 @@ def _populate_sub_parser_by_class(cls, sub_parser):
                 ]
 
         if action_name == "create":
-            if hasattr(mgr_cls, "_create_attrs"):
-                [
-                    sub_parser_action.add_argument(
-                        "--%s" % x.replace("_", "-"), required=True
-                    )
-                    for x in mgr_cls._create_attrs[0]
-                ]
-
-                [
-                    sub_parser_action.add_argument(
-                        "--%s" % x.replace("_", "-"), required=False
-                    )
-                    for x in mgr_cls._create_attrs[1]
-                ]
+            for x in mgr_cls._create_attrs[0]:
+                sub_parser_action.add_argument(
+                    "--%s" % x.replace("_", "-"), required=True
+                )
+            for x in mgr_cls._create_attrs[1]:
+                sub_parser_action.add_argument(
+                    "--%s" % x.replace("_", "-"), required=False
+                )
 
         if action_name == "update":
             if cls._id_attr is not None:
                 id_attr = cls._id_attr.replace("_", "-")
                 sub_parser_action.add_argument("--%s" % id_attr, required=True)
 
-            if hasattr(mgr_cls, "_update_attrs"):
-                [
+            for x in mgr_cls._update_attrs[0]:
+                if x != cls._id_attr:
                     sub_parser_action.add_argument(
                         "--%s" % x.replace("_", "-"), required=True
                     )
-                    for x in mgr_cls._update_attrs[0]
-                    if x != cls._id_attr
-                ]
 
-                [
+            for x in mgr_cls._update_attrs[1]:
+                if x != cls._id_attr:
                     sub_parser_action.add_argument(
                         "--%s" % x.replace("_", "-"), required=False
                     )
-                    for x in mgr_cls._update_attrs[1]
-                    if x != cls._id_attr
-                ]
 
     if cls.__name__ in cli.custom_actions:
         name = cls.__name__


### PR DESCRIPTION
Add the attributes: _create_attrs and _update_attrs to the RESTManager
class. This is so that we stop using getattr() if we don't need to.

This also helps with type-hints being available for these attributes.