### PR TITLE
chore(ci): automate releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  schedule:
+    - cron: '0 0 28 * *'  # Monthly auto-release
+  workflow_dispatch:      # Manual trigger for quick fixes
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Python Semantic Release
+      uses: relekang/python-semantic-release@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,21 +4,6 @@ stages:
   - deploy
   - deploy-latest
 
-deploy:
-  stage: deploy
-  script:
-    - pip install -U setuptools wheel twine
-    - python setup.py sdist bdist_wheel
-    # test package
-    - python3 -m venv test
-    - . test/bin/activate
-    - pip install -U dist/python_gitlab*.whl
-    - gitlab -h
-    - deactivate
-    - twine upload --skip-existing -u $TWINE_USERNAME -p $TWINE_PASSWORD dist/*
-  only:
-    - tags
-
 deploy_image:
   stage: deploy
   image:

--- a/README.rst
+++ b/README.rst
@@ -213,3 +213,27 @@ To cleanup the environment delete the container:
    docker rm -f gitlab-test
    docker rm -f gitlab-runner-test
 
+Releases
+--------
+
+A release is automatically published once a month on the 28th if any commits merged
+to the main branch contain commit message types that signal a semantic version bump
+(``fix``, ``feat``, ``BREAKING CHANGE:``).
+
+Additionally, the release workflow can be run manually by maintainers to publish urgent
+fixes, either on GitHub or using the ``gh`` CLI with ``gh workflow run release.yml``.
+
+**Note:** As a maintainer, this means you should carefully review commit messages
+used by contributors in their pull requests. If scopes such as ``fix`` and ``feat``
+are applied to trivial commits not relevant to end users, it's best to squash their
+pull requests and summarize the addition in a single conventional commit.
+This avoids triggering incorrect version bumps and releases without functional changes.
+
+The release workflow uses `python-semantic-release
+<https://python-semantic-release.readthedocs.io>`_ and does the following:
+
+* Bumps the version in ``__version__.py`` and adds an entry in ``CHANGELOG.md``,
+* Commits and tags the changes, then pushes to the main branch as the ``github-actions`` user,
+* Creates a release from the tag and adds the changelog entry to the release notes,
+* Uploads the package as assets to the GitHub release,
+* Uploads the package to PyPI using ``PYPI_TOKEN`` (configured as a secret).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.semantic_release]
+version_variable = "gitlab/__version__.py:__version__"
+commit_subject = "chore: release v{version}"
+commit_message = ""


### PR DESCRIPTION
Adds an automated release ~~every week~~ once a month + manual workflow if quick fixes are needed. I thought this would be a good compromise. I didn't want this on every push as otherwise all release notes just have only 1 PR entry and it's just really noisy. I see other people are also reconsidering that: https://github.com/renovatebot/renovate/issues/9709.

Also I just chose Monday so there's no Friday releases :rofl: but open to suggestions.

I tested this here (including all my derpy trial&error pushes):
https://github.com/nejch/python-gitlab-semantic-release

Resulting releases: https://github.com/nejch/python-gitlab-semantic-release/releases
testpypi package: https://test.pypi.org/project/python-gitlab/
changelog: https://github.com/nejch/python-gitlab-semantic-release/blob/master/CHANGELOG.md

I've also already set up the `PYPI_TOKEN` secret here.

Initially I wasn't a fan of the auto-committed `CHANGELOG.md` but now I'm thinking it gives us a chance to consolidate the old changelog and release notes that are just sitting there since the GH Releases move. I can push another PR for that to add the old changes it to the new changelog.