### PR TITLE
chore(objects): remove non-existing trigger ownership method

### DIFF
--- a/docs/gl_objects/pipelines_and_jobs.rst
+++ b/docs/gl_objects/pipelines_and_jobs.rst
@@ -155,6 +155,10 @@ Update a schedule::
     sched.cron = '1 2 * * *'
     sched.save()
 
+Take ownership of a shedule:
+
+    sched.take_ownership()
+
 Trigger a pipeline schedule immediately::
 
     sched = projects.pipelineschedules.get(schedule_id)

--- a/gitlab/v4/objects/triggers.py
+++ b/gitlab/v4/objects/triggers.py
@@ -1,5 +1,3 @@
-from gitlab import cli
-from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
 
@@ -10,21 +8,7 @@ __all__ = [
 
 
 class ProjectTrigger(SaveMixin, ObjectDeleteMixin, RESTObject):
-    @cli.register_custom_action("ProjectTrigger")
-    @exc.on_http_error(exc.GitlabOwnershipError)
-    def take_ownership(self, **kwargs):
-        """Update the owner of a trigger.
-
-        Args:
-            **kwargs: Extra options to send to the server (e.g. sudo)
-
-        Raises:
-            GitlabAuthenticationError: If authentication is not correct
-            GitlabOwnershipError: If the request failed
-        """
-        path = "%s/%s/take_ownership" % (self.manager.path, self.get_id())
-        server_data = self.manager.gitlab.http_post(path, **kwargs)
-        self._update_attrs(server_data)
+    pass
 
 
 class ProjectTriggerManager(CRUDMixin, RESTManager):


### PR DESCRIPTION
This was removed in https://gitlab.com/gitlab-org/gitlab/-/commit/ee7973142c3094442eeee909d328c1a030f4edac apparently for security reasons.

Also document usage for schedules, where it can actually be used :)