### PR TITLE
fix(types): prevent __dir__ in RestObject from producing duplicates

### DIFF
--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -132,7 +132,7 @@ class RESTObject(object):
         return super(RESTObject, self) != other
 
     def __dir__(self):
-        return super(RESTObject, self).__dir__() + list(self.attributes)
+        return super(RESTObject, self).__dir__() | self.attributes.keys()
 
     def __hash__(self) -> int:
         if not self.get_id():

--- a/gitlab/tests/test_base.py
+++ b/gitlab/tests/test_base.py
@@ -135,6 +135,10 @@ class TestRESTObject:
         assert {"foo": "foo"} == obj._attrs
         assert {} == obj._updated_attrs
 
+    def test_dir_unique(self, fake_manager):
+        obj = FakeObject(fake_manager, {"manager": "foo"})
+        assert len(dir(obj)) == len(set(dir(obj)))
+
     def test_create_managers(self, fake_gitlab, fake_manager):
         class ObjectWithManager(FakeObject):
             _managers = (("fakes", "FakeManager"),)


### PR DESCRIPTION
Fixes a small issue with the feature added in #1072 for `__dir__` to display rest object attributes.

In at least one case, classes have overlapping attributes with the attributes listed in `.attributes`. For example, the `Group` object has its own `projects` property for the `GroupProjectManager`. This shadows the name that would normally access `.attributes['projects']`. This causes `dir(some_group)`, as currently implemented, to list `projects` twice.

While this is unlikely to be problematic, it's ideal if duplicate attributes do not appear in the response for `__dir__`. This PR ensures that duplicates are not produced by the `__dir__` method.

Instead of _adding_ the list of attributes, we use the `|` operator to produce a set with the union of all the elements, ensuring there are no duplicates.