### PR TITLE
chore: add missing optional create parameter for approval_rules

### DIFF
--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -72,7 +72,8 @@ class ProjectApprovalRuleManager(
     _obj_cls = ProjectApprovalRule
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(
-        required=("name", "approvals_required"), optional=("user_ids", "group_ids")
+        required=("name", "approvals_required"),
+        optional=("user_ids", "group_ids", "protected_branch_ids"),
     )
 
 


### PR DESCRIPTION
Add missing optional create parameter ('protected_branch_ids') to the
project approvalrules.

https://docs.gitlab.com/ee/api/merge_request_approvals.html#create-project-level-rule