### PR TITLE
fix(files): do not url-encode filepaths twice

### DIFF
--- a/gitlab/__version__.py
+++ b/gitlab/__version__.py
@@ -3,4 +3,4 @@ __copyright__ = "Copyright 2013-2019 Gauvain Pocentek, 2019-2021 python-gitlab t
 __email__ = "gauvainpocentek@gmail.com"
 __license__ = "LGPL3"
 __title__ = "python-gitlab"
-__version__ = "2.7.0"
+__version__ = "2.7.1"

--- a/gitlab/tests/objects/test_repositories.py
+++ b/gitlab/tests/objects/test_repositories.py
@@ -1,0 +1,49 @@
+"""
+GitLab API:
+https://docs.gitlab.com/ee/api/repositories.html
+https://docs.gitlab.com/ee/api/repository_files.html
+"""
+from urllib.parse import quote
+
+import pytest
+import responses
+
+from gitlab.v4.objects import ProjectFile
+
+file_path = "app/models/key.rb"
+ref = "main"
+
+
+@pytest.fixture
+def resp_get_repository_file():
+    file_response = {
+        "file_name": "key.rb",
+        "file_path": file_path,
+        "size": 1476,
+        "encoding": "base64",
+        "content": "IyA9PSBTY2hlbWEgSW5mb3...",
+        "content_sha256": "4c294617b60715c1d218e61164a3abd4808a4284cbc30e6728a01ad9aada4481",
+        "ref": ref,
+        "blob_id": "79f7bbd25901e8334750839545a9bd021f0e4c83",
+        "commit_id": "d5a3ff139356ce33e37e73add446f16869741b50",
+        "last_commit_id": "570e7b2abdd848b95f2f578043fc23bd6f6fd24d",
+    }
+
+    # requests also encodes `.`
+    encoded_path = quote(file_path, safe="").replace(".", "%2E")
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.GET,
+            url=f"http://localhost/api/v4/projects/1/repository/files/{encoded_path}",
+            json=file_response,
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
+def test_get_repository_file(project, resp_get_repository_file):
+    file = project.files.get(file_path, ref=ref)
+    assert isinstance(file, ProjectFile)
+    assert file.file_path == file_path

--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -94,7 +94,6 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         Returns:
             object: The generated RESTObject
         """
-        file_path = file_path.replace("/", "%2F")
         return GetMixin.get(self, file_path, ref=ref, **kwargs)
 
     @cli.register_custom_action(


### PR DESCRIPTION
Closes https://github.com/python-gitlab/python-gitlab/issues/1416.

This is a quick fix for 2.7.0 but we should clean up with https://github.com/python-gitlab/python-gitlab/issues/1356 eventually :)