### PR TITLE
docs: fix a few typos

### DIFF
--- a/docs/gl_objects/deploy_tokens.rst
+++ b/docs/gl_objects/deploy_tokens.rst
@@ -75,7 +75,7 @@ the following parameters:
 
    With GitLab 12.9, even though ``username`` and ``expires_at`` are not required, they always have to be passed to the API.
    You can set them to empty strings, see: https://gitlab.com/gitlab-org/gitlab/-/issues/211878.
-   Also, the ``username``'s value is ignored by the API and will be overriden with ``gitlab+deploy-token-{n}``,
+   Also, the ``username``'s value is ignored by the API and will be overridden with ``gitlab+deploy-token-{n}``,
    see: https://gitlab.com/gitlab-org/gitlab/-/issues/211963
    These issues were fixed in GitLab 12.10.
 
@@ -125,7 +125,7 @@ the following parameters:
 
    With GitLab 12.9, even though ``username`` and ``expires_at`` are not required, they always have to be passed to the API.
    You can set them to empty strings, see: https://gitlab.com/gitlab-org/gitlab/-/issues/211878.
-   Also, the ``username``'s value is ignored by the API and will be overriden with ``gitlab+deploy-token-{n}``,
+   Also, the ``username``'s value is ignored by the API and will be overridden with ``gitlab+deploy-token-{n}``,
    see: https://gitlab.com/gitlab-org/gitlab/-/issues/211963
    These issues were fixed in GitLab 12.10.
 

--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -192,7 +192,7 @@ class RESTObjectList(object):
     This generator uses the Gitlab pagination system to fetch new data when
     required.
 
-    Note: you should not instanciate such objects, they are returned by calls
+    Note: you should not instantiate such objects, they are returned by calls
     to RESTManager.list()
 
     Args:

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -439,7 +439,7 @@ class SetMixin(_RestManagerBase):
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct
-            GitlabSetError: If an error occured
+            GitlabSetError: If an error occurred
 
         Returns:
             obj: The created/updated attribute
@@ -661,7 +661,7 @@ class DownloadMixin(_RestObjectBase):
         Args:
             streamed (bool): If True the data will be processed by chunks of
                 `chunk_size` and each chunk is passed to `action` for
-                reatment
+                treatment
             action (callable): Callable responsible of dealing with chunk of
                 data
             chunk_size (int): Size of each chunk

--- a/gitlab/v4/objects/features.py
+++ b/gitlab/v4/objects/features.py
@@ -41,7 +41,7 @@ class FeatureManager(ListMixin, DeleteMixin, RESTManager):
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct
-            GitlabSetError: If an error occured
+            GitlabSetError: If an error occurred
 
         Returns:
             obj: The created/updated attribute

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -83,7 +83,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct
-            GitlabTransferProjectError: If the project could not be transfered
+            GitlabTransferProjectError: If the project could not be transferred
         """
         path = "/groups/%s/projects/%s" % (self.id, project_id)
         self.manager.gitlab.http_post(path, **kwargs)

--- a/gitlab/v4/objects/packages.py
+++ b/gitlab/v4/objects/packages.py
@@ -105,7 +105,7 @@ class GenericPackageManager(RESTManager):
             file_name (str): The name of the file in the registry
             streamed (bool): If True the data will be processed by chunks of
                 `chunk_size` and each chunk is passed to `action` for
-                reatment
+                treatment
             action (callable): Callable responsible of dealing with chunk of
                 data
             chunk_size (int): Size of each chunk

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -515,7 +515,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct
-            GitlabTransferProjectError: If the project could not be transfered
+            GitlabTransferProjectError: If the project could not be transferred
         """
         path = "/projects/%s/transfer" % (self.id,)
         self.manager.gitlab.http_put(

--- a/gitlab/v4/objects/sidekiq.py
+++ b/gitlab/v4/objects/sidekiq.py
@@ -10,14 +10,14 @@ __all__ = [
 class SidekiqManager(RESTManager):
     """Manager for the Sidekiq methods.
 
-    This manager doesn't actually manage objects but provides helper fonction
+    This manager doesn't actually manage objects but provides helper function
     for the sidekiq metrics API.
     """
 
     @cli.register_custom_action("SidekiqManager")
     @exc.on_http_error(exc.GitlabGetError)
     def queue_metrics(self, **kwargs):
-        """Return the registred queues information.
+        """Return the registered queues information.
 
         Args:
             **kwargs: Extra options to send to the server (e.g. sudo)
@@ -34,7 +34,7 @@ class SidekiqManager(RESTManager):
     @cli.register_custom_action("SidekiqManager")
     @exc.on_http_error(exc.GitlabGetError)
     def process_metrics(self, **kwargs):
-        """Return the registred sidekiq workers.
+        """Return the registered sidekiq workers.
 
         Args:
             **kwargs: Extra options to send to the server (e.g. sudo)

--- a/gitlab/v4/objects/todos.py
+++ b/gitlab/v4/objects/todos.py
@@ -45,6 +45,6 @@ class TodoManager(ListMixin, DeleteMixin, RESTManager):
             GitlabTodoError: If the server failed to perform the request
 
         Returns:
-            int: The number of todos maked done
+            int: The number of todos marked done
         """
         self.gitlab.http_post("/todos/mark_as_done", **kwargs)


### PR DESCRIPTION
There are small typos in:
- docs/gl_objects/deploy_tokens.rst
- gitlab/base.py
- gitlab/mixins.py
- gitlab/v4/objects/features.py
- gitlab/v4/objects/groups.py
- gitlab/v4/objects/packages.py
- gitlab/v4/objects/projects.py
- gitlab/v4/objects/sidekiq.py
- gitlab/v4/objects/todos.py

Fixes:
- Should read `treatment` rather than `reatment`.
- Should read `transferred` rather than `transfered`.
- Should read `registered` rather than `registred`.
- Should read `occurred` rather than `occured`.
- Should read `overridden` rather than `overriden`.
- Should read `marked` rather than `maked`.
- Should read `instantiate` rather than `instanciate`.
- Should read `function` rather than `fonction`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md