### PR TITLE
fix: functional project service test

### DIFF
--- a/tests/functional/api/test_projects.py
+++ b/tests/functional/api/test_projects.py
@@ -213,7 +213,12 @@ def test_project_remote_mirrors(project):
 
 
 def test_project_services(project):
+    # Use 'update' to create a service as we don't have a 'create' method and
+    # to add one is somewhat complicated so it hasn't been done yet.
+    project.services.update("asana", api_key="foo")
+
     service = project.services.get("asana")
+    assert service.active is True
     service.api_key = "whatever"
     service.save()
 

--- a/tests/functional/fixtures/.env
+++ b/tests/functional/fixtures/.env
@@ -1,2 +1,2 @@
 GITLAB_IMAGE=gitlab/gitlab-ce
-GITLAB_TAG=13.11.4-ce.0
+GITLAB_TAG=13.12.0-ce.0

--- a/tests/functional/fixtures/docker-compose.yml
+++ b/tests/functional/fixtures/docker-compose.yml
@@ -11,10 +11,10 @@ services:
     hostname: 'gitlab.test'
     privileged: true # Just in case https://gitlab.com/gitlab-org/omnibus-gitlab/-/issues/1350
     environment:
+      GITLAB_ROOT_PASSWORD: 5iveL!fe
+      GITLAB_SHARED_RUNNERS_REGISTRATION_TOKEN: registration-token
       GITLAB_OMNIBUS_CONFIG: |
         external_url 'http://gitlab.test'
-        gitlab_rails['initial_root_password'] = '5iveL!fe'
-        gitlab_rails['initial_shared_runners_registration_token'] = 'registration-token'
         registry['enable'] = false
         nginx['redirect_http_to_https'] = false
         nginx['listen_port'] = 80


### PR DESCRIPTION
```
The PR: https://github.com/python-gitlab/python-gitlab/pull/1462 was
not able to merge due to a change in the latest version of Gitlab.

More details here:
https://gitlab.com/gitlab-org/gitlab/-/merge_requests/61646

Update the functional test to first create the project service before
doing a get.
```

Also bring in the two commits from https://github.com/python-gitlab/python-gitlab/pull/1462