### PR TITLE
chore: make ListMixin._list_filters always present

### DIFF
--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -22,6 +22,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Tuple,
     Type,
     TYPE_CHECKING,
     Union,
@@ -186,6 +187,7 @@ class RefreshMixin(_RestObjectBase):
 class ListMixin(_RestManagerBase):
     _computed_path: Optional[str]
     _from_parent_attrs: Dict[str, Any]
+    _list_filters: Tuple[str, ...] = ()
     _obj_cls: Optional[Type[base.RESTObject]]
     _parent: Optional[base.RESTObject]
     _parent_attrs: Dict[str, Any]

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -145,13 +145,10 @@ def _populate_sub_parser_by_class(cls, sub_parser):
                 )
 
         if action_name == "list":
-            if hasattr(mgr_cls, "_list_filters"):
-                [
-                    sub_parser_action.add_argument(
-                        "--%s" % x.replace("_", "-"), required=False
-                    )
-                    for x in mgr_cls._list_filters
-                ]
+            for x in mgr_cls._list_filters:
+                sub_parser_action.add_argument(
+                    "--%s" % x.replace("_", "-"), required=False
+                )
 
             sub_parser_action.add_argument("--page", required=False)
             sub_parser_action.add_argument("--per-page", required=False)


### PR DESCRIPTION
Always create ListMixin._list_filters attribute with a default value
of tuple().

This way we don't need to use hasattr() and we will know the type of
the attribute.