### PR TITLE
fix: catch invalid type used to initialize RESTObject

### DIFF
--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -20,6 +20,7 @@ from types import ModuleType
 from typing import Any, Dict, Iterable, NamedTuple, Optional, Tuple, Type
 
 from gitlab import types as g_types
+from gitlab.exceptions import GitlabParsingError
 
 from .client import Gitlab, GitlabList
 
@@ -51,6 +52,12 @@ class RESTObject(object):
     manager: "RESTManager"
 
     def __init__(self, manager: "RESTManager", attrs: Dict[str, Any]) -> None:
+        if not isinstance(attrs, dict):
+            raise GitlabParsingError(
+                "Attempted to initialize RESTObject with a non-dictionary value: "
+                "{!r}\nThis likely indicates an incorrect or malformed server "
+                "response.".format(attrs)
+            )
         self.__dict__.update(
             {
                 "manager": manager,

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -19,6 +19,7 @@ import pickle
 
 import pytest
 
+import gitlab
 from gitlab import base
 
 
@@ -84,6 +85,10 @@ class TestRESTObject:
         assert obj._create_managers() is None
         assert fake_manager == obj.manager
         assert fake_gitlab == obj.manager.gitlab
+
+    def test_instantiate_non_dict(self, fake_gitlab, fake_manager):
+        with pytest.raises(gitlab.exceptions.GitlabParsingError):
+            FakeObject(fake_manager, ["a", "list", "fails"])
 
     def test_picklability(self, fake_manager):
         obj = FakeObject(fake_manager, {"foo": "bar"})


### PR DESCRIPTION
```
Sometimes we have errors where we don't get a dictionary passed to
RESTObject.__init__() method. This breaks things but in confusing
ways.

Check in the __init__() method and raise an exception if it occurs.
```