### PR TITLE
feat: add support for lists of integers to ListAttribute

### DIFF
--- a/gitlab/tests/test_types.py
+++ b/gitlab/tests/test_types.py
@@ -59,6 +59,11 @@ def test_list_attribute_get_for_api_from_list():
     assert o.get_for_api() == "foo,bar,baz"
 
 
+def test_list_attribute_get_for_api_from_int_list():
+    o = types.ListAttribute([1, 9, 7])
+    assert o.get_for_api() == "1,9,7"
+
+
 def test_list_attribute_does_not_split_string():
     o = types.ListAttribute("foo")
     assert o.get_for_api() == "foo"

--- a/gitlab/types.py
+++ b/gitlab/types.py
@@ -42,7 +42,7 @@ class ListAttribute(GitlabAttribute):
         if isinstance(self._value, str):
             return self._value
 
-        return ",".join(self._value)
+        return ",".join([str(x) for x in self._value])
 
 
 class LowercaseStringAttribute(GitlabAttribute):


### PR DESCRIPTION
Previously ListAttribute only support lists of integers. Now be more
flexible and support lists of items which can be coerced into strings,
for example integers.

This will help us fix issue #1407 by using ListAttribute for the
'iids' field.