### PR TITLE
fix(objects): make lists work for filters in all objects

### DIFF
--- a/gitlab/v4/objects/deploy_tokens.py
+++ b/gitlab/v4/objects/deploy_tokens.py
@@ -1,3 +1,4 @@
+from gitlab import types
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import CreateMixin, DeleteMixin, ListMixin, ObjectDeleteMixin
 
@@ -39,6 +40,7 @@ class GroupDeployTokenManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
             "username",
         ),
     )
+    _types = {"scopes": types.ListAttribute}
 
 
 class ProjectDeployToken(ObjectDeleteMixin, RESTObject):
@@ -59,3 +61,4 @@ class ProjectDeployTokenManager(ListMixin, CreateMixin, DeleteMixin, RESTManager
             "username",
         ),
     )
+    _types = {"scopes": types.ListAttribute}

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -244,7 +244,7 @@ class GroupManager(CRUDMixin, RESTManager):
             "default_branch_protection",
         ),
     )
-    _types = {"avatar": types.ImageAttribute}
+    _types = {"avatar": types.ImageAttribute, "skip_groups": types.ListAttribute}
 
     @exc.on_http_error(exc.GitlabImportError)
     def import_group(self, file, path, name, parent_id=None, **kwargs):
@@ -293,3 +293,4 @@ class GroupSubgroupManager(ListMixin, RESTManager):
         "owned",
         "with_custom_attributes",
     )
+    _types = {"skip_groups": types.ListAttribute}

--- a/gitlab/v4/objects/issues.py
+++ b/gitlab/v4/objects/issues.py
@@ -62,7 +62,7 @@ class IssueManager(RetrieveMixin, RESTManager):
         "updated_after",
         "updated_before",
     )
-    _types = {"labels": types.ListAttribute}
+    _types = {"iids": types.ListAttribute, "labels": types.ListAttribute}
 
 
 class GroupIssue(RESTObject):
@@ -89,7 +89,7 @@ class GroupIssueManager(ListMixin, RESTManager):
         "updated_after",
         "updated_before",
     )
-    _types = {"labels": types.ListAttribute}
+    _types = {"iids": types.ListAttribute, "labels": types.ListAttribute}
 
 
 class ProjectIssue(

--- a/gitlab/v4/objects/members.py
+++ b/gitlab/v4/objects/members.py
@@ -1,4 +1,4 @@
-from gitlab import cli
+from gitlab import cli, types
 from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
@@ -26,6 +26,7 @@ class GroupMemberManager(CRUDMixin, RESTManager):
     _update_attrs = RequiredOptional(
         required=("access_level",), optional=("expires_at",)
     )
+    _types = {"user_ids": types.ListAttribute}
 
     @cli.register_custom_action("GroupMemberManager")
     @exc.on_http_error(exc.GitlabListError)
@@ -67,6 +68,7 @@ class ProjectMemberManager(CRUDMixin, RESTManager):
     _update_attrs = RequiredOptional(
         required=("access_level",), optional=("expires_at",)
     )
+    _types = {"user_ids": types.ListAttribute}
 
     @cli.register_custom_action("ProjectMemberManager")
     @exc.on_http_error(exc.GitlabListError)

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -62,13 +62,19 @@ class MergeRequestManager(ListMixin, RESTManager):
         "scope",
         "author_id",
         "assignee_id",
+        "approver_ids",
+        "approved_by_ids",
         "my_reaction_emoji",
         "source_branch",
         "target_branch",
         "search",
         "wip",
     )
-    _types = {"labels": types.ListAttribute}
+    _types = {
+        "approver_ids": types.ListAttribute,
+        "approved_by_ids": types.ListAttribute,
+        "labels": types.ListAttribute,
+    }
 
 
 class GroupMergeRequest(RESTObject):
@@ -93,13 +99,19 @@ class GroupMergeRequestManager(ListMixin, RESTManager):
         "scope",
         "author_id",
         "assignee_id",
+        "approver_ids",
+        "approved_by_ids",
         "my_reaction_emoji",
         "source_branch",
         "target_branch",
         "search",
         "wip",
     )
