### PR TITLE
feat(api):add support for creating/editing reviewers in project MRs

### DIFF
--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -138,6 +138,22 @@ class ProjectMergeRequest(
 ):
     _id_attr = "iid"
 
+    @property
+    def reviewer_ids(self):
+        return [reviewer["id"] for reviewer in self.reviewers]
+
+    @reviewer_ids.setter
+    def reviewer_ids(self, new_reviewer_ids):
+        new_reviewers = [{"id": id} for id in set(new_reviewer_ids)]
+        new_reviewers.extend(
+            [
+                reviewer
+                for reviewer in self.reviewers
+                if reviewer["id"] in new_reviewer_ids
+            ]
+        )
+        self.reviewers = new_reviewers
+
     _managers = (
         ("approvals", "ProjectMergeRequestApprovalManager"),
         ("approval_rules", "ProjectMergeRequestApprovalRuleManager"),
@@ -373,6 +389,7 @@ class ProjectMergeRequestManager(CRUDMixin, RESTManager):
             "remove_source_branch",
             "allow_maintainer_to_push",
             "squash",
+            "reviewer_ids",
         ),
     )
     _update_attrs = RequiredOptional(
@@ -388,6 +405,7 @@ class ProjectMergeRequestManager(CRUDMixin, RESTManager):
             "discussion_locked",
             "allow_maintainer_to_push",
             "squash",
+            "reviewer_ids",
         ),
     )
     _list_filters = (

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -138,22 +138,6 @@ class ProjectMergeRequest(
 ):
     _id_attr = "iid"
 
-    @property
-    def reviewer_ids(self):
-        return [reviewer["id"] for reviewer in self.reviewers]
-
-    @reviewer_ids.setter
-    def reviewer_ids(self, new_reviewer_ids):
-        new_reviewers = [{"id": id} for id in set(new_reviewer_ids)]
-        new_reviewers.extend(
-            [
-                reviewer
-                for reviewer in self.reviewers
-                if reviewer["id"] in new_reviewer_ids
-            ]
-        )
-        self.reviewers = new_reviewers
-
     _managers = (
         ("approvals", "ProjectMergeRequestApprovalManager"),
         ("approval_rules", "ProjectMergeRequestApprovalRuleManager"),


### PR DESCRIPTION
This is a first attempt at allowing users to create MRs with reviewers or edit an existing MR with the `reviewer_ids` parameter.

This is kind of unique in the sense that `reviewer_ids` doesn't appear in the rest response, but it is an accepted parameter.

A manager might be a better way to implement this, but I'm not sure it's appropriate since reviewers doesn't have its own API path, so reviewers are not really a rest object in their own right. The only example of a manager being used as a helper is the sidekiq manager.

API:

```python
mr.reviewer_ids = [1,2,3]
mr.save()
```

The property can be omitted and the same code as above works, however `mr.reviewer_ids` would be an attribute error, which may be an odd interface.

What I have here _works_ but I'm not sure it's an ideal interface. Mainly raising this to get feedback from maintainers on how this should be implemented. Feedback appreciated.

Relates to #1267 