### PR TITLE
refactor(objects): remove deprecated members.all() method

### DIFF
--- a/docs/gl_objects/groups.rst
+++ b/docs/gl_objects/groups.rst
@@ -272,8 +272,6 @@ List the group members recursively (including inherited members through
 ancestor groups)::
 
     members = group.members_all.list(all=True)
-    # or
-    members = group.members.all(all=True) # Deprecated
 
 Get only direct group member::
 

--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -519,8 +519,6 @@ List the project members recursively (including inherited members through
 ancestor groups)::
 
     members = project.members_all.list(all=True)
-    # or
-    members = project.members.all(all=True) # Deprecated
 
 Search project members matching a query string::
 

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import warnings
 from types import ModuleType
 from typing import (
     Any,
@@ -927,50 +926,3 @@ class BadgeRenderMixin(_RestManagerBase):
         if TYPE_CHECKING:
             assert not isinstance(result, requests.Response)
         return result
-
-
-class MemberAllMixin(_RestManagerBase):
-    """This mixin is deprecated."""
-
-    _computed_path: Optional[str]
-    _from_parent_attrs: Dict[str, Any]
-    _obj_cls: Optional[Type[base.RESTObject]]
-    _parent: Optional[base.RESTObject]
-    _parent_attrs: Dict[str, Any]
-    _path: Optional[str]
-    gitlab: gitlab.Gitlab
-
-    @cli.register_custom_action(("GroupMemberManager", "ProjectMemberManager"))
-    @exc.on_http_error(exc.GitlabListError)
-    def all(self, **kwargs: Any) -> List[base.RESTObject]:
-        """List all the members, included inherited ones.
-
-        This Method is deprecated.
-
-        Args:
-            all (bool): If True, return all the items, without pagination
-            per_page (int): Number of items to retrieve per request
-            page (int): ID of the page to return (starts with page 1)
-            as_list (bool): If set to False and no pagination option is
-                defined, return a generator instead of a list
-            **kwargs: Extra options to send to the server (e.g. sudo)
-
-        Raises:
-            GitlabAuthenticationError: If authentication is not correct
-            GitlabListError: If the list could not be retrieved
-
-        Returns:
-            RESTObjectList: The list of members
-        """
-
-        warnings.warn(
-            "The all() method for this object is deprecated "
-            "and will be removed in a future version. Use .members_all.list(all=True), instead.",
-            DeprecationWarning,
-        )
-        path = "%s/all" % self.path
-
-        if TYPE_CHECKING:
-            assert self._obj_cls is not None
-        obj = self.gitlab.http_list(path, **kwargs)
-        return [self._obj_cls(self, item) for item in obj]

--- a/gitlab/v4/objects/members.py
+++ b/gitlab/v4/objects/members.py
@@ -4,7 +4,6 @@ from gitlab.mixins import (
     CRUDMixin,
     DeleteMixin,
     ListMixin,
-    MemberAllMixin,
     ObjectDeleteMixin,
     RetrieveMixin,
     SaveMixin,
@@ -28,7 +27,7 @@ class GroupMember(SaveMixin, ObjectDeleteMixin, RESTObject):
     _short_print_attr = "username"
 
 
-class GroupMemberManager(MemberAllMixin, CRUDMixin, RESTManager):
+class GroupMemberManager(CRUDMixin, RESTManager):
     _path = "/groups/%(group_id)s/members"
     _obj_cls = GroupMember
     _from_parent_attrs = {"group_id": "id"}
@@ -74,7 +73,7 @@ class ProjectMember(SaveMixin, ObjectDeleteMixin, RESTObject):
     _short_print_attr = "username"
 
 
-class ProjectMemberManager(MemberAllMixin, CRUDMixin, RESTManager):
+class ProjectMemberManager(CRUDMixin, RESTManager):
     _path = "/projects/%(project_id)s/members"
     _obj_cls = ProjectMember
     _from_parent_attrs = {"project_id": "id"}

--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -89,7 +89,6 @@ def test_groups(gl):
 
     group1.members.delete(user.id)
     assert len(group1.members.list()) == 2
-    assert len(group1.members.all())  # Deprecated
     assert len(group1.members_all.list())
     member = group1.members.get(user2.id)
     member.access_level = gitlab.const.OWNER_ACCESS


### PR DESCRIPTION
BREAKING CHANGE: remove deprecated members.all() method in favor of members_all.list()