### PR TITLE
Improve helper example section with env var usage

### DIFF
--- a/docs/cli-usage.rst
+++ b/docs/cli-usage.rst
@@ -170,6 +170,25 @@ In `/path/to/helper.sh`:
 
     #!/bin/bash
     pass show path/to/password | head -n 1
+    
+Example for an `environnement variable`:
+
+.. code-block:: ini
+
+   [global]
+   default = somewhere
+   ssl_verify = true
+   timeout = 5
+
+   [somewhere]
+   url = http://somewhe.re
+   private_token = helper: printf -- '%%s' ${GITLAB_TOKEN}
+   timeout = 1
+
+**Notice:**
+
+   * ``printf`` is the executable provided by coreutils package (on a debian based distribution).
+   * ``%`` must be escaped using an other `%` (in order to allow `configparser` load configuration properly.
 
 CLI
 ===


### PR DESCRIPTION
Hi,
I wanted to use an env var for the token.
I spend some time to figure out that I needed to escape '%' because of configparser.
Therefore, I made this PR to improve the current documentation hoping others will spend much less time than me.
Kind regards,