### PR TITLE
feat: allow global retry_transient_errors

### DIFF
--- a/docs/api-usage.rst
+++ b/docs/api-usage.rst
@@ -391,6 +391,17 @@ default an exception is raised for these errors.
    gl = gitlab.gitlab(url, token, api_version=4)
    gl.projects.list(all=True, retry_transient_errors=True)
 
+The default ``retry_transient_errors`` can also be set on the ``Gitlab`` object
+and overridden by individual API calls.
+
+.. code-block:: python
+
+   import gitlab
+   import requests
+   gl = gitlab.gitlab(url, token, api_version=4, retry_transient_errors=True)
+   gl.projects.list(all=True)                               # retries due to default value
+   gl.projects.list(all=True, retry_transient_errors=False) # does not retry
+
 Timeout
 -------
 

--- a/gitlab/config.py
+++ b/gitlab/config.py
@@ -206,6 +206,20 @@ class GitlabConfigParser(object):
         except Exception:
             pass
 
+        self.retry_transient_errors = False
+        try:
+            self.retry_transient_errors = self._config.getboolean(
+                "global", "retry_transient_errors"
+            )
+        except Exception:
+            pass
+        try:
+            self.retry_transient_errors = self._config.getboolean(
+                self.gitlab_id, "retry_transient_errors"
+            )
+        except Exception:
+            pass
+
     def _get_values_from_helper(self) -> None:
         """Update attributes that may get values from an external helper program"""
         for attr in HELPER_ATTRIBUTES:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,7 +9,18 @@ def gl():
         "http://localhost",
         private_token="private_token",
         ssl_verify=True,
-        api_version=4,
+        api_version="4",
+    )
+
+
+@pytest.fixture
+def gl_retry():
+    return gitlab.Gitlab(
+        "http://localhost",
+        private_token="private_token",
+        ssl_verify=True,
+        api_version="4",
+        retry_transient_errors=True,
     )
 
 
@@ -17,7 +28,7 @@ def gl():
 @pytest.fixture
 def gl_trailing():
     return gitlab.Gitlab(
-        "http://localhost/", private_token="private_token", api_version=4
+        "http://localhost/", private_token="private_token", api_version="4"
     )
 
 


### PR DESCRIPTION
Value set on the `Gitlab` object will be used as a default in case every
subsequent API call does not provide a `retry_transient_errors`
parameter.

This allows code to be succinct and the retry policy to be set for all
calls to the `Gitlab` instance.