### PR TITLE
Optionally keep containers after running integration tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,6 +186,21 @@ To run these tests:
    # run the python API tests:
    tox -e py_func_v4
 
+When developing tests it can be a little frustrating to wait for GitLab to spin
+up every run. To prevent the containers from being cleaned up afterwards, pass
+`--keep-containers` to pytest, i.e.:
+
+.. code-block:: bash
+
+   tox -e py_func_v4 -- --keep-containers
+
+If you then wish to test against a clean slate, you may perform a manual clean
+up of the containers by running:
+
+.. code-block:: bash
+
+   docker-compose -f tests/functional/fixtures/docker-compose.yml -p pytest-python-gitlab down -v
+
 By default, the tests run against the latest version of the ``gitlab/gitlab-ce``
 image. You can override both the image and tag by providing either the
 ``GITLAB_IMAGE`` or ``GITLAB_TAG`` environment variables.

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -787,7 +787,7 @@ class Gitlab(object):
             ) from e
 
     def http_delete(self, path: str, **kwargs: Any) -> requests.Response:
-        """Make a PUT request to the Gitlab server.
+        """Make a DELETE request to the Gitlab server.
 
         Args:
             path (str): Path or full URL to query ('/projects' or

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -576,7 +576,7 @@ class ObjectDeleteMixin(_RestObjectBase):
         """
         if TYPE_CHECKING:
             assert isinstance(self.manager, DeleteMixin)
-        self.manager.delete(self.get_id())
+        self.manager.delete(self.get_id(), **kwargs)
 
 
 class UserAgentDetailMixin(_RestObjectBase):

--- a/tests/functional/api/test_issues.py
+++ b/tests/functional/api/test_issues.py
@@ -4,11 +4,11 @@ import gitlab
 def test_create_issue(project):
     issue = project.issues.create({"title": "my issue 1"})
     issue2 = project.issues.create({"title": "my issue 2"})
-    issue_ids = [issue.id for issue in project.issues.list()]
-    assert len(issue_ids) == 2
+    issue_iids = [issue.iid for issue in project.issues.list()]
+    assert len(issue_iids) == 2
 
     # Test 'iids' as a list
-    assert len(project.issues.list(iids=issue_ids)) == 2
+    assert len(project.issues.list(iids=issue_iids)) == 2
 
     issue2.state_event = "close"
     issue2.save()

--- a/tests/functional/cli/test_cli_artifacts.py
+++ b/tests/functional/cli/test_cli_artifacts.py
@@ -1,11 +1,8 @@
 import subprocess
-import sys
 import textwrap
 import time
 from io import BytesIO
 from zipfile import is_zipfile
-
-import pytest
 
 content = textwrap.dedent(
     """\
@@ -23,11 +20,12 @@ data = {
 }
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="I am the walrus")
 def test_cli_artifacts(capsysbinary, gitlab_config, gitlab_runner, project):
     project.files.create(data)
 
-    while not (jobs := project.jobs.list(scope="success")):
+    jobs = None
+    while not jobs:
+        jobs = project.jobs.list(scope="success")
         time.sleep(0.5)
 
     job = project.jobs.get(jobs[0].id)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -12,8 +12,12 @@ import gitlab
 def reset_gitlab(gl):
     # previously tools/reset_gitlab.py
     for project in gl.projects.list():
+        for deploy_token in project.deploytokens.list():
+            deploy_token.delete()
         project.delete()
     for group in gl.groups.list():
+        for deploy_token in group.deploytokens.list():
+            deploy_token.delete()
         group.delete()
     for variable in gl.variables.list():
         variable.delete()

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -23,7 +23,7 @@ def reset_gitlab(gl):
         variable.delete()
     for user in gl.users.list():
         if user.username != "root":
-            user.delete()
+            user.delete(hard_delete=True)
 
 
 def set_token(container, rootdir):

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -50,6 +50,14 @@ def pytest_report_collectionfinish(config, startdir, items):
     ]
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--keep-containers",
+        action="store_true",
+        help="Keep containers running after testing",
+    )
+
+
 @pytest.fixture(scope="session")
 def temp_dir():
     return Path(tempfile.gettempdir())
@@ -63,6 +71,21 @@ def test_dir(pytestconfig):
 @pytest.fixture(scope="session")
 def docker_compose_file(test_dir):
     return test_dir / "fixtures" / "docker-compose.yml"
+
+
+@pytest.fixture(scope="session")
+def docker_compose_project_name():
+    """Set a consistent project name to enable optional reuse of containers."""
+    return "pytest-python-gitlab"
+
+
+@pytest.fixture(scope="session")
+def docker_cleanup(request):
+    """Conditionally keep containers around by overriding the cleanup command."""
+    if request.config.getoption("--keep-containers"):
+        # Print version and exit.
+        return "-v"
+    return "down -v"
 
 
 @pytest.fixture(scope="session")

--- a/tests/functional/fixtures/set_token.rb
+++ b/tests/functional/fixtures/set_token.rb
@@ -2,7 +2,7 @@
 
 user = User.find_by_username('root')
 
-token = user.personal_access_tokens.create(scopes: [:api, :sudo], name: 'default');
+token = user.personal_access_tokens.first_or_create(scopes: [:api, :sudo], name: 'default');
 token.set_token('python-gitlab-token');
 token.save!
 


### PR DESCRIPTION
While developing tests, waiting for a new GitLab container to spin up every run became a little frustrating, especially given I only wanted to run one file within the suite.

Added an optional flag which may be passed to pytest to keep the containers around after a test run.