### PR TITLE
Do not require Release name for creation

### DIFF
--- a/gitlab/v4/objects/releases.py
+++ b/gitlab/v4/objects/releases.py
@@ -19,7 +19,7 @@ class ProjectReleaseManager(CRUDMixin, RESTManager):
     _obj_cls = ProjectRelease
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(
-        required=("name", "tag_name", "description"), optional=("ref", "assets")
+        required=("tag_name", "description"), optional=("name", "ref", "assets")
     )
     _update_attrs = RequiredOptional(
         optional=("name", "description", "milestones", "released_at")

--- a/tests/functional/api/test_releases.py
+++ b/tests/functional/api/test_releases.py
@@ -23,6 +23,24 @@ def test_create_project_release(project, project_file):
     assert release.description == release_description
 
 
+def test_create_project_release_no_name(project, project_file):
+    unnamed_release_tag_name = "v2.3.4"
+
+    project.refresh()  # Gets us the current default branch
+    release = project.releases.create(
+        {
+            "tag_name": unnamed_release_tag_name,
+            "description": release_description,
+            "ref": project.default_branch,
+        }
+    )
+
+    assert len(project.releases.list()) >= 1
+    assert project.releases.get(unnamed_release_tag_name)
+    assert release.tag_name == unnamed_release_tag_name
+    assert release.description == release_description
+
+
 def test_update_save_project_release(project, release):
     updated_description = f"{release.description} updated"
     release.description = updated_description


### PR DESCRIPTION
This has not been required by the [GitLab API](https://docs.gitlab.com/ee/api/releases/#create-a-release) since v12.5, so should not be required here.