### PR TITLE
fix: urlencode id part of path

### DIFF
--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import urllib.parse
 from types import ModuleType
 from typing import (
     Any,
@@ -391,7 +392,7 @@ class UpdateMixin(_RestManagerBase):
         if id is None:
             path = self.path
         else:
-            path = "%s/%s" % (self.path, id)
+            path = "%s/%s" % (self.path, urllib.parse.quote_plus(str(id)))
 
         self._check_missing_update_attrs(new_data)
         files = {}


### PR DESCRIPTION
The `tag_name` part of the path must be urlencoded.

Found this issue when trying to update a release which has a slash in its title, e.g., "1.2.3/testing"

See also:
https://docs.gitlab.com/ee/api/releases/index.html#update-a-release

