### PR TITLE
chore: make certain dotfiles searchable by ripgrep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,14 @@ docs/_build
 .tox
 .venv/
 venv/
+
+# Include tracked hidden files and directories in search and diff tools
+!.commitlintrc.json
+!.dockerignore
+!.github/
+!.gitignore
+!.gitlab-ci.yml
+!.mypy.ini
+!.pre-commit-config.yaml
+!.readthedocs.yml
+!.renovaterc.json


### PR DESCRIPTION
By explicitly NOT excluding the dotfiles we care about to the
.gitignore file we make those files searchable by tools like ripgrep.

By default dotfiles are ignored by ripgrep and other search tools (not
grep)