### PR TITLE
fix(build): only package tests in source distribution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
             toxenv: py38
           - python-version: 3.9
             toxenv: py39
+          - python-version: 3.9
+            toxenv: smoke
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ module = [
     "setup",
     "tests.functional.*",
     "tests.functional.api.*",
-    "tests.unit.*"
+    "tests.unit.*",
+    "tests.smoke.*"
 ]
 ignore_errors = true
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     author_email="gauvain@pocentek.net",
     license="LGPLv3",
     url="https://github.com/python-gitlab/python-gitlab",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests*"]),
     install_requires=["requests>=2.25.0", "requests-toolbelt>=0.9.1"],
     package_data={
         "gitlab": ["py.typed"],

--- a/tests/smoke/test_dists.py
+++ b/tests/smoke/test_dists.py
@@ -1,0 +1,33 @@
+import tarfile
+import zipfile
+from pathlib import Path
+from sys import version_info
+
+import pytest
+from setuptools import sandbox
+
+from gitlab import __title__, __version__
+
+DIST_DIR = Path("dist")
+TEST_DIR = "tests"
+SDIST_FILE = f"{__title__}-{__version__}.tar.gz"
+WHEEL_FILE = (
+    f"{__title__.replace('-', '_')}-{__version__}-py{version_info.major}-none-any.whl"
+)
+
+
+@pytest.fixture(scope="function")
+def build():
+    sandbox.run_setup("setup.py", ["clean", "--all"])
+    return sandbox.run_setup("setup.py", ["sdist", "bdist_wheel"])
+
+
+def test_sdist_includes_tests(build):
+    sdist = tarfile.open(DIST_DIR / SDIST_FILE, "r:gz")
+    test_dir = sdist.getmember(f"{__title__}-{__version__}/{TEST_DIR}")
+    assert test_dir.isdir()
+
+
+def test_wheel_excludes_tests(build):
+    wheel = zipfile.ZipFile(DIST_DIR / WHEEL_FILE)
+    assert [not file.startswith(TEST_DIR) for file in wheel.namelist()]

--- a/tox.ini
+++ b/tox.ini
@@ -96,3 +96,7 @@ commands =
 deps = -r{toxinidir}/requirements-docker.txt
 commands =
   pytest --cov --cov-report xml tests/functional/api {posargs}
+
+[testenv:smoke]
+deps = -r{toxinidir}/requirements-test.txt
+commands = pytest tests/smoke {posargs}


### PR DESCRIPTION
Closes https://github.com/python-gitlab/python-gitlab/issues/1586.

This way tests are packaged in the source distribution (via includes in Manifest), but excluded from the wheel.