### PR TITLE
Fix all issues reported by running: tox -e pep8 and enable pep8 as a linter check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,14 +12,6 @@ env:
   PY_COLORS: 1
 
 jobs:
-  black:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: psf/black@stable
-        with:
-          black_args: ". --check"
   commitlint:
     runs-on: ubuntu-latest
     steps:
@@ -28,10 +20,15 @@ jobs:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v3
 
-  mypy:
+  linters:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: pip install --upgrade tox
-      - run: tox -e mypy
+      - name: Run black code formatter (https://black.readthedocs.io/en/stable/)
+        run: tox -e black -- --check
+      - name: Run flake8 (https://flake8.pycqa.org/en/latest/)
+        run: tox -e pep8
+      - name: Run mypy static typing checker (http://mypy-lang.org/)
+        run: tox -e mypy

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -18,8 +18,8 @@
 
 import warnings
 
-import gitlab.config
-from gitlab.__version__ import (
+import gitlab.config  # noqa: F401
+from gitlab.__version__ import (  # noqa: F401
     __author__,
     __copyright__,
     __email__,
@@ -27,9 +27,9 @@ from gitlab.__version__ import (
     __title__,
     __version__,
 )
-from gitlab.client import Gitlab, GitlabList
-from gitlab.const import *  # noqa
-from gitlab.exceptions import *  # noqa
+from gitlab.client import Gitlab, GitlabList  # noqa: F401
+from gitlab.const import *  # noqa: F401,F403
+from gitlab.exceptions import *  # noqa: F401,F403
 
 
 warnings.filterwarnings("default", category=DeprecationWarning, module="^gitlab")

--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -23,7 +23,7 @@ import re
 import sys
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
-import gitlab.config
+import gitlab.config  # noqa: F401
 
 camel_re = re.compile("(.)([A-Z])")
 

--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -162,7 +162,6 @@ def docs() -> argparse.ArgumentParser:
     if "sphinx" not in sys.modules:
         sys.exit("Docs parser is only intended for build_sphinx")
 
-    parser = _get_base_parser(add_help=False)
     # NOTE: We must delay import of gitlab.v4.cli until now or
     # otherwise it will cause circular import errors
     import gitlab.v4.cli

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -22,7 +22,6 @@ from typing import (
     Dict,
     List,
     Optional,
-    Tuple,
     Type,
     TYPE_CHECKING,
     Union,

--- a/gitlab/tests/mixins/test_mixin_methods.py
+++ b/gitlab/tests/mixins/test_mixin_methods.py
@@ -44,7 +44,7 @@ def test_get_mixin(gl):
 
 
 def test_refresh_mixin(gl):
-    class O(RefreshMixin, FakeObject):
+    class TestClass(RefreshMixin, FakeObject):
         pass
 
     @urlmatch(scheme="http", netloc="localhost", path="/api/v4/tests/42", method="get")
@@ -55,7 +55,7 @@ def test_refresh_mixin(gl):
 
     with HTTMock(resp_cont):
         mgr = FakeManager(gl)
-        obj = O(mgr, {"id": 42})
+        obj = TestClass(mgr, {"id": 42})
         res = obj.refresh()
         assert res is None
         assert obj.foo == "bar"
@@ -265,7 +265,7 @@ def test_save_mixin(gl):
     class M(UpdateMixin, FakeManager):
         pass
 
-    class O(SaveMixin, base.RESTObject):
+    class TestClass(SaveMixin, base.RESTObject):
         pass
 
     @urlmatch(scheme="http", netloc="localhost", path="/api/v4/tests/42", method="put")
@@ -276,7 +276,7 @@ def test_save_mixin(gl):
 
     with HTTMock(resp_cont):
         mgr = M(gl)
-        obj = O(mgr, {"id": 42, "foo": "bar"})
+        obj = TestClass(mgr, {"id": 42, "foo": "bar"})
         obj.foo = "baz"
         obj.save()
         assert obj._attrs["foo"] == "baz"

--- a/gitlab/tests/mixins/test_object_mixins_attributes.py
+++ b/gitlab/tests/mixins/test_object_mixins_attributes.py
@@ -27,35 +27,35 @@ from gitlab.mixins import (
 
 
 def test_access_request_mixin():
-    class O(AccessRequestMixin):
+    class TestClass(AccessRequestMixin):
         pass
 
-    obj = O()
+    obj = TestClass()
     assert hasattr(obj, "approve")
 
 
 def test_subscribable_mixin():
-    class O(SubscribableMixin):
+    class TestClass(SubscribableMixin):
         pass
 
-    obj = O()
+    obj = TestClass()
     assert hasattr(obj, "subscribe")
     assert hasattr(obj, "unsubscribe")
 
 
 def test_todo_mixin():
-    class O(TodoMixin):
+    class TestClass(TodoMixin):
         pass
 
-    obj = O()
+    obj = TestClass()
     assert hasattr(obj, "todo")
 
 
 def test_time_tracking_mixin():
-    class O(TimeTrackingMixin):
+    class TestClass(TimeTrackingMixin):
         pass
 
-    obj = O()
+    obj = TestClass()
     assert hasattr(obj, "time_stats")
     assert hasattr(obj, "time_estimate")
     assert hasattr(obj, "reset_time_estimate")
@@ -64,16 +64,16 @@ def test_time_tracking_mixin():
 
 
 def test_set_mixin():
-    class O(SetMixin):
+    class TestClass(SetMixin):
         pass
 
-    obj = O()
+    obj = TestClass()
     assert hasattr(obj, "set")
 
 
 def test_user_agent_detail_mixin():
-    class O(UserAgentDetailMixin):
+    class TestClass(UserAgentDetailMixin):
         pass
 
-    obj = O()
+    obj = TestClass()
     assert hasattr(obj, "user_agent_detail")

--- a/gitlab/tests/objects/test_appearance.py
+++ b/gitlab/tests/objects/test_appearance.py
@@ -63,4 +63,4 @@ def test_get_update_appearance(gl, resp_application_appearance):
 
 
 def test_update_appearance(gl, resp_application_appearance):
-    resp = gl.appearance.update(title=new_title, description=new_description)
+    gl.appearance.update(title=new_title, description=new_description)

--- a/gitlab/tests/objects/test_bridges.py
+++ b/gitlab/tests/objects/test_bridges.py
@@ -1,12 +1,10 @@
 """
 GitLab API: https://docs.gitlab.com/ee/api/jobs.html#list-pipeline-bridges
 """
-import re
-
 import pytest
 import responses
 
-from gitlab.v4.objects import Project, ProjectPipelineBridge
+from gitlab.v4.objects import ProjectPipelineBridge
 
 
 @pytest.fixture

--- a/gitlab/tests/objects/test_project_merge_request_approvals.py
+++ b/gitlab/tests/objects/test_project_merge_request_approvals.py
@@ -241,7 +241,7 @@ def test_project_approval_manager_update_uses_post(project, resp_snippet):
     assert isinstance(
         approvals, gitlab.v4.objects.merge_request_approvals.ProjectApprovalManager
     )
-    assert approvals._update_uses_post == True
+    assert approvals._update_uses_post is True
 
 
 def test_list_merge_request_approval_rules(project, resp_snippet):
@@ -257,7 +257,7 @@ def test_update_merge_request_approvals_set_approvers(project, resp_snippet):
         approvals,
         gitlab.v4.objects.merge_request_approvals.ProjectMergeRequestApprovalManager,
     )
-    assert approvals._update_uses_post == True
+    assert approvals._update_uses_post is True
     response = approvals.set_approvers(
         updated_approval_rule_approvals_required,
         approver_ids=updated_approval_rule_user_ids,
@@ -277,7 +277,7 @@ def test_create_merge_request_approvals_set_approvers(project, resp_snippet):
         approvals,
         gitlab.v4.objects.merge_request_approvals.ProjectMergeRequestApprovalManager,
     )
-    assert approvals._update_uses_post == True
+    assert approvals._update_uses_post is True
     response = approvals.set_approvers(
         new_approval_rule_approvals_required,
         approver_ids=new_approval_rule_user_ids,

--- a/gitlab/tests/objects/test_runners.py
+++ b/gitlab/tests/objects/test_runners.py
@@ -200,7 +200,7 @@ def resp_runner_verify():
 
 def test_owned_runners_list(gl: gitlab.Gitlab, resp_get_runners_list):
     runners = gl.runners.list()
-    assert runners[0].active == True
+    assert runners[0].active is True
     assert runners[0].id == 6
     assert runners[0].name == "test-name"
     assert len(runners) == 1
@@ -208,7 +208,7 @@ def test_owned_runners_list(gl: gitlab.Gitlab, resp_get_runners_list):
 
 def test_project_runners_list(gl: gitlab.Gitlab, resp_get_runners_list):
     runners = gl.projects.get(1, lazy=True).runners.list()
-    assert runners[0].active == True
+    assert runners[0].active is True
     assert runners[0].id == 6
     assert runners[0].name == "test-name"
     assert len(runners) == 1
@@ -216,7 +216,7 @@ def test_project_runners_list(gl: gitlab.Gitlab, resp_get_runners_list):
 
 def test_group_runners_list(gl: gitlab.Gitlab, resp_get_runners_list):
     runners = gl.groups.get(1, lazy=True).runners.list()
-    assert runners[0].active == True
+    assert runners[0].active is True
     assert runners[0].id == 6
     assert runners[0].name == "test-name"
     assert len(runners) == 1
@@ -224,7 +224,7 @@ def test_group_runners_list(gl: gitlab.Gitlab, resp_get_runners_list):
 
 def test_all_runners_list(gl: gitlab.Gitlab, resp_get_runners_list):
     runners = gl.runners.all()
-    assert runners[0].active == True
+    assert runners[0].active is True
     assert runners[0].id == 6
     assert runners[0].name == "test-name"
     assert len(runners) == 1
@@ -238,7 +238,7 @@ def test_create_runner(gl: gitlab.Gitlab, resp_runner_register):
 
 def test_get_update_runner(gl: gitlab.Gitlab, resp_runner_detail):
     runner = gl.runners.get(6)
-    assert runner.active == True
+    assert runner.active is True
     runner.tag_list.append("new")
     runner.save()
 
@@ -259,14 +259,14 @@ def test_disable_group_runner(gl: gitlab.Gitlab, resp_runner_disable):
 
 def test_enable_project_runner(gl: gitlab.Gitlab, resp_runner_enable):
     runner = gl.projects.get(1, lazy=True).runners.create({"runner_id": 6})
-    assert runner.active == True
+    assert runner.active is True
     assert runner.id == 6
     assert runner.name == "test-name"
 
 
 def test_enable_group_runner(gl: gitlab.Gitlab, resp_runner_enable):
     runner = gl.groups.get(1, lazy=True).runners.create({"runner_id": 6})
-    assert runner.active == True
+    assert runner.active is True
     assert runner.id == 6
     assert runner.name == "test-name"
 

--- a/gitlab/tests/objects/test_submodules.py
+++ b/gitlab/tests/objects/test_submodules.py
@@ -4,8 +4,6 @@ GitLab API: https://docs.gitlab.com/ce/api/repository_submodules.html
 import pytest
 import responses
 
-from gitlab.v4.objects import Project
-
 
 @pytest.fixture
 def resp_update_submodule():

--- a/gitlab/tests/test_base.py
+++ b/gitlab/tests/test_base.py
@@ -92,7 +92,7 @@ class TestRESTObject:
         assert isinstance(unpickled, FakeObject)
         assert hasattr(unpickled, "_module")
         assert unpickled._module == original_obj_module
-        pickled2 = pickle.dumps(unpickled)
+        pickle.dumps(unpickled)
 
     def test_attrs(self, fake_manager):
         obj = FakeObject(fake_manager, {"foo": "bar"})

--- a/gitlab/tests/test_base.py
+++ b/gitlab/tests/test_base.py
@@ -80,7 +80,7 @@ class TestRESTObject:
 
         assert {"foo": "bar"} == obj._attrs
         assert {} == obj._updated_attrs
-        assert None == obj._create_managers()
+        assert obj._create_managers() is None
         assert fake_manager == obj.manager
         assert fake_gitlab == obj.manager.gitlab
 
@@ -112,7 +112,7 @@ class TestRESTObject:
         assert 42 == obj.get_id()
 
         obj.id = None
-        assert None == obj.get_id()
+        assert obj.get_id() is None
 
     def test_custom_id_attr(self, fake_manager):
         class OtherFakeObject(FakeObject):

--- a/gitlab/tests/test_config.py
+++ b/gitlab/tests/test_config.py
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import unittest
 from textwrap import dedent
 
 import mock

--- a/gitlab/tests/test_config.py
+++ b/gitlab/tests/test_config.py
@@ -156,7 +156,7 @@ def test_valid_data(m_open, path_exists):
     assert "ABCDEF" == cp.private_token
     assert None == cp.oauth_token
     assert 2 == cp.timeout
-    assert True == cp.ssl_verify
+    assert cp.ssl_verify is True
     assert cp.per_page is None
 
     fd = io.StringIO(valid_config)
@@ -168,7 +168,7 @@ def test_valid_data(m_open, path_exists):
     assert "GHIJKL" == cp.private_token
     assert None == cp.oauth_token
     assert 10 == cp.timeout
-    assert False == cp.ssl_verify
+    assert cp.ssl_verify is False
 
     fd = io.StringIO(valid_config)
     fd.close = mock.Mock(return_value=None)
@@ -191,7 +191,7 @@ def test_valid_data(m_open, path_exists):
     assert None == cp.private_token
     assert "STUV" == cp.oauth_token
     assert 2 == cp.timeout
-    assert True == cp.ssl_verify
+    assert cp.ssl_verify is True
 
 
 @mock.patch("os.path.exists")

--- a/gitlab/tests/test_config.py
+++ b/gitlab/tests/test_config.py
@@ -154,7 +154,7 @@ def test_valid_data(m_open, path_exists):
     assert "one" == cp.gitlab_id
     assert "http://one.url" == cp.url
     assert "ABCDEF" == cp.private_token
-    assert None == cp.oauth_token
+    assert cp.oauth_token is None
     assert 2 == cp.timeout
     assert cp.ssl_verify is True
     assert cp.per_page is None
@@ -166,7 +166,7 @@ def test_valid_data(m_open, path_exists):
     assert "two" == cp.gitlab_id
     assert "https://two.url" == cp.url
     assert "GHIJKL" == cp.private_token
-    assert None == cp.oauth_token
+    assert cp.oauth_token is None
     assert 10 == cp.timeout
     assert cp.ssl_verify is False
 
@@ -177,7 +177,7 @@ def test_valid_data(m_open, path_exists):
     assert "three" == cp.gitlab_id
     assert "https://three.url" == cp.url
     assert "MNOPQR" == cp.private_token
-    assert None == cp.oauth_token
+    assert cp.oauth_token is None
     assert 2 == cp.timeout
     assert "/path/to/CA/bundle.crt" == cp.ssl_verify
     assert 50 == cp.per_page
@@ -188,7 +188,7 @@ def test_valid_data(m_open, path_exists):
     cp = config.GitlabConfigParser(gitlab_id="four")
     assert "four" == cp.gitlab_id
     assert "https://four.url" == cp.url
-    assert None == cp.private_token
+    assert cp.private_token is None
     assert "STUV" == cp.oauth_token
     assert 2 == cp.timeout
     assert cp.ssl_verify is True
@@ -227,7 +227,7 @@ def test_data_from_helper(m_open, path_exists, tmp_path):
     cp = config.GitlabConfigParser(gitlab_id="helper")
     assert "helper" == cp.gitlab_id
     assert "https://helper.url" == cp.url
-    assert None == cp.private_token
+    assert cp.private_token is None
     assert "secret" == cp.oauth_token
 
 

--- a/gitlab/tests/test_gitlab.py
+++ b/gitlab/tests/test_gitlab.py
@@ -86,10 +86,10 @@ def test_gitlab_build_list(gl):
     assert obj.total == 2
 
     with HTTMock(resp_page_2):
-        l = list(obj)
-    assert len(l) == 2
-    assert l[0]["a"] == "b"
-    assert l[1]["c"] == "d"
+        test_list = list(obj)
+    assert len(test_list) == 2
+    assert test_list[0]["a"] == "b"
+    assert test_list[1]["c"] == "d"
 
 
 @with_httmock(resp_page_1, resp_page_2)

--- a/gitlab/tests/test_gitlab_http_methods.py
+++ b/gitlab/tests/test_gitlab_http_methods.py
@@ -219,7 +219,7 @@ def test_delete_request(gl):
     with HTTMock(resp_cont):
         result = gl.http_delete("/projects")
         assert isinstance(result, requests.Response)
-        assert result.json() == True
+        assert result.json() is True
 
 
 def test_delete_request_404(gl):

--- a/gitlab/tests/test_gitlab_http_methods.py
+++ b/gitlab/tests/test_gitlab_http_methods.py
@@ -3,7 +3,7 @@ import requests
 
 from httmock import HTTMock, urlmatch, response
 
-from gitlab import *
+from gitlab import GitlabHttpError, GitlabList, GitlabParsingError
 
 
 def test_build_url(gl):

--- a/gitlab/v4/objects/commits.py
+++ b/gitlab/v4/objects/commits.py
@@ -2,7 +2,7 @@ from gitlab import cli
 from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import CreateMixin, ListMixin, RefreshMixin, RetrieveMixin
-from .discussions import ProjectCommitDiscussionManager
+from .discussions import ProjectCommitDiscussionManager  # noqa: F401
 
 
 __all__ = [

--- a/gitlab/v4/objects/discussions.py
+++ b/gitlab/v4/objects/discussions.py
@@ -1,6 +1,6 @@
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import CreateMixin, RetrieveMixin, SaveMixin, UpdateMixin
-from .notes import (
+from .notes import (  # noqa: F401
     ProjectCommitDiscussionNoteManager,
     ProjectIssueDiscussionNoteManager,
     ProjectMergeRequestDiscussionNoteManager,

--- a/gitlab/v4/objects/epics.py
+++ b/gitlab/v4/objects/epics.py
@@ -10,7 +10,7 @@ from gitlab.mixins import (
     SaveMixin,
     UpdateMixin,
 )
-from .events import GroupEpicResourceLabelEventManager
+from .events import GroupEpicResourceLabelEventManager  # noqa: F401
 
 
 __all__ = [

--- a/gitlab/v4/objects/events.py
+++ b/gitlab/v4/objects/events.py
@@ -1,4 +1,3 @@
-from gitlab import exceptions as exc
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import ListMixin, RetrieveMixin
 

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -2,25 +2,25 @@ from gitlab import cli, types
 from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ListMixin, ObjectDeleteMixin, SaveMixin
-from .access_requests import GroupAccessRequestManager
-from .audit_events import GroupAuditEventManager
-from .badges import GroupBadgeManager
-from .boards import GroupBoardManager
-from .custom_attributes import GroupCustomAttributeManager
-from .export_import import GroupExportManager, GroupImportManager
-from .epics import GroupEpicManager
-from .issues import GroupIssueManager
-from .labels import GroupLabelManager
-from .members import GroupMemberManager
-from .merge_requests import GroupMergeRequestManager
-from .milestones import GroupMilestoneManager
-from .notification_settings import GroupNotificationSettingsManager
-from .packages import GroupPackageManager
-from .projects import GroupProjectManager
-from .runners import GroupRunnerManager
-from .variables import GroupVariableManager
-from .clusters import GroupClusterManager
-from .deploy_tokens import GroupDeployTokenManager
+from .access_requests import GroupAccessRequestManager  # noqa: F401
+from .audit_events import GroupAuditEventManager  # noqa: F401
+from .badges import GroupBadgeManager  # noqa: F401
+from .boards import GroupBoardManager  # noqa: F401
+from .custom_attributes import GroupCustomAttributeManager  # noqa: F401
+from .export_import import GroupExportManager, GroupImportManager  # noqa: F401
+from .epics import GroupEpicManager  # noqa: F401
+from .issues import GroupIssueManager  # noqa: F401
+from .labels import GroupLabelManager  # noqa: F401
+from .members import GroupMemberManager  # noqa: F401
+from .merge_requests import GroupMergeRequestManager  # noqa: F401
+from .milestones import GroupMilestoneManager  # noqa: F401
+from .notification_settings import GroupNotificationSettingsManager  # noqa: F401
+from .packages import GroupPackageManager  # noqa: F401
+from .projects import GroupProjectManager  # noqa: F401
+from .runners import GroupRunnerManager  # noqa: F401
+from .variables import GroupVariableManager  # noqa: F401
+from .clusters import GroupClusterManager  # noqa: F401
+from .deploy_tokens import GroupDeployTokenManager  # noqa: F401
 
 
 __all__ = [

--- a/gitlab/v4/objects/issues.py
+++ b/gitlab/v4/objects/issues.py
@@ -15,13 +15,13 @@ from gitlab.mixins import (
     TodoMixin,
     UserAgentDetailMixin,
 )
-from .award_emojis import ProjectIssueAwardEmojiManager
-from .discussions import ProjectIssueDiscussionManager
-from .events import (
+from .award_emojis import ProjectIssueAwardEmojiManager  # noqa: F401
+from .discussions import ProjectIssueDiscussionManager  # noqa: F401
+from .events import (  # noqa: F401
     ProjectIssueResourceLabelEventManager,
     ProjectIssueResourceMilestoneEventManager,
 )
-from .notes import ProjectIssueNoteManager
+from .notes import ProjectIssueNoteManager  # noqa: F401
 
 
 __all__ = [

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -14,14 +14,14 @@ from gitlab.mixins import (
 )
 from .commits import ProjectCommit, ProjectCommitManager
 from .issues import ProjectIssue, ProjectIssueManager
-from .merge_request_approvals import (
+from .merge_request_approvals import (  # noqa: F401
     ProjectMergeRequestApprovalManager,
     ProjectMergeRequestApprovalRuleManager,
 )
-from .award_emojis import ProjectMergeRequestAwardEmojiManager
-from .discussions import ProjectMergeRequestDiscussionManager
-from .notes import ProjectMergeRequestNoteManager
-from .events import (
+from .award_emojis import ProjectMergeRequestAwardEmojiManager  # noqa: F401
+from .discussions import ProjectMergeRequestDiscussionManager  # noqa: F401
+from .notes import ProjectMergeRequestNoteManager  # noqa: F401
+from .events import (  # noqa: F401
     ProjectMergeRequestResourceLabelEventManager,
     ProjectMergeRequestResourceMilestoneEventManager,
 )

--- a/gitlab/v4/objects/milestones.py
+++ b/gitlab/v4/objects/milestones.py
@@ -7,7 +7,6 @@ from .merge_requests import (
     ProjectMergeRequest,
     ProjectMergeRequestManager,
     GroupMergeRequest,
-    GroupMergeRequestManager,
 )
 
 

--- a/gitlab/v4/objects/notes.py
+++ b/gitlab/v4/objects/notes.py
@@ -1,5 +1,3 @@
-from gitlab import cli
-from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import (
     CRUDMixin,
@@ -11,7 +9,7 @@ from gitlab.mixins import (
     SaveMixin,
     UpdateMixin,
 )
-from .award_emojis import (
+from .award_emojis import (  # noqa: F401
     ProjectIssueNoteAwardEmojiManager,
     ProjectMergeRequestNoteAwardEmojiManager,
     ProjectSnippetNoteAwardEmojiManager,

--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -1,4 +1,4 @@
-from gitlab import cli, types
+from gitlab import cli
 from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import (

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -11,55 +11,58 @@ from gitlab.mixins import (
     UpdateMixin,
 )
 
-from .project_access_tokens import ProjectAccessTokenManager
-from .access_requests import ProjectAccessRequestManager
-from .badges import ProjectBadgeManager
-from .boards import ProjectBoardManager
-from .branches import ProjectBranchManager, ProjectProtectedBranchManager
-from .clusters import ProjectClusterManager
-from .commits import ProjectCommitManager
-from .container_registry import ProjectRegistryRepositoryManager
-from .custom_attributes import ProjectCustomAttributeManager
-from .deploy_keys import ProjectKeyManager
-from .deploy_tokens import ProjectDeployTokenManager
-from .deployments import ProjectDeploymentManager
-from .environments import ProjectEnvironmentManager
-from .events import ProjectEventManager
-from .audit_events import ProjectAuditEventManager
-from .export_import import ProjectExportManager, ProjectImportManager
-from .files import ProjectFileManager
-from .hooks import ProjectHookManager
-from .issues import ProjectIssueManager
-from .jobs import ProjectJobManager
-from .labels import ProjectLabelManager
-from .members import ProjectMemberManager
-from .merge_request_approvals import ProjectApprovalManager, ProjectApprovalRuleManager
-from .merge_requests import ProjectMergeRequestManager
-from .milestones import ProjectMilestoneManager
-from .notes import ProjectNoteManager
-from .notification_settings import ProjectNotificationSettingsManager
-from .packages import ProjectPackageManager
-from .pages import ProjectPagesDomainManager
-from .pipelines import (
+from .project_access_tokens import ProjectAccessTokenManager  # noqa: F401
+from .access_requests import ProjectAccessRequestManager  # noqa: F401
+from .badges import ProjectBadgeManager  # noqa: F401
+from .boards import ProjectBoardManager  # noqa: F401
+from .branches import ProjectBranchManager, ProjectProtectedBranchManager  # noqa: F401
+from .clusters import ProjectClusterManager  # noqa: F401
+from .commits import ProjectCommitManager  # noqa: F401
+from .container_registry import ProjectRegistryRepositoryManager  # noqa: F401
+from .custom_attributes import ProjectCustomAttributeManager  # noqa: F401
+from .deploy_keys import ProjectKeyManager  # noqa: F401
+from .deploy_tokens import ProjectDeployTokenManager  # noqa: F401
+from .deployments import ProjectDeploymentManager  # noqa: F401
+from .environments import ProjectEnvironmentManager  # noqa: F401
+from .events import ProjectEventManager  # noqa: F401
+from .audit_events import ProjectAuditEventManager  # noqa: F401
+from .export_import import ProjectExportManager, ProjectImportManager  # noqa: F401
+from .files import ProjectFileManager  # noqa: F401
+from .hooks import ProjectHookManager  # noqa: F401
+from .issues import ProjectIssueManager  # noqa: F401
+from .jobs import ProjectJobManager  # noqa: F401
+from .labels import ProjectLabelManager  # noqa: F401
+from .members import ProjectMemberManager  # noqa: F401
+from .merge_request_approvals import (  # noqa: F401
+    ProjectApprovalManager,
+    ProjectApprovalRuleManager,
+)
+from .merge_requests import ProjectMergeRequestManager  # noqa: F401
+from .milestones import ProjectMilestoneManager  # noqa: F401
+from .notes import ProjectNoteManager  # noqa: F401
+from .notification_settings import ProjectNotificationSettingsManager  # noqa: F401
+from .packages import ProjectPackageManager  # noqa: F401
+from .pages import ProjectPagesDomainManager  # noqa: F401
+from .pipelines import (  # noqa: F401
     ProjectPipeline,
     ProjectPipelineManager,
     ProjectPipelineScheduleManager,
 )
-from .push_rules import ProjectPushRulesManager
-from .releases import ProjectReleaseManager
+from .push_rules import ProjectPushRulesManager  # noqa: F401
+from .releases import ProjectReleaseManager  # noqa: F401
 from .repositories import RepositoryMixin
-from .runners import ProjectRunnerManager
-from .services import ProjectServiceManager
-from .snippets import ProjectSnippetManager
-from .statistics import (
+from .runners import ProjectRunnerManager  # noqa: F401
+from .services import ProjectServiceManager  # noqa: F401
+from .snippets import ProjectSnippetManager  # noqa: F401
+from .statistics import (  # noqa: F401
     ProjectAdditionalStatisticsManager,
     ProjectIssuesStatisticsManager,
 )
-from .tags import ProjectProtectedTagManager, ProjectTagManager
-from .triggers import ProjectTriggerManager
-from .users import ProjectUserManager
-from .variables import ProjectVariableManager
-from .wikis import ProjectWikiManager
+from .tags import ProjectProtectedTagManager, ProjectTagManager  # noqa: F401
+from .triggers import ProjectTriggerManager  # noqa: F401
+from .users import ProjectUserManager  # noqa: F401
+from .variables import ProjectVariableManager  # noqa: F401
+from .wikis import ProjectWikiManager  # noqa: F401
 
 
 __all__ = [

--- a/gitlab/v4/objects/releases.py
+++ b/gitlab/v4/objects/releases.py
@@ -1,5 +1,3 @@
-from gitlab import cli
-from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, NoUpdateMixin, ObjectDeleteMixin, SaveMixin
 

--- a/gitlab/v4/objects/repositories.py
+++ b/gitlab/v4/objects/repositories.py
@@ -4,7 +4,7 @@ GitLab API: https://docs.gitlab.com/ee/api/repositories.html
 Currently this module only contains repository-related methods for projects.
 """
 
-from gitlab import cli, types, utils
+from gitlab import cli, utils
 from gitlab import exceptions as exc
 
 

--- a/gitlab/v4/objects/services.py
+++ b/gitlab/v4/objects/services.py
@@ -1,5 +1,4 @@
 from gitlab import cli
-from gitlab import exceptions as exc
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     DeleteMixin,

--- a/gitlab/v4/objects/snippets.py
+++ b/gitlab/v4/objects/snippets.py
@@ -3,9 +3,9 @@ from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin, UserAgentDetailMixin
 
-from .award_emojis import ProjectSnippetAwardEmojiManager
-from .discussions import ProjectSnippetDiscussionManager
-from .notes import ProjectSnippetNoteManager, ProjectSnippetDiscussionNoteManager
+from .award_emojis import ProjectSnippetAwardEmojiManager  # noqa: F401
+from .discussions import ProjectSnippetDiscussionManager  # noqa: F401
+from .notes import ProjectSnippetNoteManager  # noqa: F401
 
 
 __all__ = [

--- a/gitlab/v4/objects/todos.py
+++ b/gitlab/v4/objects/todos.py
@@ -48,4 +48,4 @@ class TodoManager(ListMixin, DeleteMixin, RESTManager):
         Returns:
             int: The number of todos maked done
         """
-        result = self.gitlab.http_post("/todos/mark_as_done", **kwargs)
+        self.gitlab.http_post("/todos/mark_as_done", **kwargs)

--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -14,8 +14,8 @@ from gitlab.mixins import (
     UpdateMixin,
 )
 
-from .custom_attributes import UserCustomAttributeManager
-from .events import UserEventManager
+from .custom_attributes import UserCustomAttributeManager  # noqa: F401
+from .events import UserEventManager  # noqa: F401
 
 
 __all__ = [

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,8 @@ commands = {posargs}
 exclude = .git,.venv,.tox,dist,doc,*egg,build,
 max-line-length = 88
 ignore = E501,H501,H803,W503
+per-file-ignores =
+    gitlab/v4/objects/__init__.py:F401,F403
 
 [testenv:docs]
 deps = -r{toxinidir}/rtd-requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,11 @@ commands = {posargs}
 [flake8]
 exclude = .git,.venv,.tox,dist,doc,*egg,build,
 max-line-length = 88
-ignore = E501,H501,H803,W503
+# We ignore the following because we use black to handle code-formatting
+# E203: Whitespace before ':'
+# E501: Line too long
+# W503: Line break occurred before a binary operator
+ignore = E203,E501,W503
 per-file-ignores =
     gitlab/v4/objects/__init__.py:F401,F403
 


### PR DESCRIPTION
Fixed all the issues reported by `flake8` when running `tox -e pep8`.

Separated them into individual commits for fixing different reported `flake8` errors.

Finally enabled the `tox -e pep8` to run as part of the CI linting process.

# NOTE

In the F841 patch, I deleted the line:
`parser = _get_base_parser(add_help=False)`

As it doesn't seem have any impact. Please correct me if I am wrong.

---

Closes https://github.com/python-gitlab/python-gitlab/issues/1368.