-    _types = {"labels": types.ListAttribute}
+    _types = {
+        "approver_ids": types.ListAttribute,
+        "approved_by_ids": types.ListAttribute,
+        "labels": types.ListAttribute,
+    }
 
 
 class ProjectMergeRequest(
@@ -377,15 +389,23 @@ class ProjectMergeRequestManager(CRUDMixin, RESTManager):
         "updated_after",
         "updated_before",
         "scope",
+        "iids",
         "author_id",
         "assignee_id",
+        "approver_ids",
+        "approved_by_ids",
         "my_reaction_emoji",
         "source_branch",
         "target_branch",
         "search",
         "wip",
     )
-    _types = {"labels": types.ListAttribute}
+    _types = {
+        "approver_ids": types.ListAttribute,
+        "approved_by_ids": types.ListAttribute,
+        "iids": types.ListAttribute,
+        "labels": types.ListAttribute,
+    }
 
 
 class ProjectMergeRequestDiff(RESTObject):

--- a/gitlab/v4/objects/milestones.py
+++ b/gitlab/v4/objects/milestones.py
@@ -1,4 +1,4 @@
-from gitlab import cli
+from gitlab import cli, types
 from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject, RESTObjectList
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
@@ -86,6 +86,7 @@ class GroupMilestoneManager(CRUDMixin, RESTManager):
         optional=("title", "description", "due_date", "start_date", "state_event"),
     )
     _list_filters = ("iids", "state", "search")
+    _types = {"iids": types.ListAttribute}
 
 
 class ProjectMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
@@ -159,3 +160,4 @@ class ProjectMilestoneManager(CRUDMixin, RESTManager):
         optional=("title", "description", "due_date", "start_date", "state_event"),
     )
     _list_filters = ("iids", "state", "search")
+    _types = {"iids": types.ListAttribute}

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -676,7 +676,6 @@ class ProjectManager(CRUDMixin, RESTManager):
             "service_desk_enabled",
         ),
     )
-    _types = {"avatar": types.ImageAttribute}
     _list_filters = (
         "archived",
         "id_after",
@@ -695,6 +694,7 @@ class ProjectManager(CRUDMixin, RESTManager):
         "sort",
         "starred",
         "statistics",
+        "topic",
         "visibility",
         "wiki_checksum_failed",
         "with_custom_attributes",
@@ -702,6 +702,7 @@ class ProjectManager(CRUDMixin, RESTManager):
         "with_merge_requests_enabled",
         "with_programming_language",
     )
+    _types = {"avatar": types.ImageAttribute, "topic": types.ListAttribute}
 
     def import_project(
         self,

--- a/gitlab/v4/objects/runners.py
+++ b/gitlab/v4/objects/runners.py
@@ -1,4 +1,4 @@
-from gitlab import cli
+from gitlab import cli, types
 from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import (
@@ -40,7 +40,6 @@ class Runner(SaveMixin, ObjectDeleteMixin, RESTObject):
 class RunnerManager(CRUDMixin, RESTManager):
     _path = "/runners"
     _obj_cls = Runner
-    _list_filters = ("scope",)
     _create_attrs = RequiredOptional(
         required=("token",),
         optional=(
@@ -65,6 +64,8 @@ class RunnerManager(CRUDMixin, RESTManager):
             "maximum_timeout",
         ),
     )
+    _list_filters = ("scope", "tag_list")
+    _types = {"tag_list": types.ListAttribute}
 
     @cli.register_custom_action("RunnerManager", tuple(), ("scope",))
     @exc.on_http_error(exc.GitlabListError)
@@ -122,6 +123,8 @@ class GroupRunnerManager(NoUpdateMixin, RESTManager):
     _obj_cls = GroupRunner
     _from_parent_attrs = {"group_id": "id"}
     _create_attrs = RequiredOptional(required=("runner_id",))
+    _list_filters = ("scope", "tag_list")
+    _types = {"tag_list": types.ListAttribute}
 
 
 class ProjectRunner(ObjectDeleteMixin, RESTObject):
@@ -133,3 +136,5 @@ class ProjectRunnerManager(NoUpdateMixin, RESTManager):
     _obj_cls = ProjectRunner
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(required=("runner_id",))
+    _list_filters = ("scope", "tag_list")
+    _types = {"tag_list": types.ListAttribute}

--- a/gitlab/v4/objects/settings.py
+++ b/gitlab/v4/objects/settings.py
@@ -1,3 +1,4 @@
+from gitlab import types
 from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import GetWithoutIdMixin, SaveMixin, UpdateMixin
@@ -35,13 +36,18 @@ class ApplicationSettingsManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
             "default_snippet_visibility",
             "default_group_visibility",
             "outbound_local_requests_whitelist",
+            "disabled_oauth_sign_in_sources",
             "domain_whitelist",
             "domain_blacklist_enabled",
             "domain_blacklist",
+            "domain_allowlist",
+            "domain_denylist_enabled",
+            "domain_denylist",
             "external_authorization_service_enabled",
             "external_authorization_service_url",
             "external_authorization_service_default_label",
             "external_authorization_service_timeout",
+            "import_sources",
             "user_oauth_applications",
             "after_sign_out_path",
             "container_registry_token_expire_delay",
@@ -65,12 +71,21 @@ class ApplicationSettingsManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
             "asset_proxy_enabled",
             "asset_proxy_url",
             "asset_proxy_whitelist",
+            "asset_proxy_allowlist",
             "geo_node_allowed_ips",
             "allow_local_requests_from_hooks_and_services",
             "allow_local_requests_from_web_hooks_and_services",
             "allow_local_requests_from_system_hooks",
         ),
     )
