### PR TITLE
chore: have black run at the top-level

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        black
 commands =
-  black {posargs} gitlab tools/functional
+  black {posargs} .
 
 [testenv:twine-check]
 basepython = python3


### PR DESCRIPTION
This will ensure everything is formatted with black, including
setup.py.