### PR TITLE
feat(objects): add support for generic packages API

### DIFF
--- a/docs/cli-usage.rst
+++ b/docs/cli-usage.rst
@@ -319,6 +319,20 @@ Delete a specific project package by id:
 
    $ gitlab -v project-package delete --id 1 --project-id 3
 
+Upload a generic package to a project:
+
+.. code-block:: console
+
+   $ gitlab generic-package upload --project-id 1 --package-name hello-world \
+        --package-version v1.0.0 --file-name hello.tar.gz --path /path/to/hello.tar.gz
+
+Download a project's generic package:
+
+.. code-block:: console
+
+   $ gitlab generic-package download --project-id 1 --package-name hello-world \
+        --package-version v1.0.0 --file-name hello.tar.gz > /path/to/hello.tar.gz
+
 Get a list of issues for this project:
 
 .. code-block:: console

--- a/docs/gl_objects/packages.rst
+++ b/docs/gl_objects/packages.rst
@@ -3,7 +3,7 @@ Packages
 ########
 
 Packages allow you to utilize GitLab as a private repository for a variety
-of common package managers.
+of common package managers, as well as GitLab's generic package registry.
 
 Project Packages
 =====================
@@ -88,3 +88,44 @@ List package files for package in project::
 
     package = project.packages.get(1)
     package_files = package.package_files.list()
+
+Generic Packages
+================
+
+You can use python-gitlab to upload and download generic packages.
+
+Reference
+---------
+
+* v4 API:
+
+  + :class:`gitlab.v4.objects.GenericPackage`
+  + :class:`gitlab.v4.objects.GenericPackageManager`
+  + :attr:`gitlab.v4.objects.Project.generic_packages`
+
+* GitLab API: https://docs.gitlab.com/ee/user/packages/generic_packages
+
+Examples
+--------
+
+Upload a generic package to a project::
+
+    project = gl.projects.get(1, lazy=True)
+    package = project.generic_packages.upload(
+        package_name="hello-world",
+        package_version="v1.0.0",
+        file_name="hello.tar.gz",
+        path="/path/to/local/hello.tar.gz"
+    )
+
+Download a project's generic package::
+
+    project = gl.projects.get(1, lazy=True)
+    package = project.generic_packages.download(
+        package_name="hello-world",
+        package_version="v1.0.0",
+        file_name="hello.tar.gz",
+    )
+
+.. hint:: You can use the Packages API described above to find packages and
+    retrieve the metadata you need download them.

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -437,10 +437,14 @@ class Gitlab(object):
 
     def _prepare_send_data(
         self,
-        files: Dict[str, Any] = None,
-        post_data: Dict[str, Any] = None,
-        raw: Optional[bool] = False,
-    ) -> Tuple:
+        files: Optional[Dict[str, Any]] = None,
+        post_data: Optional[Dict[str, Any]] = None,
+        raw: bool = False,
+    ) -> Tuple[
+        Optional[Dict[str, Any]],
+        Optional[Union[Dict[str, Any], MultipartEncoder]],
+        str,
+    ]:
         if files:
             if post_data is None:
                 post_data = {}
@@ -467,7 +471,7 @@ class Gitlab(object):
         path: str,
         query_data: Optional[Dict[str, Any]] = None,
         post_data: Optional[Dict[str, Any]] = None,
-        raw: Optional[bool] = False,
+        raw: bool = False,
         streamed: bool = False,
         files: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
@@ -690,7 +694,7 @@ class Gitlab(object):
         path: str,
         query_data: Optional[Dict[str, Any]] = None,
         post_data: Optional[Dict[str, Any]] = None,
-        raw: Optional[bool] = False,
+        raw: bool = False,
         files: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> Union[Dict[str, Any], requests.Response]:
@@ -739,7 +743,7 @@ class Gitlab(object):
         path: str,
         query_data: Optional[Dict[str, Any]] = None,
         post_data: Optional[Dict[str, Any]] = None,
-        raw: Optional[bool] = False,
+        raw: bool = False,
         files: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> Union[Dict[str, Any], requests.Response]:

