### PR TITLE
chore: mypy: Disallow untyped definitions

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -4,3 +4,6 @@ files = gitlab/*.py
 # disallow_incomplete_defs: This flag reports an error whenever it encounters a
 # partly annotated function definition.
 disallow_incomplete_defs = True
+# disallow_untyped_defs: This flag reports an error whenever it encounters a
+# function without type annotations or with incomplete type annotations.
+disallow_untyped_defs = True

--- a/gitlab/__main__.py
+++ b/gitlab/__main__.py
@@ -1,4 +1,5 @@
 import gitlab.cli
 
 
-__name__ == "__main__" and gitlab.cli.main()
+if __name__ == "__main__":
+    gitlab.cli.main()

--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -17,7 +17,7 @@
 
 import importlib
 from types import ModuleType
-from typing import Any, Dict, NamedTuple, Optional, Tuple, Type
+from typing import Any, Dict, Iterable, NamedTuple, Optional, Tuple, Type
 
 from .client import Gitlab, GitlabList
 from gitlab import types as g_types
@@ -133,8 +133,8 @@ class RESTObject(object):
             return self.get_id() != other.get_id()
         return super(RESTObject, self) != other
 
-    def __dir__(self):
-        return super(RESTObject, self).__dir__() | self.attributes.keys()
+    def __dir__(self) -> Iterable[str]:
+        return set(self.attributes).union(super(RESTObject, self).__dir__())
 
     def __hash__(self) -> int:
         if not self.get_id():
@@ -155,7 +155,7 @@ class RESTObject(object):
         self.__dict__["_updated_attrs"] = {}
         self.__dict__["_attrs"] = new_attrs
 
-    def get_id(self):
+    def get_id(self) -> Any:
         """Returns the id of the resource."""
         if self._id_attr is None or not hasattr(self, self._id_attr):
             return None
@@ -207,10 +207,10 @@ class RESTObjectList(object):
     def __len__(self) -> int:
         return len(self._list)
 
-    def __next__(self):
+    def __next__(self) -> RESTObject:
         return self.next()
 
-    def next(self):
+    def next(self) -> RESTObject:
         data = self._list.next()
         return self._obj_cls(self.manager, data)
 

--- a/gitlab/config.py
+++ b/gitlab/config.py
@@ -206,7 +206,7 @@ class GitlabConfigParser(object):
         except Exception:
             pass
 
-    def _get_values_from_helper(self):
+    def _get_values_from_helper(self) -> None:
         """Update attributes that may get values from an external helper program"""
         for attr in HELPER_ATTRIBUTES:
             value = getattr(self, attr)

--- a/gitlab/tests/test_cli.py
+++ b/gitlab/tests/test_cli.py
@@ -26,7 +26,6 @@ from contextlib import redirect_stderr  # noqa: H302
 import pytest
 
 from gitlab import cli
-import gitlab.v4.cli
 
 
 def test_what_to_cls():
@@ -94,14 +93,14 @@ def test_base_parser():
 
 
 def test_v4_parse_args():
-    parser = cli._get_parser(gitlab.v4.cli)
+    parser = cli._get_parser()
     args = parser.parse_args(["project", "list"])
     assert args.what == "project"
     assert args.whaction == "list"
 
 
 def test_v4_parser():
-    parser = cli._get_parser(gitlab.v4.cli)
+    parser = cli._get_parser()
     subparsers = next(
         action
         for action in parser._actions

--- a/gitlab/types.py
+++ b/gitlab/types.py
@@ -15,46 +15,50 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Any, Optional, TYPE_CHECKING
+
 
 class GitlabAttribute(object):
-    def __init__(self, value=None):
+    def __init__(self, value: Any = None) -> None:
         self._value = value
 
-    def get(self):
+    def get(self) -> Any:
         return self._value
 
-    def set_from_cli(self, cli_value):
+    def set_from_cli(self, cli_value: Any) -> None:
         self._value = cli_value
 
-    def get_for_api(self):
+    def get_for_api(self) -> Any:
         return self._value
 
 
 class ListAttribute(GitlabAttribute):
-    def set_from_cli(self, cli_value):
+    def set_from_cli(self, cli_value: str) -> None:
         if not cli_value.strip():
             self._value = []
         else:
             self._value = [item.strip() for item in cli_value.split(",")]
 
-    def get_for_api(self):
+    def get_for_api(self) -> str:
         # Do not comma-split single value passed as string
         if isinstance(self._value, str):
             return self._value
 
+        if TYPE_CHECKING:
+            assert isinstance(self._value, list)
         return ",".join([str(x) for x in self._value])
 
 
 class LowercaseStringAttribute(GitlabAttribute):
-    def get_for_api(self):
+    def get_for_api(self) -> str:
         return str(self._value).lower()
 
 
 class FileAttribute(GitlabAttribute):
-    def get_file_name(self, attr_name=None):
+    def get_file_name(self, attr_name: Optional[str] = None) -> Optional[str]:
         return attr_name
 
 
 class ImageAttribute(FileAttribute):
-    def get_file_name(self, attr_name=None):
+    def get_file_name(self, attr_name: Optional[str] = None) -> str:
         return "%s.png" % attr_name if attr_name else "image.png"


### PR DESCRIPTION
Be more strict and don't allow untyped definitions on the files we
check.

Also this adds type-hints for two of the decorators so that now
functions/methods decorated by them will have their types be revealed
correctly.