### PR TITLE
chore(deps): upgrade gitlab-ce to 14.3.2-ce.0

### DIFF
--- a/tests/functional/fixtures/.env
+++ b/tests/functional/fixtures/.env
@@ -1,2 +1,2 @@
 GITLAB_IMAGE=gitlab/gitlab-ce
-GITLAB_TAG=13.12.0-ce.0
+GITLAB_TAG=14.3.2-ce.0


### PR DESCRIPTION
Not sure yet why renovate stopped upgrading this, maybe because we closed that MR last time it was failing.