### PR TITLE
feat(api): implement a count method

### DIFF
--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -21,6 +21,7 @@ from typing import cast, Any, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import requests
 import requests.utils
+from requests.structures import CaseInsensitiveDict
 
 import gitlab.config
 import gitlab.const
@@ -632,6 +633,32 @@ class Gitlab(object):
                 ) from e
         else:
             return result
+
+    def http_head(
+        self,
+        path: str,
+        query_data: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> CaseInsensitiveDict:
+        """Make a HEAD request to the Gitlab server.
+
+        Args:
+            path (str): Path or full URL to query ('/projects' or
+                        'http://whatever/v4/api/projecs')
+            query_data (dict): Data to send as query parameters
+            **kwargs: Extra options to send to the server (e.g. sudo, page,
+                      per_page)
+
+        Returns:
+            requests.structures.CaseInsensitiveDict: A requests.header object
+
+        Raises:
+            GitlabHttpError: When the return code is not 2xx
+        """
+
+        url = self._build_url(path)
+        result = self.http_request("head", url, query_data=query_data, **kwargs)
+        return result.headers
 
     def http_list(
         self,

--- a/gitlab/exceptions.py
+++ b/gitlab/exceptions.py
@@ -79,6 +79,10 @@ class GitlabListError(GitlabOperationError):
     pass
 
 
+class GitlabCountError(GitlabOperationError):
+    pass
+
+
 class GitlabGetError(GitlabOperationError):
     pass
 

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -246,6 +246,26 @@ class ListMixin(_RestManagerBase):
         else:
             return base.RESTObjectList(self, self._obj_cls, obj)
 
+    @exc.on_http_error(exc.GitlabListError)
+    def count(self, **kwargs: Any) -> int:
+        """Retrieve the number of available objects.
+
+        Args:
+            **kwargs: Extra options to send to the server (e.g. sudo)
+
+        Returns:
+            int: The number of objects
+
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabCountError: If the server cannot perform the request
+        """
+        # Allow to overwrite the path, handy for custom calls
+        path = kwargs.pop("path", self.path)
+
+        headers = self.gitlab.http_head(path, **kwargs)
+        return int(headers["x-total"])
+
 
 class RetrieveMixin(ListMixin, GetMixin):
     _computed_path: Optional[str]

--- a/gitlab/tests/mixins/test_mixin_methods.py
+++ b/gitlab/tests/mixins/test_mixin_methods.py
@@ -107,6 +107,18 @@ def test_list_mixin(gl):
         assert isinstance(obj_list[0], FakeObject)
         assert len(obj_list) == 2
 
+    @urlmatch(scheme="http", netloc="localhost", path="/api/v4/tests", method="head")
+    def resp_count_cont(url, request):
+        headers = {"Content-Type": "application/json", "X-Total": 2}
+        content = ""
+        return response(200, content, headers, None, 5, request)
+
+    with HTTMock(resp_count_cont):
+        mgr = M(gl)
+        # test count()
+        res = mgr.count()
+        assert res == 2
+
 
 def test_list_other_url(gl):
     class M(ListMixin, FakeManager):

--- a/gitlab/tests/objects/test_projects.py
+++ b/gitlab/tests/objects/test_projects.py
@@ -43,6 +43,18 @@ def resp_list_projects():
 
 
 @pytest.fixture
+def resp_count_projects():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.HEAD,
+            url="http://localhost/api/v4/projects",
+            headers={"X-Total": "1"},
+            status=200,
+        )
+        yield rsps
+
+
+@pytest.fixture
 def resp_import_bitbucket_server():
     with responses.RequestsMock() as rsps:
         rsps.add(
@@ -66,6 +78,12 @@ def test_list_projects(gl, resp_list_projects):
     projects = gl.projects.list()
     assert isinstance(projects[0], Project)
     assert projects[0].name == "name"
+
+
+def test_count_projects(gl, resp_count_projects):
+    res = gl.projects.count()
+    assert isinstance(res, int)
+    assert res == 1
 
 
 def test_import_bitbucket_server(gl, resp_import_bitbucket_server):

--- a/gitlab/tests/test_gitlab_http_methods.py
+++ b/gitlab/tests/test_gitlab_http_methods.py
@@ -2,6 +2,7 @@ import pytest
 import requests
 
 from httmock import HTTMock, urlmatch, response
+from requests.structures import CaseInsensitiveDict
 
 from gitlab import GitlabHttpError, GitlabList, GitlabParsingError
 
@@ -108,6 +109,18 @@ def test_list_request(gl):
         result = gl.http_list("/projects", all=True)
         assert isinstance(result, list)
         assert len(result) == 1
+
+
+def test_head_request(gl):
+    @urlmatch(scheme="http", netloc="localhost", path="/api/v4/projects", method="head")
+    def resp_cont(url, request):
+        headers = {"content-type": "application/json", "X-Total": 1}
+        content = ""
+        return response(200, content, headers, None, 5, request)
+
+    with HTTMock(resp_cont):
+        result = gl.http_head("/projects")
+        assert isinstance(result, CaseInsensitiveDict)
 
 
 def test_list_request_404(gl):

--- a/tools/functional/api/test_projects.py
+++ b/tools/functional/api/test_projects.py
@@ -14,10 +14,12 @@ def test_create_project(gl, user):
     created = gl.projects.list()
     created_gen = gl.projects.list(as_list=False)
     owned = gl.projects.list(owned=True)
+    counter = gl.projects.count()
 
     assert admin_project in created and sudo_project in created
     assert admin_project in owned and sudo_project not in owned
     assert len(created) == len(list(created_gen))
+    assert len(created) == counter
 
     admin_project.delete()
     sudo_project.delete()


### PR DESCRIPTION
Hi, I found an issue https://github.com/python-gitlab/python-gitlab/issues/682 which I think I can finish. At the moment work is in progress. I have added tests for http_head(), count(), gl.projects.count() and others.
@nejch, does my change make sense or what else needs to be done except docs? Documentation part is still on me.
Br, Alex