### PR TITLE
Switch mr.merge() to use post_data (was using query_data)

### DIFF
--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -342,7 +342,7 @@ class ProjectMergeRequest(
         if merge_when_pipeline_succeeds:
             data["merge_when_pipeline_succeeds"] = True
 
-        server_data = self.manager.gitlab.http_put(path, query_data=data, **kwargs)
+        server_data = self.manager.gitlab.http_put(path, post_data=data, **kwargs)
         self._update_attrs(server_data)
 
 

--- a/tools/functional/api/test_merge_requests.py
+++ b/tools/functional/api/test_merge_requests.py
@@ -1,6 +1,9 @@
+import time
+
 import pytest
 
 import gitlab
+import gitlab.v4.objects
 
 
 def test_merge_requests(project):
@@ -95,3 +98,59 @@ def test_merge_request_merge(project):
     with pytest.raises(gitlab.GitlabMRClosedError):
         # Two merge attempts should raise GitlabMRClosedError
         mr.merge()
+
+
+def test_merge_request_should_remove_source_branch(
+    project: gitlab.v4.objects.Project, wait_for_sidekiq
+):
+    """Test to ensure https://github.com/python-gitlab/python-gitlab/issues/1120
+    is fixed"""
+
+    source_branch = "remove_source_branch"
+    project.branches.create({"branch": source_branch, "ref": "master"})
+
+    # NOTE(jlvillal): Must create a commit in the new branch before we can
+    # create an MR that will work.
+    project.files.create(
+        {
+            "file_path": f"README.{source_branch}",
+            "branch": source_branch,
+            "content": "Initial content",
+            "commit_message": "New commit in new branch",
+        }
+    )
+
+    mr = project.mergerequests.create(
+        {
+            "source_branch": source_branch,
+            "target_branch": "master",
+            "title": "Should remove source branch",
+            "remove_source_branch": True,
+        }
+    )
+
+    result = wait_for_sidekiq(timeout=60)
+    assert result is True, "sidekiq process should have terminated but did not"
+
+    mr_iid = mr.iid
+    for _ in range(60):
+        mr = project.mergerequests.get(mr_iid)
+        if mr.merge_status != "checking":
+            break
+        time.sleep(0.5)
+    assert mr.merge_status != "checking"
+
+    # Ensure we can get the MR branch
+    project.branches.get(source_branch)
+
+    mr.merge(should_remove_source_branch=True)
+
+    result = wait_for_sidekiq(timeout=60)
+    assert result is True, "sidekiq process should have terminated but did not"
+
+    # Ensure we can NOT get the MR branch
+    with pytest.raises(gitlab.exceptions.GitlabGetError):
+        project.branches.get(source_branch)
+
+    mr = project.mergerequests.get(mr.iid)
+    assert mr.merged_at is not None  # Now is merged


### PR DESCRIPTION
MR https://github.com/python-gitlab/python-gitlab/pull/1121 changed
mr.merge() to use 'query_data'. This appears to have been wrong.

From the Gitlab docs they state it should be sent in a payload body
https://docs.gitlab.com/ee/api/README.html#request-payload since
mr.merge() is a PUT request.

```
Request Payload

API Requests can use parameters sent as query strings or as a
payload body. GET requests usually send a query string, while PUT
or POST requests usually send the payload body
```