+    _types = {
+        "asset_proxy_allowlist": types.ListAttribute,
+        "disabled_oauth_sign_in_sources": types.ListAttribute,
+        "domain_allowlist": types.ListAttribute,
+        "domain_denylist": types.ListAttribute,
+        "import_sources": types.ListAttribute,
+        "restricted_visibility_levels": types.ListAttribute,
+    }
 
     @exc.on_http_error(exc.GitlabUpdateError)
     def update(self, id=None, new_data=None, **kwargs):

--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -328,7 +328,8 @@ class ProjectUserManager(ListMixin, RESTManager):
     _path = "/projects/%(project_id)s/users"
     _obj_cls = ProjectUser
     _from_parent_attrs = {"project_id": "id"}
-    _list_filters = ("search",)
+    _list_filters = ("search", "skip_users")
+    _types = {"skip_users": types.ListAttribute}
 
 
 class UserEmail(ObjectDeleteMixin, RESTObject):

--- a/tools/functional/api/test_groups.py
+++ b/tools/functional/api/test_groups.py
@@ -33,6 +33,10 @@ def test_groups(gl):
     assert group3.parent_id == p_id
     assert group2.subgroups.list()[0].id == group3.id
 
+    filtered_groups = gl.groups.list(skip_groups=[group3.id, group4.id])
+    assert group3 not in filtered_groups
+    assert group3 not in filtered_groups
+
     group1.members.create(
         {"access_level": gitlab.const.OWNER_ACCESS, "user_id": user.id}
     )


### PR DESCRIPTION
Well, this was tedious :grin: Follow-up to https://github.com/python-gitlab/python-gitlab/pull/1413.

Long term I don't see this being a good idea to maintain manually. Maybe later we can just convert any list we get in the data for `ListMixin`. Either way - finding candidates was  `grep -r 'type: Array' lib/api` in the gitlab repo, and weeding out non-`GET` params and endpoints not implemented by python-gitlab:

