### PR TITLE
feat: add code owner approval as attribute

### DIFF
--- a/gitlab/v4/objects/branches.py
+++ b/gitlab/v4/objects/branches.py
@@ -84,5 +84,6 @@ class ProjectProtectedBranchManager(NoUpdateMixin, RESTManager):
             "allowed_to_push",
             "allowed_to_merge",
             "allowed_to_unprotect",
+            "code_owner_approval_required",
         ),
     )


### PR DESCRIPTION
Add `ProjectProtectedBranchManager.code_owner_approval_required` to mimick [GitLab API documentation](https://docs.gitlab.com/ce/api/protected_branches.html#protect-repository-branches):

Attribute | Type | Required | Description
-- | -- | -- | --
code_owner_approval_required | boolean | no | Prevent pushes to this branch if it matches an item in the CODEOWNERS file. (defaults: false)

Fixes #1436 