### PR TITLE
feat(objects): add support for descendant groups API

### DIFF
--- a/docs/gl_objects/groups.rst
+++ b/docs/gl_objects/groups.rst
@@ -167,6 +167,31 @@ List the subgroups for a group::
         real_group = gl.groups.get(subgroup_id, lazy=True)
         real_group.issues.list()
 
+Descendant Groups
+=================
+
+Reference
+---------
+
+* v4 API:
+
+  + :class:`gitlab.v4.objects.GroupDescendantGroup`
+  + :class:`gitlab.v4.objects.GroupDescendantGroupManager`
+  + :attr:`gitlab.v4.objects.Group.descendant_groups`
+
+Examples
+--------
+
+List the descendant groups of a group::
+
+    descendant_groups = group.descendant_groups.list()
+
+.. note::
+
+    Like the ``GroupSubgroup`` objects described above, ``GroupDescendantGroup``
+    objects do not expose the same API as the ``Group`` objects. Create a new
+    ``Group`` object instead if needed, as shown in the subgroup example.
+
 Group custom attributes
 =======================
 

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -31,6 +31,8 @@ from .variables import GroupVariableManager  # noqa: F401
 __all__ = [
     "Group",
     "GroupManager",
+    "GroupDescendantGroup",
+    "GroupDescendantGroupManager",
     "GroupSubgroup",
     "GroupSubgroupManager",
 ]
@@ -45,6 +47,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
         ("billable_members", "GroupBillableMemberManager"),
         ("boards", "GroupBoardManager"),
         ("customattributes", "GroupCustomAttributeManager"),
+        ("descendant_groups", "GroupDescendantGroupManager"),
         ("exports", "GroupExportManager"),
         ("epics", "GroupEpicManager"),
         ("imports", "GroupImportManager"),
@@ -310,3 +313,17 @@ class GroupSubgroupManager(ListMixin, RESTManager):
         "min_access_level",
     )
     _types = {"skip_groups": types.ListAttribute}
+
+
+class GroupDescendantGroup(RESTObject):
+    pass
+
+
+class GroupDescendantGroupManager(GroupSubgroupManager):
+    """
+    This manager inherits from GroupSubgroupManager as descendant groups
+    share all attributes with subgroups, except the path and object class.
+    """
+
+    _path = "/groups/%(group_id)s/descendant_groups"
+    _obj_cls = GroupDescendantGroup

--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -32,6 +32,7 @@ def test_groups(gl):
     assert len(gl.groups.list(search="oup1")) == 1
     assert group3.parent_id == p_id
     assert group2.subgroups.list()[0].id == group3.id
+    assert group2.descendant_groups.list()[0].id == group3.id
 
     filtered_groups = gl.groups.list(skip_groups=[group3.id, group4.id])
     assert group3 not in filtered_groups


### PR DESCRIPTION
Closes https://github.com/python-gitlab/python-gitlab/issues/1479.

I'm struggling to understand why gitlab didn't just add a `recursive` param to subgroups instead of a whole new endpoint, but maybe I'm missing something ¯\\\_(ツ)\_/¯ :grin: 