```bash
lib/api/resource_access_tokens.rb:          requires :scopes, type: Array[String], desc: "The permissions of the token"
lib/api/deploy_tokens.rb:        requires :scopes, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, values: ::DeployToken::AVAILABLE_SCOPES.map(&:to_s),
lib/api/deploy_tokens.rb:        requires :scopes, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, values: ::DeployToken::AVAILABLE_SCOPES.map(&:to_s),
lib/api/rubygem_packages.rb:            optional :gems, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, desc: 'Comma delimited gem names'
lib/api/releases.rb:          optional :links, type: Array do
lib/api/releases.rb:        optional :milestones, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, desc: 'The titles of the related milestones', default: []
lib/api/releases.rb:        optional :milestones,  type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, desc: 'The titles of the related milestones'
lib/api/settings.rb:      optional :asset_proxy_whitelist, type: Array[String], coerce_with: Validations::Types::CommaSeparatedToArray.coerce, desc: 'Deprecated: Use :asset_proxy_allowlist instead. Assets that match these domain(s) will NOT be proxied. Wildcards allowed. Your GitLab installation URL is automatically whitelisted.'
lib/api/settings.rb:      optional :asset_proxy_allowlist, type: Array[String], coerce_with: Validations::Types::CommaSeparatedToArray.coerce, desc: 'Assets that match these domain(s) will NOT be proxied. Wildcards allowed. Your GitLab installation URL is automatically allowed.'
lib/api/settings.rb:      optional :disabled_oauth_sign_in_sources, type: Array[String], coerce_with: Validations::Types::CommaSeparatedToArray.coerce, desc: 'Disable certain OAuth sign-in sources'
lib/api/settings.rb:      optional :domain_denylist, type: Array[String], coerce_with: Validations::Types::CommaSeparatedToArray.coerce, desc: 'Users with e-mail addresses that match these domain(s) will NOT be able to sign-up. Wildcards allowed. Use separate lines for multiple entries. Ex: domain.com, *.domain.com'
lib/api/settings.rb:      optional :domain_allowlist, type: Array[String], coerce_with: Validations::Types::CommaSeparatedToArray.coerce, desc: 'ONLY users with e-mail addresses that match these domain(s) will be able to sign-up. Wildcards allowed. Use separate lines for multiple entries. Ex: domain.com, *.domain.com'
lib/api/settings.rb:      optional :import_sources, type: Array[String], coerce_with: Validations::Types::CommaSeparatedToArray.coerce,
lib/api/settings.rb:      optional :restricted_visibility_levels, type: Array[String], coerce_with: Validations::Types::CommaSeparatedToArray.coerce, desc: 'Selected levels cannot be used by non-admin users for groups, projects or snippets. If the public level is restricted, user profiles are only visible to logged in users.'
lib/api/repositories.rb:        requires :refs, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce
lib/api/milestone_responses.rb:          optional :iids, type: Array[Integer], coerce_with: ::API::Validations::Types::CommaSeparatedToIntegerArray.coerce, desc: 'The IIDs of the milestones'
lib/api/container_registry_event.rb:        requires :events, type: Array
lib/api/commits.rb:        requires :actions, type: Array, desc: 'Actions to perform in commit' do
lib/api/helpers/merge_requests_helpers.rb:        optional :assignee_username, type: Array[String], check_assignees_count: true,
lib/api/helpers/merge_requests_helpers.rb:                 type: Array[String],
lib/api/helpers/projects_helpers.rb:        optional :tag_list, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, desc: 'The list of tags for a project'
lib/api/helpers/snippets_helpers.rb:        optional :files, type: Array, desc: 'An array of files' do
lib/api/helpers/snippets_helpers.rb:        optional :files, type: Array, desc: 'An array of files to update' do
lib/api/members.rb:          optional :user_ids, type: Array[Integer], coerce_with: ::API::Validations::Types::CommaSeparatedToIntegerArray.coerce, desc: 'Array of user ids to look up for membership'
lib/api/members.rb:          optional :user_ids, type: Array[Integer], coerce_with: ::API::Validations::Types::CommaSeparatedToIntegerArray.coerce, desc: 'Array of user ids to look up for membership'
lib/api/projects.rb:        optional :topic, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, desc: 'Comma-separated list of topics. Limit results to projects having all topics'
lib/api/projects.rb:        optional :skip_users, type: Array[Integer], coerce_with: ::API::Validations::Types::CommaSeparatedToIntegerArray.coerce, desc: 'Filter out users with the specified IDs'
lib/api/projects.rb:        optional :skip_groups, type: Array[Integer], coerce_with: ::API::Validations::Types::CommaSeparatedToIntegerArray.coerce, desc: 'Array of group ids to exclude from list'
lib/api/suggestions.rb:        requires :ids, type: Array[Integer], coerce_with: ::API::Validations::Types::CommaSeparatedToIntegerArray.coerce, desc: "An array of suggestion ID's"
lib/api/ci/runner.rb:          optional :tag_list, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, desc: %q(List of Runner's tags)
lib/api/ci/runners.rb:          optional :tag_list, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, desc: 'The tags of the runners to show'
lib/api/ci/runners.rb:          optional :tag_list, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, desc: 'The tags of the runners to show'
lib/api/ci/runners.rb:          optional :tag_list, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, desc: 'The list of tags for a runner'
lib/api/ci/runners.rb:          optional :tag_list, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, desc: 'The tags of the runners to show'
lib/api/ci/runners.rb:          optional :tag_list, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, desc: 'The tags of the runners to show'
lib/api/issues.rb:        optional :labels, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, desc: 'Comma-separated list of label names'
lib/api/issues.rb:        optional :iids, type: Array[Integer], coerce_with: ::API::Validations::Types::CommaSeparatedToIntegerArray.coerce, desc: 'The IID array of issues'
lib/api/issues.rb:        optional :assignee_username, type: Array[String], check_assignees_count: true,
lib/api/issues.rb:        optional :labels, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, desc: 'Comma-separated list of label names'
lib/api/issues.rb:        optional :iids, type: Array[Integer], coerce_with: ::API::Validations::Types::CommaSeparatedToIntegerArray.coerce, desc: 'The IID array of issues'
lib/api/issues.rb:        optional :assignee_username, type: Array[String], check_assignees_count: true,
lib/api/issues.rb:        optional :assignee_ids, type: Array[Integer], coerce_with: ::API::Validations::Types::CommaSeparatedToIntegerArray.coerce, desc: 'The array of user IDs to assign issue'
lib/api/issues.rb:        optional :labels, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, desc: 'Comma-separated list of label names'
lib/api/issues.rb:        optional :add_labels, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, desc: 'Comma-separated list of label names'
lib/api/issues.rb:        optional :remove_labels, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, desc: 'Comma-separated list of label names'
lib/api/groups.rb:        optional :skip_groups, type: Array[Integer], coerce_with: ::API::Validations::Types::CommaSeparatedToIntegerArray.coerce, desc: 'Array of group ids to exclude from list'
lib/api/users.rb:            optional :scopes, type: Array, desc: 'The array of scopes of the impersonation token'
lib/api/users.rb:            requires :scopes, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, values: ::Gitlab::Auth.all_available_scopes.map(&:to_s),
lib/api/feature_flags.rb:          optional :scopes, type: Array do
lib/api/feature_flags.rb:          optional :strategies, type: Array do
lib/api/feature_flags.rb:            optional :scopes, type: Array do
lib/api/feature_flags.rb:          optional :strategies, type: Array do
lib/api/feature_flags.rb:            optional :scopes, type: Array do
lib/api/merge_requests.rb:          optional :assignee_ids, type: Array[Integer], coerce_with: ::API::Validations::Types::CommaSeparatedToIntegerArray.coerce, desc: 'Comma-separated list of assignee ids'
lib/api/merge_requests.rb:          optional :reviewer_ids, type: Array[Integer], coerce_with: ::API::Validations::Types::CommaSeparatedToIntegerArray.coerce, desc: 'Comma-separated list of reviewer ids'
lib/api/merge_requests.rb:          optional :labels, type: Array[String], coerce_with: Validations::Types::CommaSeparatedToArray.coerce, desc: 'Comma-separated list of label names'
lib/api/merge_requests.rb:          optional :add_labels, type: Array[String], coerce_with: Validations::Types::CommaSeparatedToArray.coerce, desc: 'Comma-separated list of label names'
lib/api/merge_requests.rb:          optional :remove_labels, type: Array[String], coerce_with: Validations::Types::CommaSeparatedToArray.coerce, desc: 'Comma-separated list of label names'
lib/api/merge_requests.rb:        optional :iids, type: Array[Integer], coerce_with: ::API::Validations::Types::CommaSeparatedToIntegerArray.coerce, desc: 'The IID array of merge requests'
lib/api/merge_requests.rb:        requires :commits, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, allow_blank: false, desc: 'List of context commits sha'
lib/api/merge_requests.rb:        requires :commits, type: Array[String], coerce_with: ::API::Validations::Types::CommaSeparatedToArray.coerce, allow_blank: false, desc: 'List of context commits sha'
```

Closes https://github.com/python-gitlab/python-gitlab/issues/1256
Closes https://github.com/python-gitlab/python-gitlab/issues/1419