### PR TITLE
docs(project): add example on getting a single project using name with namespace

### DIFF
--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -66,6 +66,10 @@ Get a single project::
     project_id = 851
     project = gl.projects.get(project_id)
 
+    # Get a project by name with namespace
+    project_name_with_namespace = "namespace/project_name"
+    project = gl.projects.get(project_name_with_namespace)
+
 Create a project::
 
     project = gl.projects.create({'name': 'project1'})


### PR DESCRIPTION
Hello,

This is apparently not present in the documentation (I couldn't find it) while the API supports it and it's very useful.

I've tried to keep the terminology "name_with_namespace" from `project.attributes`.

Kind regards,