### PR TITLE
fix(deps): upgrade requests to minimum 2.25.0 (CVE-2021-33503)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     license="LGPLv3",
     url="https://github.com/python-gitlab/python-gitlab",
     packages=find_packages(),
-    install_requires=["requests>=2.22.0", "requests-toolbelt>=0.9.1"],
+    install_requires=["requests>=2.25.0", "requests-toolbelt>=0.9.1"],
     package_data={
         "gitlab": ["py.typed"],
     },


### PR DESCRIPTION
Closes https://github.com/python-gitlab/python-gitlab/issues/1547.

We have already been testing with 2.25.x and 2.26.0 for a while (https://github.com/python-gitlab/python-gitlab/commits/master/requirements.txt), so I don't see an issue bumping this. Technically 2.25.0 already has the urllib3 fix though.