### PR TITLE
chore: have flake8 check the entire project

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,11 +18,10 @@ from __future__ import unicode_literals
 import os
 import sys
 
-import sphinx
+import gitlab
 
 sys.path.append("../")
 sys.path.append(os.path.dirname(__file__))
-import gitlab
 
 on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
@@ -207,11 +206,11 @@ htmlhelp_basename = "python-gitlabdoc"
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
-    #'papersize': 'letterpaper',
-    # The font size ('10pt', '11pt' or '12pt').
-    #'pointsize': '10pt',
-    # Additional stuff for the LaTeX preamble.
-    #'preamble': '',
+    # 'papersize': 'letterpaper',
+    #  The font size ('10pt', '11pt' or '12pt').
+    # 'pointsize': '10pt',
+    #  Additional stuff for the LaTeX preamble.
+    # 'preamble': '',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/docs/ext/docstrings.py
+++ b/docs/ext/docstrings.py
@@ -1,5 +1,4 @@
 import inspect
-import itertools
 import os
 
 import jinja2
@@ -14,7 +13,6 @@ def classref(value, short=True):
     if not inspect.isclass(value):
         return ":class:%s" % value
     tilde = "~" if short else ""
-    string = "%s.%s" % (value.__module__, value.__name__)
     return ":class:`%sgitlab.objects.%s`" % (tilde, value.__name__)
 
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,9 @@ setup(
     url="https://github.com/python-gitlab/python-gitlab",
     packages=find_packages(),
     install_requires=["requests>=2.22.0", "requests-toolbelt>=0.9.1"],
-    package_data = {'gitlab': ['py.typed'], },
+    package_data={
+        "gitlab": ["py.typed"],
+    },
     python_requires=">=3.6.0",
     entry_points={"console_scripts": ["gitlab = gitlab.cli:main"]},
     classifiers=[

--- a/tools/functional/api/test_issues.py
+++ b/tools/functional/api/test_issues.py
@@ -39,7 +39,7 @@ def test_issue_notes(issue):
 
 
 def test_issue_labels(project, issue):
-    label = project.labels.create({"name": "label2", "color": "#aabbcc"})
+    project.labels.create({"name": "label2", "color": "#aabbcc"})
     issue.labels = ["label2"]
     issue.save()
 

--- a/tools/functional/api/test_merge_requests.py
+++ b/tools/functional/api/test_merge_requests.py
@@ -14,7 +14,7 @@ def test_merge_requests(project):
     )
 
     source_branch = "branch1"
-    branch = project.branches.create({"branch": source_branch, "ref": "master"})
+    project.branches.create({"branch": source_branch, "ref": "master"})
 
     project.files.create(
         {
@@ -24,7 +24,7 @@ def test_merge_requests(project):
             "commit_message": "New commit in new branch",
         }
     )
-    mr = project.mergerequests.create(
+    project.mergerequests.create(
         {"source_branch": "branch1", "target_branch": "master", "title": "MR readme2"}
     )
 

--- a/tools/functional/api/test_projects.py
+++ b/tools/functional/api/test_projects.py
@@ -150,10 +150,10 @@ def test_project_labels(project):
     assert label.name == "labelupdated"
 
     label.subscribe()
-    assert label.subscribed == True
+    assert label.subscribed is True
 
     label.unsubscribe()
-    assert label.subscribed == False
+    assert label.subscribed is False
 
     label.delete()
     assert len(project.labels.list()) == 0

--- a/tools/functional/api/test_releases.py
+++ b/tools/functional/api/test_releases.py
@@ -29,7 +29,7 @@ def test_delete_project_release(project, release):
 
 
 def test_create_project_release_links(project, release):
-    link = release.links.create(link_data)
+    release.links.create(link_data)
 
     release = project.releases.get(release.tag_name)
     assert release.assets["links"][0]["url"] == link_data["url"]

--- a/tools/functional/api/test_repository.py
+++ b/tools/functional/api/test_repository.py
@@ -74,7 +74,7 @@ def test_create_commit(project):
 def test_create_commit_status(project):
     commit = project.commits.list()[0]
     size = len(commit.statuses.list())
-    status = commit.statuses.create({"state": "success", "sha": commit.id})
+    commit.statuses.create({"state": "success", "sha": commit.id})
     assert len(commit.statuses.list()) == size + 1
 
 
@@ -82,7 +82,7 @@ def test_commit_signature(project):
     commit = project.commits.list()[0]
 
     with pytest.raises(gitlab.GitlabGetError) as e:
-        signature = commit.signature()
+        commit.signature()
 
     assert "404 Signature Not Found" in str(e.value)
 

--- a/tools/functional/api/test_users.py
+++ b/tools/functional/api/test_users.py
@@ -3,9 +3,6 @@ GitLab API:
 https://docs.gitlab.com/ee/api/users.html
 https://docs.gitlab.com/ee/api/users.html#delete-authentication-identity-from-user
 """
-import time
-from pathlib import Path
-
 import pytest
 import requests
 
@@ -57,7 +54,7 @@ def test_delete_user(gl, wait_for_sidekiq):
 
     new_user.delete()
     result = wait_for_sidekiq(timeout=60)
-    assert result == True, "sidekiq process should have terminated but did not"
+    assert result is True, "sidekiq process should have terminated but did not"
 
     assert new_user.id not in [user.id for user in gl.users.list()]
 

--- a/tools/functional/conftest.py
+++ b/tools/functional/conftest.py
@@ -2,7 +2,6 @@ import tempfile
 import time
 import uuid
 from pathlib import Path
-from random import randint
 from subprocess import check_output
 
 import pytest

--- a/tools/functional/ee-test.py
+++ b/tools/functional/ee-test.py
@@ -125,13 +125,13 @@ pr.deny_delete_tag = False
 pr.save()
 pr = project1.pushrules.get()
 assert pr is not None
-assert pr.deny_delete_tag == False
+assert pr.deny_delete_tag is False
 pr.delete()
 end_log()
 
 start_log("license")
-l = gl.get_license()
-assert "user_limit" in l
+license = gl.get_license()
+assert "user_limit" in license
 try:
     gl.set_license("dummykey")
 except Exception as e:

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        flake8
 commands =
-  flake8 {posargs} gitlab/
+  flake8 {posargs} .
 
 [testenv:black]
 basepython = python3


### PR DESCRIPTION
Have flake8 run at the top-level of the projects instead of just the
gitlab directory.