### PR TITLE
chore: make Get.*Mixin._optional_get_attrs always present

### DIFF
--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -22,6 +22,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Tuple,
     Type,
     TYPE_CHECKING,
     Union,
@@ -74,6 +75,7 @@ class GetMixin(_RestManagerBase):
     _computed_path: Optional[str]
     _from_parent_attrs: Dict[str, Any]
     _obj_cls: Optional[Type[base.RESTObject]]
+    _optional_get_attrs: Tuple[str, ...] = ()
     _parent: Optional[base.RESTObject]
     _parent_attrs: Dict[str, Any]
     _path: Optional[str]
@@ -118,6 +120,7 @@ class GetWithoutIdMixin(_RestManagerBase):
     _computed_path: Optional[str]
     _from_parent_attrs: Dict[str, Any]
     _obj_cls: Optional[Type[base.RESTObject]]
+    _optional_get_attrs: Tuple[str, ...] = ()
     _parent: Optional[base.RESTObject]
     _parent_attrs: Dict[str, Any]
     _path: Optional[str]

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -168,13 +168,10 @@ def _populate_sub_parser_by_class(cls, sub_parser):
                     id_attr = cls._id_attr.replace("_", "-")
                     sub_parser_action.add_argument("--%s" % id_attr, required=True)
 
-            if hasattr(mgr_cls, "_optional_get_attrs"):
-                [
-                    sub_parser_action.add_argument(
-                        "--%s" % x.replace("_", "-"), required=False
-                    )
-                    for x in mgr_cls._optional_get_attrs
-                ]
+            for x in mgr_cls._optional_get_attrs:
+                sub_parser_action.add_argument(
+                    "--%s" % x.replace("_", "-"), required=False
+                )
 
         if action_name == "create":
             for x in mgr_cls._create_attrs.required:


### PR DESCRIPTION
Always create GetMixin/GetWithoutIdMixin._optional_get_attrs attribute
with a default value of tuple()


This way we don't need to use hasattr() and we will know the type of
the attribute.