### PR TITLE
feat(api): add merge request approval state

### DIFF
--- a/docs/gl_objects/mr_approvals.rst
+++ b/docs/gl_objects/mr_approvals.rst
@@ -21,6 +21,9 @@ References
   + :class:`gitlab.v4.objects.ProjectMergeRequestApprovalRule`
   + :class:`gitlab.v4.objects.ProjectMergeRequestApprovalRuleManager`
   + :attr:`gitlab.v4.objects.ProjectMergeRequest.approval_rules`
+  + :class:`gitlab.v4.objects.ProjectMergeRequestApprovalState`
+  + :class:`gitlab.v4.objects.ProjectMergeRequestApprovalStateManager`
+  + :attr:`gitlab.v4.objects.ProjectMergeRequest.approval_state`
 
 * GitLab API: https://docs.gitlab.com/ee/api/merge_request_approvals.html
 
@@ -45,6 +48,10 @@ Get project-level or MR-level MR approvals settings::
     p_mras = project.approvals.get()
 
     mr_mras = mr.approvals.get()
+
+Get MR-level approval state::
+
+    mr_approval_state = mr.approval_state.get()
 
 Change project-level or MR-level MR approvals settings::
 

--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -19,6 +19,8 @@ __all__ = [
     "ProjectMergeRequestApprovalManager",
     "ProjectMergeRequestApprovalRule",
     "ProjectMergeRequestApprovalRuleManager",
+    "ProjectMergeRequestApprovalState",
+    "ProjectMergeRequestApprovalStateManager",
 ]
 
 
@@ -204,3 +206,13 @@ class ProjectMergeRequestApprovalRuleManager(
         new_data["id"] = self._from_parent_attrs["project_id"]
         new_data["merge_request_iid"] = self._from_parent_attrs["mr_iid"]
         return CreateMixin.create(self, new_data, **kwargs)
+
+
+class ProjectMergeRequestApprovalState(RESTObject):
+    pass
+
+
+class ProjectMergeRequestApprovalStateManager(GetWithoutIdMixin, RESTManager):
+    _path = "/projects/%(project_id)s/merge_requests/%(mr_iid)s/approval_state"
+    _obj_cls = ProjectMergeRequestApprovalState
+    _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -26,6 +26,7 @@ from .issues import ProjectIssue, ProjectIssueManager
 from .merge_request_approvals import (  # noqa: F401
     ProjectMergeRequestApprovalManager,
     ProjectMergeRequestApprovalRuleManager,
+    ProjectMergeRequestApprovalStateManager,
 )
 from .notes import ProjectMergeRequestNoteManager  # noqa: F401
 from .pipelines import ProjectMergeRequestPipelineManager  # noqa: F401
@@ -140,6 +141,7 @@ class ProjectMergeRequest(
     _id_attr = "iid"
 
     approval_rules: ProjectMergeRequestApprovalRuleManager
+    approval_state: ProjectMergeRequestApprovalStateManager
     approvals: ProjectMergeRequestApprovalManager
     awardemojis: ProjectMergeRequestAwardEmojiManager
     diffs: "ProjectMergeRequestDiffManager"


### PR DESCRIPTION
Add support for [merge request approval state](https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-the-approval-state-of-merge-requests).