### PR TITLE
chore(objects): remove deprecated pipelines() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 * **release:** Allow to update release ([`b4c4787`](https://github.com/python-gitlab/python-gitlab/commit/b4c4787af54d9db6c1f9e61154be5db9d46de3dd))
 * **api:** Add group hooks ([`4a7e9b8`](https://github.com/python-gitlab/python-gitlab/commit/4a7e9b86aa348b72925bce3af1e5d988b8ce3439))
 * **api:** Remove responsibility for API inconsistencies for MR reviewers ([`3d985ee`](https://github.com/python-gitlab/python-gitlab/commit/3d985ee8cdd5d27585678f8fbb3eb549818a78eb))
-* **api:** Add MR pipeline manager in favor of pipelines() method ([`954357c`](https://github.com/python-gitlab/python-gitlab/commit/954357c49963ef51945c81c41fd4345002f9fb98))
+* **api:** Add MR pipeline manager and deprecate pipelines() method ([`954357c`](https://github.com/python-gitlab/python-gitlab/commit/954357c49963ef51945c81c41fd4345002f9fb98))
 * **api:** Add support for creating/editing reviewers in project merge requests ([`676d1f6`](https://github.com/python-gitlab/python-gitlab/commit/676d1f6565617a28ee84eae20e945f23aaf3d86f))
 
 ### Documentation

--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -1,5 +1,3 @@
-import warnings
-
 from gitlab import cli
 from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
@@ -44,33 +42,6 @@ class ProjectMergeRequestPipelineManager(CreateMixin, ListMixin, RESTManager):
     _path = "/projects/%(project_id)s/merge_requests/%(mr_iid)s/pipelines"
     _obj_cls = ProjectMergeRequestPipeline
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}
-
-    # If the manager was called directly as a callable via
-    # mr.pipelines(), execute the deprecated method for now.
-    # TODO: in python-gitlab 3.0.0, remove this method entirely.
-
-    @cli.register_custom_action("ProjectMergeRequest", custom_action="pipelines")
-    @exc.on_http_error(exc.GitlabListError)
-    def __call__(self, **kwargs):
-        """List the merge request pipelines.
-
-        Args:
-            **kwargs: Extra options to send to the server (e.g. sudo)
-
-        Raises:
-            GitlabAuthenticationError: If authentication is not correct
-            GitlabListError: If the list could not be retrieved
-
-        Returns:
-            RESTObjectList: List of changes
-        """
-        warnings.warn(
-            "Calling the ProjectMergeRequest.pipelines() method on "
-            "merge request objects directly is deprecated and will be replaced "
-            "by ProjectMergeRequest.pipelines.list() in python-gitlab 3.0.0.\n",
-            DeprecationWarning,
-        )
-        return self.list(**kwargs)
 
 
 class ProjectPipeline(RefreshMixin, ObjectDeleteMixin, RESTObject):

--- a/tests/unit/objects/test_merge_request_pipelines.py
+++ b/tests/unit/objects/test_merge_request_pipelines.py
@@ -40,17 +40,6 @@ def resp_create_merge_request_pipeline():
         yield rsps
 
 
-def test_merge_requests_pipelines_deprecated_raises_warning(
-    project, resp_list_merge_request_pipelines
-):
-    with pytest.deprecated_call():
-        pipelines = project.mergerequests.get(1, lazy=True).pipelines()
-
-    assert len(pipelines) == 1
-    assert isinstance(pipelines[0], ProjectMergeRequestPipeline)
-    assert pipelines[0].sha == pipeline_content["sha"]
-
-
 def test_list_merge_requests_pipelines(project, resp_list_merge_request_pipelines):
     pipelines = project.mergerequests.get(1, lazy=True).pipelines.list()
     assert len(pipelines) == 1


### PR DESCRIPTION


BREAKING CHANGE: remove deprecated pipelines() methods in favor of pipelines.list()