### PR TITLE
chore(docs): fix import order for readthedocs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,10 +18,9 @@ from __future__ import unicode_literals
 import os
 import sys
 
-import gitlab
-
 sys.path.append("../")
 sys.path.append(os.path.dirname(__file__))
+import gitlab  # noqa: E402. Needed purely for readthedocs' build
 
 on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 


### PR DESCRIPTION
This partially reverts https://github.com/python-gitlab/python-gitlab/commit/b498ebd804461031e2d2d391f77dfbbcf0d2e281. I noticed the builds are failing on RTD right now and it started with this commit.

Turns out RTD does not have `gitlab` in path because it does its own weird build, so we really need this hack. Here's requests doing the same: https://github.com/psf/requests/blob/c45a4dfe6bfc6017d4ea7e9f051d6cc30972b310/docs/conf.py#L23-L27

There might be cleaner solutions but if `psf` repos do it, I guess this is ok :rofl: 