### PR TITLE
docs(mergequests): gl.mergequests.list documentation was missleading

### DIFF
--- a/docs/gl_objects/mrs.rst
+++ b/docs/gl_objects/mrs.rst
@@ -30,9 +30,13 @@ Reference
 Examples
 --------
 
-List the merge requests available on the GitLab server::
+List the merge requests created by the user of the token on the GitLab server::
 
     mrs = gl.mergerequests.list()
+
+List the merge requests available on the GitLab server::
+
+    mrs = gl.mergerequests.list(scope="all")
 
 List the merge requests for a group::
 


### PR DESCRIPTION
Hello,

Quoting gitlab's official documentation: https://docs.gitlab.com/ce/api/merge_requests.html#list-merge-requests

> Get all merge requests the authenticated user has access to. By default it returns only merge requests created by the current user. To get all merge requests, use parameter scope=all. 

I've tried to adapt the documentation according to this fact.

Kind regards,