### PR TITLE
refactor(objects): remove deprecated project.issuesstatistics

### DIFF
--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -135,7 +135,6 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
     imports: ProjectImportManager
     issues: ProjectIssueManager
     issues_statistics: ProjectIssuesStatisticsManager
-    issuesstatistics: ProjectIssuesStatisticsManager  # Deprecated
     jobs: ProjectJobManager
     keys: ProjectKeyManager
     labels: ProjectLabelManager

--- a/tests/unit/objects/test_issues.py
+++ b/tests/unit/objects/test_issues.py
@@ -86,7 +86,3 @@ def test_get_project_issues_statistics(project, resp_issue_statistics):
     statistics = project.issues_statistics.get()
     assert isinstance(statistics, ProjectIssuesStatistics)
     assert statistics.statistics["counts"]["all"] == 20
-
-    # Deprecated attribute
-    deprecated = project.issuesstatistics.get()
-    assert deprecated.statistics == statistics.statistics


### PR DESCRIPTION
BREAKING CHANGE: remove deprecated project.issuesstatistics in favor of project.issues_statistics