--- a/gitlab/v4/objects/packages.py
+++ b/gitlab/v4/objects/packages.py
@@ -1,7 +1,17 @@
+from pathlib import Path
+from typing import Any, Callable, Optional, TYPE_CHECKING, Union
+
+import requests
+
+from gitlab import cli
+from gitlab import exceptions as exc
+from gitlab import utils
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import DeleteMixin, GetMixin, ListMixin, ObjectDeleteMixin
 
 __all__ = [
+    "GenericPackage",
+    "GenericPackageManager",
     "GroupPackage",
     "GroupPackageManager",
     "ProjectPackage",
@@ -9,6 +19,110 @@ __all__ = [
     "ProjectPackageFile",
     "ProjectPackageFileManager",
 ]
+
+
+class GenericPackage(RESTObject):
+    _id_attr = "package_name"
+
+
+class GenericPackageManager(RESTManager):
+    _path = "/projects/%(project_id)s/packages/generic"
+    _obj_cls = GenericPackage
+    _from_parent_attrs = {"project_id": "id"}
+
+    @cli.register_custom_action(
+        "GenericPackageManager",
+        ("package_name", "package_version", "file_name", "path"),
+    )
+    @exc.on_http_error(exc.GitlabUploadError)
+    def upload(
+        self,
+        package_name: str,
+        package_version: str,
+        file_name: str,
+        path: Union[str, Path],
+        **kwargs,
+    ) -> GenericPackage:
+        """Upload a file as a generic package.
+
+        Args:
+            package_name (str): The package name. Must follow generic package
+                                name regex rules
+            package_version (str): The package version. Must follow semantic
+                                version regex rules
+            file_name (str): The name of the file as uploaded in the registry
+            path (str): The path to a local file to upload
+
+        Raises:
+            GitlabConnectionError: If the server cannot be reached
+            GitlabUploadError: If the file upload fails
+            GitlabUploadError: If ``filepath`` cannot be read
+
+        Returns:
+            GenericPackage: An object storing the metadata of the uploaded package.
+        """
+
+        try:
+            with open(path, "rb") as f:
+                file_data = f.read()
+        except OSError:
+            raise exc.GitlabUploadError(f"Failed to read package file {path}")
+
+        url = f"{self._computed_path}/{package_name}/{package_version}/{file_name}"
+        server_data = self.gitlab.http_put(url, post_data=file_data, raw=True, **kwargs)
+
+        return self._obj_cls(
+            self,
+            {
+                "package_name": package_name,
+                "package_version": package_version,
+                "file_name": file_name,
+                "path": path,
+                "message": server_data["message"],
+            },
+        )
+
+    @cli.register_custom_action(
+        "GenericPackageManager",
+        ("package_name", "package_version", "file_name"),
+    )
+    @exc.on_http_error(exc.GitlabGetError)
+    def download(
+        self,
+        package_name: str,
+        package_version: str,
+        file_name: str,
+        streamed: bool = False,
+        action: Optional[Callable] = None,
+        chunk_size: int = 1024,
+        **kwargs: Any,
+    ) -> Optional[bytes]:
+        """Download a generic package.
+
+        Args:
+            package_name (str): The package name.
+            package_version (str): The package version.
+            file_name (str): The name of the file in the registry
+            streamed (bool): If True the data will be processed by chunks of
+                `chunk_size` and each chunk is passed to `action` for
+                reatment
+            action (callable): Callable responsible of dealing with chunk of
+                data
+            chunk_size (int): Size of each chunk
+            **kwargs: Extra options to send to the server (e.g. sudo)
+
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabGetError: If the server failed to perform the request
+
+        Returns:
+            str: The package content if streamed is False, None otherwise
+        """
+        path = f"{self._computed_path}/{package_name}/{package_version}/{file_name}"
+        result = self.gitlab.http_get(path, streamed=streamed, raw=True, **kwargs)
+        if TYPE_CHECKING:
+            assert isinstance(result, requests.Response)
+        return utils.response_content(result, streamed, action, chunk_size)
 
 
 class GroupPackage(RESTObject):

--- a/gitlab/v4/objects/packages.py
+++ b/gitlab/v4/objects/packages.py
@@ -73,7 +73,7 @@ class GenericPackageManager(RESTManager):
 
         return self._obj_cls(
             self,
-            {
+            attrs={
                 "package_name": package_name,
                 "package_version": package_version,
                 "file_name": file_name,

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -41,7 +41,7 @@ from .merge_requests import ProjectMergeRequestManager  # noqa: F401
 from .milestones import ProjectMilestoneManager  # noqa: F401
 from .notes import ProjectNoteManager  # noqa: F401
 from .notification_settings import ProjectNotificationSettingsManager  # noqa: F401
-from .packages import ProjectPackageManager  # noqa: F401
+from .packages import GenericPackageManager, ProjectPackageManager  # noqa: F401
 from .pages import ProjectPagesDomainManager  # noqa: F401
 from .pipelines import (  # noqa: F401
     ProjectPipeline,
@@ -124,6 +124,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         ("exports", "ProjectExportManager"),
         ("files", "ProjectFileManager"),
         ("forks", "ProjectForkManager"),
+        ("generic_packages", "GenericPackageManager"),
         ("hooks", "ProjectHookManager"),
         ("keys", "ProjectKeyManager"),
         ("imports", "ProjectImportManager"),

--- a/tests/functional/api/test_packages.py
+++ b/tests/functional/api/test_packages.py
@@ -1,6 +1,14 @@
 """
-GitLab API: https://docs.gitlab.com/ce/api/packages.html
+GitLab API:
+https://docs.gitlab.com/ce/api/packages.html
+https://docs.gitlab.com/ee/user/packages/generic_packages
 """
+from gitlab.v4.objects import GenericPackage
+
+package_name = "hello-world"
+package_version = "v1.0.0"
+file_name = "hello.tar.gz"
+file_content = "package content"
 
 
 def test_list_project_packages(project):
@@ -11,3 +19,44 @@ def test_list_project_packages(project):
 def test_list_group_packages(group):
     packages = group.packages.list()
     assert isinstance(packages, list)
+
+
+def test_upload_generic_package(tmp_path, project):
+    path = tmp_path / file_name
+    path.write_text(file_content)
+    package = project.generic_packages.upload(
+        package_name=package_name,
+        package_version=package_version,
+        file_name=file_name,
+        path=path,
+    )
+
+    assert isinstance(package, GenericPackage)
+    assert package.message == "201 Created"
+
+
+def test_download_generic_package(project):
+    package = project.generic_packages.download(
+        package_name=package_name,
+        package_version=package_version,
+        file_name=file_name,
+    )
+
+    assert isinstance(package, bytes)
+    assert package.decode("utf-8") == file_content
+
+
+def test_download_generic_package_to_file(tmp_path, project):
+    path = tmp_path / file_name
+
+    with open(path, "wb") as f:
+        project.generic_packages.download(
+            package_name=package_name,
+            package_version=package_version,
+            file_name=file_name,
+            streamed=True,
+            action=f.write,
+        )
+
+    with open(path, "r") as f:
+        assert f.read() == file_content

--- a/tests/functional/cli/test_cli_packages.py
+++ b/tests/functional/cli/test_cli_packages.py
@@ -1,3 +1,9 @@
+package_name = "hello-world"
+package_version = "v1.0.0"
+file_name = "hello.tar.gz"
+file_content = "package content"
+
+
 def test_list_project_packages(gitlab_cli, project):
     cmd = ["project-package", "list", "--project-id", project.id]
     ret = gitlab_cli(cmd)
@@ -10,3 +16,45 @@ def test_list_group_packages(gitlab_cli, group):
     ret = gitlab_cli(cmd)
 
     assert ret.success
+
+
+def test_upload_generic_package(tmp_path, gitlab_cli, project):
+    path = tmp_path / file_name
+    path.write_text(file_content)
+
+    cmd = [
+        "-v",
+        "generic-package",
+        "upload",
+        "--project-id",
+        project.id,
+        "--package-name",
+        package_name,
+        "--path",
+        path,
+        "--package-version",
+        package_version,
+        "--file-name",
+        file_name,
+    ]
+    ret = gitlab_cli(cmd)
+
+    assert "201 Created" in ret.stdout
+
+
+def test_download_generic_package(gitlab_cli, project):
+    cmd = [
+        "generic-package",
+        "download",
+        "--project-id",
+        project.id,
+        "--package-name",
+        package_name,
+        "--package-version",
+        package_version,
+        "--file-name",
+        file_name,
+    ]
+    ret = gitlab_cli(cmd)
+
+    assert ret.stdout == file_content


### PR DESCRIPTION
Closes https://github.com/python-gitlab/python-gitlab/issues/1389.

I had to add a `raw` param to put/post like we have for get, instead of using `files` with the multipart encoder, to really ensure only the raw data ended up as the uploaded package :thinking:

Maybe it's just how `files` are handled currently and can still be refactored to take out redundant stuff if we want a raw upload. In the meantime I also cleaned out some code from `http_request` into a helper method and centralized the content_types there (`http_request` would be getting quite long and messy otherwise).