### PR TITLE
fix: iids not working as a list in projects.issues.list()

### DIFF
--- a/gitlab/v4/objects/issues.py
+++ b/gitlab/v4/objects/issues.py
@@ -220,7 +220,7 @@ class ProjectIssueManager(CRUDMixin, RESTManager):
             "discussion_locked",
         ),
     )
-    _types = {"labels": types.ListAttribute}
+    _types = {"iids": types.ListAttribute, "labels": types.ListAttribute}
 
 
 class ProjectIssueLink(ObjectDeleteMixin, RESTObject):

--- a/tools/functional/api/test_issues.py
+++ b/tools/functional/api/test_issues.py
@@ -4,7 +4,11 @@ import gitlab
 def test_create_issue(project):
     issue = project.issues.create({"title": "my issue 1"})
     issue2 = project.issues.create({"title": "my issue 2"})
-    assert len(project.issues.list()) == 2
+    issue_ids = [issue.id for issue in project.issues.list()]
+    assert len(issue_ids) == 2
+
+    # Test 'iids' as a list
+    assert len(project.issues.list(iids=issue_ids)) == 2
 
     issue2.state_event = "close"
     issue2.save()


### PR DESCRIPTION
Set the 'iids' values as type ListAttribute so it will pass the list
as a comma-separated string, instead of a list.

Closes: #1407