### PR TITLE
chore: remove unused function sanitize_parameters()

### DIFF
--- a/gitlab/tests/test_utils.py
+++ b/gitlab/tests/test_utils.py
@@ -40,23 +40,3 @@ def test_sanitized_url():
     src = "http://localhost/foo.bar.baz"
     dest = "http://localhost/foo%2Ebar%2Ebaz"
     assert dest == utils.sanitized_url(src)
-
-
-def test_sanitize_parameters_does_nothing():
-    assert 1 == utils.sanitize_parameters(1)
-    assert 1.5 == utils.sanitize_parameters(1.5)
-    assert "foo" == utils.sanitize_parameters("foo")
-
-
-def test_sanitize_parameters_slash():
-    assert "foo%2Fbar" == utils.sanitize_parameters("foo/bar")
-
-
-def test_sanitize_parameters_slash_and_percent():
-    assert "foo%2Fbar%25quuz" == utils.sanitize_parameters("foo/bar%quuz")
-
-
-def test_sanitize_parameters_dict():
-    source = {"url": "foo/bar", "id": 1}
-    expected = {"url": "foo%2Fbar", "id": 1}
-    assert expected == utils.sanitize_parameters(source)

--- a/gitlab/utils.py
+++ b/gitlab/utils.py
@@ -60,14 +60,6 @@ def clean_str_id(id: str) -> str:
     return quote(id, safe="")
 
 
-def sanitize_parameters(value):
-    if isinstance(value, dict):
-        return dict((k, sanitize_parameters(v)) for k, v in value.items())
-    if isinstance(value, str):
-        return quote(value, safe="")
-    return value
-
-
 def sanitized_url(url: str) -> str:
     parsed = urlparse(url)
     new_path = parsed.path.replace(".", "%2E")


### PR DESCRIPTION
The function sanitize_parameters() was used when the v3 API was in
use. Since v3 API support has been removed there are no more users of
this function.