### PR TITLE
chore(ci): wait for all coverage jobs before posting comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,6 +7,7 @@ coverage:
   range: "70...100"
 
 comment:
+  after_n_builds: 3 # coverage, py_func_v4, py_func_cli
   layout: "diff,flags,files"
   behavior: default
   require_changes: yes


### PR DESCRIPTION
This fixes an annoyance where codecov keeps posting comments even if the coverage didn't change, because it first reports only unit tests so it's of course lower than the full report.

With this, we should only get comments by codecov if coverage actually changes.