### PR TITLE
feat: indicate that we are a typed package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     url="https://github.com/python-gitlab/python-gitlab",
     packages=find_packages(),
     install_requires=["requests>=2.22.0", "requests-toolbelt>=0.9.1"],
+    package_data = {'gitlab': ['py.typed'], },
     python_requires=">=3.6.0",
     entry_points={"console_scripts": ["gitlab = gitlab.cli:main"]},
     classifiers=[


### PR DESCRIPTION
By adding the file: py.typed
it indicates that python-gitlab is a typed package and contains
type-hints.

https://www.python.org/dev/peps/pep-0561/