### PR TITLE
fix: argument type was not a tuple as expected

### DIFF
--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -234,7 +234,7 @@ class ProjectMergeRequest(
         path = "%s/%s/pipelines" % (self.manager.path, self.get_id())
         return self.manager.gitlab.http_get(path, **kwargs)
 
-    @cli.register_custom_action("ProjectMergeRequest", tuple(), ("sha"))
+    @cli.register_custom_action("ProjectMergeRequest", tuple(), ("sha",))
     @exc.on_http_error(exc.GitlabMRApprovalError)
     def approve(self, sha=None, **kwargs):
         """Approve the merge request.


### PR DESCRIPTION
While adding type-hints mypy flagged this as an issue. The third
argument to register_custom_action is supposed to be a tuple. It was
being passed as a string rather than a tuple of strings.