### PR TITLE
Added merge_base API endpoint support

### DIFF
--- a/gitlab/v4/objects/repositories.py
+++ b/gitlab/v4/objects/repositories.py
@@ -135,6 +135,26 @@ class RepositoryMixin:
         query_data = {"from": from_, "to": to}
         return self.manager.gitlab.http_get(path, query_data=query_data, **kwargs)
 
+    @cli.register_custom_action("Project", ("from_", "to"))
+    @exc.on_http_error(exc.GitlabGetError)
+    def merge_base(self, from_, to, **kwargs):
+        """Return a diff between two branches/commits.
+
+        Args:
+            from_(str): Source branch/SHA
+            to(str): Destination branch/SHA
+            **kwargs: Extra options to send to the server (e.g. sudo)
+
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabGetError: If the server failed to perform the request
+
+        Returns:
+            str: The diff
+        """
+        path = f'/projects/{self.get_id()}/repository/merge_base?refs[]={from_}&refs[]={to}'
+        return self.manager.gitlab.http_get(path, **kwargs)
+
     @cli.register_custom_action("Project")
     @exc.on_http_error(exc.GitlabGetError)
     def repository_contributors(self, **kwargs):


### PR DESCRIPTION
Added simple merge_base API endpoint support, based on the repository_compare code.

Closes https://github.com/python-gitlab/python-gitlab/issues/1495.