### PR TITLE
fix: correct ProjectFile.decode() documentation

### DIFF
--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -22,11 +22,11 @@ class ProjectFile(SaveMixin, ObjectDeleteMixin, RESTObject):
     _id_attr = "file_path"
     _short_print_attr = "file_path"
 
-    def decode(self):
+    def decode(self) -> bytes:
         """Returns the decoded content of the file.
 
         Returns:
-            (str): the decoded content.
+            (bytes): the decoded content.
         """
         return base64.b64decode(self.content)
 


### PR DESCRIPTION
ProjectFile.decode() returns 'bytes' and not 'str'.

Update the method's doc-string and add a type-hint.

ProjectFile.decode() returns the result of a call to
base64.b64decode()

The docs for that function state it returns 'bytes':
https://docs.python.org/3/library/base64.html#base64.b64decode

Fixes: #1403