### PR TITLE
chore: make RESTObject._short_print_attrs always present

### DIFF
--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -45,6 +45,7 @@ class RESTObject(object):
     _attrs: Dict[str, Any]
     _module: ModuleType
     _parent_attrs: Dict[str, Any]
+    _short_print_attr: Optional[str] = None
     _updated_attrs: Dict[str, Any]
     manager: "RESTManager"
 

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -380,7 +380,7 @@ class LegacyPrinter(object):
             if obj._id_attr:
                 id = getattr(obj, obj._id_attr)
                 print("%s: %s" % (obj._id_attr.replace("_", "-"), id))
-            if hasattr(obj, "_short_print_attr"):
+            if obj._short_print_attr:
                 value = getattr(obj, obj._short_print_attr) or "None"
                 value = value.replace("\r", "").replace("\n", " ")
                 # If the attribute is a note (ProjectCommitComment) then we do


### PR DESCRIPTION
Always create RESTObject._short_print_attrs with a default value of
None.

This way we don't need to use hasattr() and we will know the type of
the attribute.