### PR TITLE
feat(api): Add merge_ref for merge requests

### DIFF
--- a/docs/gl_objects/mrs.rst
+++ b/docs/gl_objects/mrs.rst
@@ -182,6 +182,11 @@ Attempt to rebase an MR::
 
     mr.rebase()
 
+Attempt to merge changes between source and target branch::
+
+    response = mr.merge_ref()
+    print(response['commit_id'])
+
 Merge Request Pipelines
 =======================
 

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -297,6 +297,21 @@ class ProjectMergeRequest(
         data = {}
         return self.manager.gitlab.http_put(path, post_data=data, **kwargs)
 
+    @cli.register_custom_action("ProjectMergeRequest")
+    @exc.on_http_error(exc.GitlabGetError)
+    def merge_ref(self, **kwargs):
+        """Attempt to merge changes between source and target branches into
+            `refs/merge-requests/:iid/merge`.
+
+        Args:
+            **kwargs: Extra options to send to the server (e.g. sudo)
+
+        Raises:
+            GitlabGetError: If cannot be merged
+        """
+        path = "%s/%s/merge_ref" % (self.manager.path, self.get_id())
+        return self.manager.gitlab.http_get(path, **kwargs)
+
     @cli.register_custom_action(
         "ProjectMergeRequest",
         tuple(),


### PR DESCRIPTION
Support merge_ref on merge requests that returns commit of attempted
merge of the MR.

Signed-off-by: Matej Focko <mfocko@redhat.com>

Needed to finish packit/ogr#584