### PR TITLE
chore(ci): use PAT for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,9 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
     - name: Python Semantic Release
       uses: relekang/python-semantic-release@master
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
         pypi_token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Since we have a protected master branch the stock action doesn't work with the default auto-generated `GITHUB_TOKEN`. The workaround is described here:

https://python-semantic-release.readthedocs.io/en/latest/automatic-releases/github-actions.html?highlight=administrator

This fixes what we discussed earlier this morning @max-wittig.
 
For now I've added my token as `RELEASE_GITHUB_TOKEN` but we should discuss creating something like a `python-gitlab-bot` user for the releases maybe?