### PR TITLE
fix(objects): return server data in cancel/retry methods

### DIFF
--- a/gitlab/tests/objects/test_jobs.py
+++ b/gitlab/tests/objects/test_jobs.py
@@ -1,0 +1,97 @@
+"""
+GitLab API: https://docs.gitlab.com/ee/api/jobs.html
+"""
+import pytest
+import responses
+
+from gitlab.v4.objects import ProjectJob
+
+
+job_content = {
+    "commit": {
+        "author_email": "admin@example.com",
+        "author_name": "Administrator",
+    },
+    "coverage": None,
+    "allow_failure": False,
+    "created_at": "2015-12-24T15:51:21.880Z",
+    "started_at": "2015-12-24T17:54:30.733Z",
+    "finished_at": "2015-12-24T17:54:31.198Z",
+    "duration": 0.465,
+    "queued_duration": 0.010,
+    "artifacts_expire_at": "2016-01-23T17:54:31.198Z",
+    "tag_list": ["docker runner", "macos-10.15"],
+    "id": 1,
+    "name": "rubocop",
+    "pipeline": {
+        "id": 1,
+        "project_id": 1,
+    },
+    "ref": "master",
+    "artifacts": [],
+    "runner": None,
+    "stage": "test",
+    "status": "failed",
+    "tag": False,
+    "web_url": "https://example.com/foo/bar/-/jobs/1",
+    "user": {"id": 1},
+}
+
+
+@pytest.fixture
+def resp_get_job():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.GET,
+            url="http://localhost/api/v4/projects/1/jobs/1",
+            json=job_content,
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
+@pytest.fixture
+def resp_cancel_job():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.POST,
+            url="http://localhost/api/v4/projects/1/jobs/1/cancel",
+            json=job_content,
+            content_type="application/json",
+            status=201,
+        )
+        yield rsps
+
+
+@pytest.fixture
+def resp_retry_job():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.POST,
+            url="http://localhost/api/v4/projects/1/jobs/1/retry",
+            json=job_content,
+            content_type="application/json",
+            status=201,
+        )
+        yield rsps
+
+
+def test_get_project_job(project, resp_get_job):
+    job = project.jobs.get(1)
+    assert isinstance(job, ProjectJob)
+    assert job.ref == "master"
+
+
+def test_cancel_project_job(project, resp_cancel_job):
+    job = project.jobs.get(1, lazy=True)
+
+    output = job.cancel()
+    assert output["ref"] == "master"
+
+
+def test_retry_project_job(project, resp_retry_job):
+    job = project.jobs.get(1, lazy=True)
+
+    output = job.retry()
+    assert output["ref"] == "master"

--- a/gitlab/tests/objects/test_pipelines.py
+++ b/gitlab/tests/objects/test_pipelines.py
@@ -1,0 +1,95 @@
+"""
+GitLab API: https://docs.gitlab.com/ee/api/pipelines.html
+"""
+import pytest
+import responses
+
+from gitlab.v4.objects import ProjectPipeline
+
+
+pipeline_content = {
+    "id": 46,
+    "project_id": 1,
+    "status": "pending",
+    "ref": "master",
+    "sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+    "before_sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+    "tag": False,
+    "yaml_errors": None,
+    "user": {
+        "name": "Administrator",
+        "username": "root",
+        "id": 1,
+        "state": "active",
+        "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+        "web_url": "http://localhost:3000/root",
+    },
+    "created_at": "2016-08-11T11:28:34.085Z",
+    "updated_at": "2016-08-11T11:32:35.169Z",
+    "started_at": None,
+    "finished_at": "2016-08-11T11:32:35.145Z",
+    "committed_at": None,
+    "duration": None,
+    "queued_duration": 0.010,
+    "coverage": None,
+    "web_url": "https://example.com/foo/bar/pipelines/46",
+}
+
+
+@pytest.fixture
+def resp_get_pipeline():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.GET,
+            url="http://localhost/api/v4/projects/1/pipelines/1",
+            json=pipeline_content,
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
+@pytest.fixture
+def resp_cancel_pipeline():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.POST,
+            url="http://localhost/api/v4/projects/1/pipelines/1/cancel",
+            json=pipeline_content,
+            content_type="application/json",
+            status=201,
+        )
+        yield rsps
+
+
+@pytest.fixture
+def resp_retry_pipeline():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.POST,
+            url="http://localhost/api/v4/projects/1/pipelines/1/retry",
+            json=pipeline_content,
+            content_type="application/json",
+            status=201,
+        )
+        yield rsps
+
+
+def test_get_project_pipeline(project, resp_get_pipeline):
+    pipeline = project.pipelines.get(1)
+    assert isinstance(pipeline, ProjectPipeline)
+    assert pipeline.ref == "master"
+
+
+def test_cancel_project_pipeline(project, resp_cancel_pipeline):
+    pipeline = project.pipelines.get(1, lazy=True)
+
+    output = pipeline.cancel()
+    assert output["ref"] == "master"
+
+
+def test_retry_project_pipeline(project, resp_retry_pipeline):
+    pipeline = project.pipelines.get(1, lazy=True)
+
+    output = pipeline.retry()
+    assert output["ref"] == "master"

--- a/gitlab/v4/objects/jobs.py
+++ b/gitlab/v4/objects/jobs.py
@@ -24,7 +24,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabJobCancelError: If the job could not be canceled
         """
         path = "%s/%s/cancel" % (self.manager.path, self.get_id())
-        self.manager.gitlab.http_post(path)
+        return self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabJobRetryError)
@@ -39,7 +39,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabJobRetryError: If the job could not be retried
         """
         path = "%s/%s/retry" % (self.manager.path, self.get_id())
-        self.manager.gitlab.http_post(path)
+        return self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabJobPlayError)

--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -50,7 +50,7 @@ class ProjectPipeline(RefreshMixin, ObjectDeleteMixin, RESTObject):
             GitlabPipelineCancelError: If the request failed
         """
         path = "%s/%s/cancel" % (self.manager.path, self.get_id())
-        self.manager.gitlab.http_post(path)
+        return self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectPipeline")
     @exc.on_http_error(exc.GitlabPipelineRetryError)
@@ -65,7 +65,7 @@ class ProjectPipeline(RefreshMixin, ObjectDeleteMixin, RESTObject):
             GitlabPipelineRetryError: If the request failed
         """
         path = "%s/%s/retry" % (self.manager.path, self.get_id())
-        self.manager.gitlab.http_post(path)
+        return self.manager.gitlab.http_post(path)
 
 
 class ProjectPipelineManager(RetrieveMixin, CreateMixin, DeleteMixin, RESTManager):


### PR DESCRIPTION
Closes https://github.com/python-gitlab/python-gitlab/issues/825. It seems like it's something people want and saves a few extra API calls in some cases.