### PR TITLE
refactor(objects): remove deprecated tag release API

### DIFF
--- a/gitlab/v4/objects/tags.py
+++ b/gitlab/v4/objects/tags.py
@@ -1,5 +1,3 @@
-from gitlab import cli
-from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import NoUpdateMixin, ObjectDeleteMixin
 
@@ -14,41 +12,6 @@ __all__ = [
 class ProjectTag(ObjectDeleteMixin, RESTObject):
     _id_attr = "name"
     _short_print_attr = "name"
-
-    @cli.register_custom_action("ProjectTag", ("description",))
-    def set_release_description(self, description, **kwargs):
-        """Set the release notes on the tag.
-
-        If the release doesn't exist yet, it will be created. If it already
-        exists, its description will be updated.
-
-        Args:
-            description (str): Description of the release.
-            **kwargs: Extra options to send to the server (e.g. sudo)
-
-        Raises:
-            GitlabAuthenticationError: If authentication is not correct
-            GitlabCreateError: If the server fails to create the release
-            GitlabUpdateError: If the server fails to update the release
-        """
-        id = self.get_id().replace("/", "%2F")
-        path = "%s/%s/release" % (self.manager.path, id)
-        data = {"description": description}
-        if self.release is None:
-            try:
-                server_data = self.manager.gitlab.http_post(
-                    path, post_data=data, **kwargs
-                )
-            except exc.GitlabHttpError as e:
-                raise exc.GitlabCreateError(e.response_code, e.error_message) from e
-        else:
-            try:
-                server_data = self.manager.gitlab.http_put(
-                    path, post_data=data, **kwargs
-                )
-            except exc.GitlabHttpError as e:
-                raise exc.GitlabUpdateError(e.response_code, e.error_message) from e
-        self.release = server_data
 
 
 class ProjectTagManager(NoUpdateMixin, RESTManager):

--- a/tests/functional/api/test_projects.py
+++ b/tests/functional/api/test_projects.py
@@ -243,10 +243,6 @@ def test_project_tags(project, project_file):
     tag = project.tags.create({"tag_name": "v1.0", "ref": "master"})
     assert len(project.tags.list()) == 1
 
-    tag.set_release_description("Description 1")
-    tag.set_release_description("Description 2")
-    assert tag.release["description"] == "Description 2"
-
     tag.delete()
     assert len(project.tags.list()) == 0
 


### PR DESCRIPTION
BREAKING CHANGE: remove deprecated tag release API.
This was removed in cca. GitLab 14.0