### PR TITLE
chore: add new required type packages for mypy

### DIFF
--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -2,3 +2,5 @@ black==20.8b1
 flake8==3.9.2
 isort==5.8.0
 mypy==0.812
+types-PyYAML==0.1.5
+types-requests==0.1.8


### PR DESCRIPTION
New version of mypy flagged errors for missing types. Install the
recommended type-* packages that resolve the issues.

PR https://github.com/python-gitlab/python-gitlab/pull/1504 will fail until this is merged.