### PR TITLE
docs: correct documented return type

### DIFF
--- a/gitlab/v4/objects/repositories.py
+++ b/gitlab/v4/objects/repositories.py
@@ -180,7 +180,7 @@ class RepositoryMixin:
             GitlabListError: If the server failed to perform the request
 
         Returns:
-            str: The binary data of the archive
+            bytes: The binary data of the archive
         """
         path = "/projects/%s/repository/archive" % self.get_id()
         query_data = {}


### PR DESCRIPTION
repository_archive() returns 'bytes' not 'str'

https://docs.gitlab.com/ee/api/repositories.html#get-file-archive

Fixes: #1584