### PR TITLE
docs: fail on warnings during sphinx build

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -26,8 +26,8 @@ Bug Fixes
 -  Make MemberManager.all() return a list of objects
 -  %d replaced by %s
 -  Re-enable command specific help messages
--  dont ask for id attr if this is *Manager originating custom action
--  fix -/_ replacament for *Manager custom actions
+-  dont ask for id attr if this is \*Manager originating custom action
+-  fix -/_ replacament for \*Manager custom actions
 -  fix repository_id marshaling in cli
 -  register cli action for delete_in_bulk
 
@@ -233,7 +233,7 @@ Version 1.2.0_ - 2018-01-01
 * Add support for features flags
 * Add support for project and group custom variables
 * Add support for user/group/project filter by custom attribute
-* Respect content of REQUESTS_CA_BUNDLE and *_proxy envvars
+* Respect content of REQUESTS_CA_BUNDLE and \*_proxy envvars
 
 Version 1.1.0_ - 2017-11-03
 ---------------------------

--- a/docs/api-objects.rst
+++ b/docs/api-objects.rst
@@ -15,6 +15,7 @@ API examples
    gl_objects/messages
    gl_objects/commits
    gl_objects/deploy_keys
+   gl_objects/deploy_tokens
    gl_objects/deployments
    gl_objects/discussions
    gl_objects/environments
@@ -34,8 +35,10 @@ API examples
    gl_objects/notes
    gl_objects/packages
    gl_objects/pagesdomains
+   gl_objects/personal_access_tokens
    gl_objects/pipelines_and_jobs
    gl_objects/projects
+   gl_objects/project_access_tokens
    gl_objects/protected_branches
    gl_objects/releases
    gl_objects/runners

--- a/docs/cli-usage.rst
+++ b/docs/cli-usage.rst
@@ -403,7 +403,7 @@ command line. This is handy for values containing new lines for instance:
    $ gitlab project create --name SuperProject --description @/tmp/description
 
 Enabling shell autocompletion
-============================
+=============================
 
 To get autocompletion, you'll need to install the package with the extra
 "autocompletion":

--- a/docs/gl_objects/deploy_tokens.rst
+++ b/docs/gl_objects/deploy_tokens.rst
@@ -1,6 +1,6 @@
-#######
+#############
 Deploy tokens
-#######
+#############
 
 Deploy tokens allow read-only access to your repository and registry images
 without having a user and a password.

--- a/docs/gl_objects/milestones.rst
+++ b/docs/gl_objects/milestones.rst
@@ -75,7 +75,7 @@ List the merge requests related to a milestone::
     merge_requests = milestone.merge_requests()
 
 Milestone events
-============
+================
 
 Resource milestone events keep track of what happens to GitLab issues and merge requests.
 

--- a/docs/gl_objects/mr_approvals.rst
+++ b/docs/gl_objects/mr_approvals.rst
@@ -76,6 +76,7 @@ Change MR-level MR approval rule::
 	mr_approvalrule.save()
 
 Create a MR-level MR approval rule::
+
    mr.approval_rules.create({
        "name": "my MR custom approval rule",
        "approvals_required": 2,

--- a/docs/gl_objects/packages.rst
+++ b/docs/gl_objects/packages.rst
@@ -1,6 +1,6 @@
-#######
+########
 Packages
-#######
+########
 
 Packages allow you to utilize GitLab as a private repository for a variety
 of common package managers.

--- a/docs/gl_objects/remote_mirrors.rst
+++ b/docs/gl_objects/remote_mirrors.rst
@@ -1,6 +1,6 @@
-##########
+######################
 Project Remote Mirrors
-##########
+######################
 
 Remote Mirrors allow you to set up push mirroring for a project.
 

--- a/docs/gl_objects/runners.rst
+++ b/docs/gl_objects/runners.rst
@@ -79,7 +79,7 @@ Verify a registered runner token::
         print("Invalid token")
 
 Project/Group runners
-===============
+=====================
 
 Reference
 ---------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[build_sphinx]
+warning-is-error = 1
+keep-going = 1


### PR DESCRIPTION
I was hesitant to make it this strict first, but realized this is useful when docs aren't included in the toctree and the articles don't show up on RTD, unless users specifically search for those keywords. So we actually had some dead documentation this whole time.

Closes https://github.com/python-gitlab/python-gitlab/issues/1370.