### PR TITLE
refactor(objects): remove deprecated branch protect methods

### DIFF
--- a/docs/gl_objects/branches.rst
+++ b/docs/gl_objects/branches.rst
@@ -35,21 +35,8 @@ Delete a repository branch::
     # or
     branch.delete()
 
-Protect/unprotect a repository branch::
-
-    branch.protect()
-    branch.unprotect()
-
-.. note::
-
-   By default, developers are not authorized to push or merge into protected
-   branches. This can be changed by passing ``developers_can_push`` or
-   ``developers_can_merge``:
-
-   .. code-block:: python
-
-      branch.protect(developers_can_push=True, developers_can_merge=True)
-
 Delete the merged branches for a project::
 
     project.delete_merged_branches()
+
+To manage protected branches, see :doc:`/gl_objects/protected_branches`.

--- a/gitlab/v4/objects/branches.py
+++ b/gitlab/v4/objects/branches.py
@@ -1,5 +1,3 @@
-from gitlab import cli
-from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import NoUpdateMixin, ObjectDeleteMixin
 
@@ -13,50 +11,6 @@ __all__ = [
 
 class ProjectBranch(ObjectDeleteMixin, RESTObject):
     _id_attr = "name"
-
-    @cli.register_custom_action(
-        "ProjectBranch", tuple(), ("developers_can_push", "developers_can_merge")
-    )
-    @exc.on_http_error(exc.GitlabProtectError)
-    def protect(self, developers_can_push=False, developers_can_merge=False, **kwargs):
-        """Protect the branch.
-
-        Args:
-            developers_can_push (bool): Set to True if developers are allowed
-                                        to push to the branch
-            developers_can_merge (bool): Set to True if developers are allowed
-                                         to merge to the branch
-            **kwargs: Extra options to send to the server (e.g. sudo)
-
-        Raises:
-            GitlabAuthenticationError: If authentication is not correct
-            GitlabProtectError: If the branch could not be protected
-        """
-        id = self.get_id().replace("/", "%2F")
-        path = "%s/%s/protect" % (self.manager.path, id)
-        post_data = {
-            "developers_can_push": developers_can_push,
-            "developers_can_merge": developers_can_merge,
-        }
-        self.manager.gitlab.http_put(path, post_data=post_data, **kwargs)
-        self._attrs["protected"] = True
-
-    @cli.register_custom_action("ProjectBranch")
-    @exc.on_http_error(exc.GitlabProtectError)
-    def unprotect(self, **kwargs):
-        """Unprotect the branch.
-
-        Args:
-            **kwargs: Extra options to send to the server (e.g. sudo)
-
-        Raises:
-            GitlabAuthenticationError: If authentication is not correct
-            GitlabProtectError: If the branch could not be unprotected
-        """
-        id = self.get_id().replace("/", "%2F")
-        path = "%s/%s/unprotect" % (self.manager.path, id)
-        self.manager.gitlab.http_put(path, **kwargs)
-        self._attrs["protected"] = False
 
 
 class ProjectBranchManager(NoUpdateMixin, RESTManager):


### PR DESCRIPTION
BREAKING CHANGE: remove deprecated branch protect methods in favor of
the more complete Protected branches API.

Closes https://github.com/python-gitlab/python-gitlab/issues/821.

@max-wittig WDYT about removing this completely? Then people will stop getting confused about the two APIs like in https://github.com/python-gitlab/python-gitlab/issues/1355 and https://github.com/python-gitlab/python-gitlab/issues/821. The endpoint still technically works, but the GitLab API docs removed it ages ago and they point to the dedicated protected branches API now (https://docs.gitlab.com/ee/api/branches.html#protect-repository-branch). 

Last time we kept a deprecated endpoint (release via tags API) it bit us because GitLab then "silently" removed it. Just adding this to the list of breaking changes as the next scheduled job will trigger 3.0.0.