### PR TITLE
fix: update user's bool data and avatar

### DIFF
--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -505,6 +505,12 @@ class Gitlab(object):
             json = None
             if post_data is None:
                 post_data = {}
+            else:
+                # booleans does not exists for data (neither for MultipartEncoder):
+                # cast to string int to avoid: 'bool' object has no attribute 'encode'
+                for k, v in post_data.items():
+                    if isinstance(v, bool):
+                        post_data[k] = str(int(v))
             post_data["file"] = files.get("file")
             post_data["avatar"] = files.get("avatar")
             data = MultipartEncoder(post_data)


### PR DESCRIPTION
Hi !

If we want to update email, avatar and do not send email confirmation change (`skip_reconfirmation` = True), `MultipartEncoder` will try to encode everything except None and bytes. So it tries to encode bools. 

Casting bool's values to their stringified int representation fix it.

Exemple to reproduce it:

```
user.skip_reconfirmation = True
user.email = user_data['email']
user.avatar = b'\xff\xd8\xff\xdb\x00C\x00\x06\x04\x0...'
user.save()
```