### PR TITLE
fix(api): allow creating an approval rule without requiring 'name'

### DIFF
--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -203,4 +203,11 @@ class ProjectMergeRequestApprovalRuleManager(
         new_data = data.copy()
         new_data["id"] = self._from_parent_attrs["project_id"]
         new_data["merge_request_iid"] = self._from_parent_attrs["mr_iid"]
+        # If the input includes approval_project_rule_id then don't require 'name'.
+        if new_data.get('approval_project_rule_id'):
+            self._create_attrs = RequiredOptional(
+                required=("id", "merge_request_iid", "approval_project_rule_id",
+                          "approvals_required"),
+                optional=("name", "user_ids", "group_ids"),
+            )
         return CreateMixin.create(self, new_data, **kwargs)


### PR DESCRIPTION
The API allows to create an approval rule by referencing a project-level
approval rule ID. In this case, it is not necessary to pass a rule
'name'. Change the ProjectMergeRequestApprovalRuleManager create method
to use a different set of _create_attrs when an approval_project_rule_id
is passed in.

Signed-off-by: Patrick Talbert <ptalbert@redhat.com>