### PR TITLE
refactor: use f-strings for string formatting

### DIFF
--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -115,17 +115,13 @@ class RESTObject(object):
     def __str__(self) -> str:
         data = self._attrs.copy()
         data.update(self._updated_attrs)
-        return "%s => %s" % (type(self), data)
+        return f"{type(self)} => {data}"
 
     def __repr__(self) -> str:
         if self._id_attr:
-            return "<%s %s:%s>" % (
-                self.__class__.__name__,
-                self._id_attr,
-                self.get_id(),
-            )
+            return f"<{self.__class__.__name__} {self._id_attr}:{self.get_id()}>"
         else:
-            return "<%s>" % self.__class__.__name__
+            return f"<{self.__class__.__name__}>"
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, RESTObject):

--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -85,8 +85,8 @@ def register_custom_action(
 
 def die(msg: str, e: Optional[Exception] = None) -> None:
     if e:
-        msg = "%s (%s)" % (msg, e)
-    sys.stderr.write(msg + "\n")
+        msg = f"{msg} ({e})"
+    sys.stderr.write(f"{msg}\n")
     sys.exit(1)
 
 
@@ -172,7 +172,7 @@ def _parse_value(v: Any) -> Any:
             with open(v[1:]) as fl:
                 return fl.read()
         except Exception as e:
-            sys.stderr.write("%s\n" % e)
+            sys.stderr.write(f"{e}\n")
             sys.exit(1)
 
     return v
@@ -209,7 +209,7 @@ def main() -> None:
         sys.exit(e)
     # We only support v4 API at this time
     if config.api_version not in ("4",):
-        raise ModuleNotFoundError(name="gitlab.v%s.cli" % config.api_version)
+        raise ModuleNotFoundError(name=f"gitlab.v{config.api_version}.cli")
 
     # Now we build the entire set of subcommands and do the complete parsing
     parser = _get_parser()

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -80,7 +80,7 @@ class Gitlab(object):
         self._server_version: Optional[str] = None
         self._server_revision: Optional[str] = None
         self._base_url = self._get_base_url(url)
-        self._url = "%s/api/v%s" % (self._base_url, api_version)
+        self._url = f"{self._base_url}/api/v{api_version}"
         #: Timeout to use for requests to gitlab server
         self.timeout = timeout
         self.retry_transient_errors = retry_transient_errors
@@ -106,7 +106,7 @@ class Gitlab(object):
 
         # We only support v4 API at this time
         if self._api_version not in ("4",):
-            raise ModuleNotFoundError(name="gitlab.v%s.objects" % self._api_version)
+            raise ModuleNotFoundError(name=f"gitlab.v{self._api_version}.objects")
         # NOTE: We must delay import of gitlab.v4.objects until now or
         # otherwise it will cause circular import errors
         import gitlab.v4.objects
@@ -196,7 +196,7 @@ class Gitlab(object):
         self.__dict__.update(state)
         # We only support v4 API at this time
         if self._api_version not in ("4",):
-            raise ModuleNotFoundError(name="gitlab.v%s.objects" % self._api_version)
+            raise ModuleNotFoundError(name=f"gitlab.v{self._api_version}.objects")
         # NOTE: We must delay import of gitlab.v4.objects until now or
         # otherwise it will cause circular import errors
         import gitlab.v4.objects
@@ -409,7 +409,7 @@ class Gitlab(object):
             self.headers.pop("JOB-TOKEN", None)
 
         if self.oauth_token:
-            self.headers["Authorization"] = "Bearer %s" % self.oauth_token
+            self.headers["Authorization"] = f"Bearer {self.oauth_token}"
             self.headers.pop("PRIVATE-TOKEN", None)
             self.headers.pop("JOB-TOKEN", None)
 
@@ -465,7 +465,7 @@ class Gitlab(object):
         if path.startswith("http://") or path.startswith("https://"):
             return path
         else:
-            return "%s%s" % (self._url, path)
+            return f"{self._url}{path}"
 
     def _check_redirects(self, result: requests.Response) -> None:
         # Check the requests history to detect 301/302 redirections.

--- a/gitlab/config.py
+++ b/gitlab/config.py
@@ -95,8 +95,8 @@ class GitlabConfigParser(object):
             self.url = self._config.get(self.gitlab_id, "url")
         except Exception as e:
             raise GitlabDataError(
-                "Impossible to get gitlab informations from "
-                "configuration (%s)" % self.gitlab_id
+                "Impossible to get gitlab details from "
+                f"configuration ({self.gitlab_id})"
             ) from e
 
         self.ssl_verify: Union[bool, str] = True
@@ -173,7 +173,7 @@ class GitlabConfigParser(object):
         except Exception:
             pass
         if self.api_version not in ("4",):
-            raise GitlabDataError("Unsupported API version: %s" % self.api_version)
+            raise GitlabDataError(f"Unsupported API version: {self.api_version}")
 
         self.per_page = None
         for section in ["global", self.gitlab_id]:
@@ -182,7 +182,7 @@ class GitlabConfigParser(object):
             except Exception:
                 pass
         if self.per_page is not None and not 0 <= self.per_page <= 100:
-            raise GitlabDataError("Unsupported per_page number: %s" % self.per_page)
+            raise GitlabDataError(f"Unsupported per_page number: {self.per_page}")
 
         self.pagination = None
         try:

--- a/gitlab/const.py
+++ b/gitlab/const.py
@@ -55,4 +55,4 @@ SEARCH_SCOPE_GLOBAL_SNIPPET_TITLES: str = "snippet_titles"
 # specific project scope
 SEARCH_SCOPE_PROJECT_NOTES: str = "notes"
 
-USER_AGENT: str = "{}/{}".format(__title__, __version__)
+USER_AGENT: str = f"{__title__}/{__version__}"

--- a/gitlab/exceptions.py
+++ b/gitlab/exceptions.py
@@ -46,9 +46,9 @@ class GitlabError(Exception):
 
     def __str__(self) -> str:
         if self.response_code is not None:
-            return "{0}: {1}".format(self.response_code, self.error_message)
+            return f"{self.response_code}: {self.error_message}"
         else:
-            return "{0}".format(self.error_message)
+            return f"{self.error_message}"
 
 
 class GitlabAuthenticationError(GitlabError):

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -101,7 +101,7 @@ class GetMixin(_RestManagerBase):
         """
         if not isinstance(id, int):
             id = utils.clean_str_id(id)
-        path = "%s/%s" % (self.path, id)
+        path = f"{self.path}/{id}"
         if TYPE_CHECKING:
             assert self._obj_cls is not None
         if lazy is True:
@@ -173,7 +173,7 @@ class RefreshMixin(_RestObjectBase):
             GitlabGetError: If the server cannot perform the request
         """
         if self._id_attr:
-            path = "%s/%s" % (self.manager.path, self.id)
+            path = f"{self.manager.path}/{self.id}"
         else:
             if TYPE_CHECKING:
                 assert self.manager.path is not None
@@ -273,7 +273,7 @@ class CreateMixin(_RestManagerBase):
                 missing.append(attr)
                 continue
         if missing:
-            raise AttributeError("Missing attributes: %s" % ", ".join(missing))
+            raise AttributeError(f"Missing attributes: {', '.join(missing)}")
 
     @exc.on_http_error(exc.GitlabCreateError)
     def create(
@@ -349,7 +349,7 @@ class UpdateMixin(_RestManagerBase):
                 missing.append(attr)
                 continue
         if missing:
-            raise AttributeError("Missing attributes: %s" % ", ".join(missing))
+            raise AttributeError(f"Missing attributes: {', '.join(missing)}")
 
     def _get_update_method(
         self,
@@ -370,7 +370,7 @@ class UpdateMixin(_RestManagerBase):
         self,
         id: Optional[Union[str, int]] = None,
         new_data: Optional[Dict[str, Any]] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> Dict[str, Any]:
         """Update an object on the server.
 
@@ -391,7 +391,7 @@ class UpdateMixin(_RestManagerBase):
         if id is None:
             path = self.path
         else:
-            path = "%s/%s" % (self.path, id)
+            path = f"{self.path}/{id}"
 
         self._check_missing_update_attrs(new_data)
         files = {}
@@ -444,7 +444,7 @@ class SetMixin(_RestManagerBase):
         Returns:
             obj: The created/updated attribute
         """
-        path = "%s/%s" % (self.path, utils.clean_str_id(key))
+        path = f"{self.path}/{utils.clean_str_id(key)}"
         data = {"value": value}
         server_data = self.gitlab.http_put(path, post_data=data, **kwargs)
         if TYPE_CHECKING:
@@ -479,7 +479,7 @@ class DeleteMixin(_RestManagerBase):
         else:
             if not isinstance(id, int):
                 id = utils.clean_str_id(id)
-            path = "%s/%s" % (self.path, id)
+            path = f"{self.path}/{id}"
         self.gitlab.http_delete(path, **kwargs)
 
 
@@ -598,7 +598,7 @@ class UserAgentDetailMixin(_RestObjectBase):
             GitlabAuthenticationError: If authentication is not correct
             GitlabGetError: If the server cannot perform the request
         """
-        path = "%s/%s/user_agent_detail" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/user_agent_detail"
         result = self.manager.gitlab.http_get(path, **kwargs)
         if TYPE_CHECKING:
             assert not isinstance(result, requests.Response)
@@ -631,7 +631,7 @@ class AccessRequestMixin(_RestObjectBase):
             GitlabUpdateError: If the server fails to perform the request
         """
 
-        path = "%s/%s/approve" % (self.manager.path, self.id)
+        path = f"{self.manager.path}/{self.id}/approve"
         data = {"access_level": access_level}
         server_data = self.manager.gitlab.http_put(path, post_data=data, **kwargs)
         if TYPE_CHECKING:
@@ -654,7 +654,7 @@ class DownloadMixin(_RestObjectBase):
         streamed: bool = False,
         action: Optional[Callable] = None,
         chunk_size: int = 1024,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> Optional[bytes]:
         """Download the archive of a resource export.
 
@@ -674,7 +674,7 @@ class DownloadMixin(_RestObjectBase):
         Returns:
             str: The blob content if streamed is False, None otherwise
         """
-        path = "%s/download" % (self.manager.path)
+        path = f"{self.manager.path}/download"
         result = self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
@@ -705,7 +705,7 @@ class SubscribableMixin(_RestObjectBase):
             GitlabAuthenticationError: If authentication is not correct
             GitlabSubscribeError: If the subscription cannot be done
         """
-        path = "%s/%s/subscribe" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/subscribe"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert not isinstance(server_data, requests.Response)
@@ -725,7 +725,7 @@ class SubscribableMixin(_RestObjectBase):
             GitlabAuthenticationError: If authentication is not correct
             GitlabUnsubscribeError: If the unsubscription cannot be done
         """
-        path = "%s/%s/unsubscribe" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/unsubscribe"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert not isinstance(server_data, requests.Response)
@@ -752,7 +752,7 @@ class TodoMixin(_RestObjectBase):
             GitlabAuthenticationError: If authentication is not correct
             GitlabTodoError: If the todo cannot be set
         """
-        path = "%s/%s/todo" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/todo"
         self.manager.gitlab.http_post(path, **kwargs)
 
 
@@ -781,7 +781,7 @@ class TimeTrackingMixin(_RestObjectBase):
         if "time_stats" in self.attributes:
             return self.attributes["time_stats"]
 
-        path = "%s/%s/time_stats" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/time_stats"
         result = self.manager.gitlab.http_get(path, **kwargs)
         if TYPE_CHECKING:
             assert not isinstance(result, requests.Response)
@@ -800,7 +800,7 @@ class TimeTrackingMixin(_RestObjectBase):
             GitlabAuthenticationError: If authentication is not correct
             GitlabTimeTrackingError: If the time tracking update cannot be done
         """
-        path = "%s/%s/time_estimate" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/time_estimate"
         data = {"duration": duration}
         result = self.manager.gitlab.http_post(path, post_data=data, **kwargs)
         if TYPE_CHECKING:
@@ -819,7 +819,7 @@ class TimeTrackingMixin(_RestObjectBase):
             GitlabAuthenticationError: If authentication is not correct
             GitlabTimeTrackingError: If the time tracking update cannot be done
         """
-        path = "%s/%s/reset_time_estimate" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/reset_time_estimate"
         result = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert not isinstance(result, requests.Response)
@@ -838,7 +838,7 @@ class TimeTrackingMixin(_RestObjectBase):
             GitlabAuthenticationError: If authentication is not correct
             GitlabTimeTrackingError: If the time tracking update cannot be done
         """
-        path = "%s/%s/add_spent_time" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/add_spent_time"
         data = {"duration": duration}
         result = self.manager.gitlab.http_post(path, post_data=data, **kwargs)
         if TYPE_CHECKING:
@@ -857,7 +857,7 @@ class TimeTrackingMixin(_RestObjectBase):
             GitlabAuthenticationError: If authentication is not correct
             GitlabTimeTrackingError: If the time tracking update cannot be done
         """
-        path = "%s/%s/reset_spent_time" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/reset_spent_time"
         result = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert not isinstance(result, requests.Response)
@@ -893,7 +893,7 @@ class ParticipantsMixin(_RestObjectBase):
             RESTObjectList: The list of participants
         """
 
-        path = "%s/%s/participants" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/participants"
         result = self.manager.gitlab.http_get(path, **kwargs)
         if TYPE_CHECKING:
             assert not isinstance(result, requests.Response)
@@ -920,7 +920,7 @@ class BadgeRenderMixin(_RestManagerBase):
         Returns:
             dict: The rendering properties
         """
-        path = "%s/render" % self.path
+        path = f"{self.path}/render"
         data = {"link_url": link_url, "image_url": image_url}
         result = self.gitlab.http_get(path, data, **kwargs)
         if TYPE_CHECKING:
@@ -967,7 +967,7 @@ class PromoteMixin(_RestObjectBase):
             dict: The updated object data (*not* a RESTObject)
         """
 
-        path = "%s/%s/promote" % (self.manager.path, self.id)
+        path = f"{self.manager.path}/{self.id}/promote"
         http_method = self._get_update_method()
         result = http_method(path, **kwargs)
         if TYPE_CHECKING:

--- a/gitlab/types.py
+++ b/gitlab/types.py
@@ -61,4 +61,4 @@ class FileAttribute(GitlabAttribute):
 
 class ImageAttribute(FileAttribute):
     def get_file_name(self, attr_name: Optional[str] = None) -> str:
-        return "%s.png" % attr_name if attr_name else "image.png"
+        return f"{attr_name}.png" if attr_name else "image.png"

--- a/gitlab/utils.py
+++ b/gitlab/utils.py
@@ -51,7 +51,7 @@ def copy_dict(dest: Dict[str, Any], src: Dict[str, Any]) -> None:
             # custom_attributes: {'foo', 'bar'} =>
             #   "custom_attributes['foo']": "bar"
             for dict_k, dict_v in v.items():
-                dest["%s[%s]" % (k, dict_k)] = dict_v
+                dest[f"{k}[{dict_k}]"] = dict_v
         else:
             dest[k] = v
 

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -46,7 +46,7 @@ class GitlabCLI(object):
             Type[gitlab.mixins.GetWithoutIdMixin],
             Type[gitlab.mixins.ListMixin],
             Type[gitlab.mixins.UpdateMixin],
-        ] = getattr(gitlab.v4.objects, self.cls.__name__ + "Manager")
+        ] = getattr(gitlab.v4.objects, f"{self.cls.__name__}Manager")
         # We could do something smart, like splitting the manager name to find
         # parents, build the chain of managers to get to the final object.
         # Instead we do something ugly and efficient: interpolate variables in
@@ -65,12 +65,12 @@ class GitlabCLI(object):
 
     def __call__(self) -> Any:
         # Check for a method that matches object + action
-        method = "do_%s_%s" % (self.what, self.action)
+        method = f"do_{self.what}_{self.action}"
         if hasattr(self, method):
             return getattr(self, method)()
 
         # Fallback to standard actions (get, list, create, ...)
-        method = "do_%s" % self.action
+        method = f"do_{self.action}"
         if hasattr(self, method):
             return getattr(self, method)()
 
@@ -177,7 +177,7 @@ class GitlabCLI(object):
 def _populate_sub_parser_by_class(
     cls: Type[gitlab.base.RESTObject], sub_parser: argparse._SubParsersAction
 ) -> None:
-    mgr_cls_name = cls.__name__ + "Manager"
+    mgr_cls_name = f"{cls.__name__}Manager"
     mgr_cls = getattr(gitlab.v4.objects, mgr_cls_name)
 
     for action_name in ["list", "get", "create", "update", "delete"]:
@@ -189,13 +189,13 @@ def _populate_sub_parser_by_class(
         if mgr_cls._from_parent_attrs:
             for x in mgr_cls._from_parent_attrs:
                 sub_parser_action.add_argument(
-                    "--%s" % x.replace("_", "-"), required=True
+                    f"--{x.replace('_', '-')}", required=True
                 )
 
         if action_name == "list":
             for x in mgr_cls._list_filters:
                 sub_parser_action.add_argument(
-                    "--%s" % x.replace("_", "-"), required=False
+                    f"--{x.replace('_', '-')}", required=False
                 )
 
             sub_parser_action.add_argument("--page", required=False)
@@ -205,44 +205,44 @@ def _populate_sub_parser_by_class(
         if action_name == "delete":
             if cls._id_attr is not None:
                 id_attr = cls._id_attr.replace("_", "-")
-                sub_parser_action.add_argument("--%s" % id_attr, required=True)
+                sub_parser_action.add_argument(f"--{id_attr}", required=True)
 
         if action_name == "get":
             if not issubclass(cls, gitlab.mixins.GetWithoutIdMixin):
                 if cls._id_attr is not None:
                     id_attr = cls._id_attr.replace("_", "-")
-                    sub_parser_action.add_argument("--%s" % id_attr, required=True)
+                    sub_parser_action.add_argument(f"--{id_attr}", required=True)
 
             for x in mgr_cls._optional_get_attrs:
                 sub_parser_action.add_argument(
-                    "--%s" % x.replace("_", "-"), required=False
+                    f"--{x.replace('_', '-')}", required=False
                 )
 
         if action_name == "create":
             for x in mgr_cls._create_attrs.required:
                 sub_parser_action.add_argument(
-                    "--%s" % x.replace("_", "-"), required=True
+                    f"--{x.replace('_', '-')}", required=True
                 )
             for x in mgr_cls._create_attrs.optional:
                 sub_parser_action.add_argument(
-                    "--%s" % x.replace("_", "-"), required=False
+                    f"--{x.replace('_', '-')}", required=False
                 )
 
         if action_name == "update":
             if cls._id_attr is not None:
                 id_attr = cls._id_attr.replace("_", "-")
-                sub_parser_action.add_argument("--%s" % id_attr, required=True)
+                sub_parser_action.add_argument(f"--{id_attr}", required=True)
 
             for x in mgr_cls._update_attrs.required:
                 if x != cls._id_attr:
                     sub_parser_action.add_argument(
-                        "--%s" % x.replace("_", "-"), required=True
+                        f"--{x.replace('_', '-')}", required=True
                     )
 
             for x in mgr_cls._update_attrs.optional:
                 if x != cls._id_attr:
                     sub_parser_action.add_argument(
-                        "--%s" % x.replace("_", "-"), required=False
+                        f"--{x.replace('_', '-')}", required=False
                     )
 
     if cls.__name__ in cli.custom_actions:
@@ -253,7 +253,7 @@ def _populate_sub_parser_by_class(
             if mgr_cls._from_parent_attrs:
                 for x in mgr_cls._from_parent_attrs:
                     sub_parser_action.add_argument(
-                        "--%s" % x.replace("_", "-"), required=True
+                        f"--{x.replace('_', '-')}", required=True
                     )
                 sub_parser_action.add_argument("--sudo", required=False)
 
@@ -261,19 +261,19 @@ def _populate_sub_parser_by_class(
             if not issubclass(cls, gitlab.mixins.GetWithoutIdMixin):
                 if cls._id_attr is not None:
                     id_attr = cls._id_attr.replace("_", "-")
-                    sub_parser_action.add_argument("--%s" % id_attr, required=True)
+                    sub_parser_action.add_argument(f"--{id_attr}", required=True)
 
             required, optional, dummy = cli.custom_actions[name][action_name]
             [
                 sub_parser_action.add_argument(
-                    "--%s" % x.replace("_", "-"), required=True
+                    f"--{x.replace('_', '-')}", required=True
                 )
                 for x in required
                 if x != cls._id_attr
             ]
             [
                 sub_parser_action.add_argument(
-                    "--%s" % x.replace("_", "-"), required=False
+                    f"--{x.replace('_', '-')}", required=False
                 )
                 for x in optional
                 if x != cls._id_attr
@@ -286,21 +286,21 @@ def _populate_sub_parser_by_class(
             if mgr_cls._from_parent_attrs:
                 for x in mgr_cls._from_parent_attrs:
                     sub_parser_action.add_argument(
-                        "--%s" % x.replace("_", "-"), required=True
+                        f"--{x.replace('_', '-')}", required=True
                     )
                 sub_parser_action.add_argument("--sudo", required=False)
 
             required, optional, dummy = cli.custom_actions[name][action_name]
             [
                 sub_parser_action.add_argument(
-                    "--%s" % x.replace("_", "-"), required=True
+                    f"--{x.replace('_', '-')}", required=True
                 )
                 for x in required
                 if x != cls._id_attr
             ]
             [
                 sub_parser_action.add_argument(
-                    "--%s" % x.replace("_", "-"), required=False
+                    f"--{x.replace('_', '-')}", required=False
                 )
                 for x in optional
                 if x != cls._id_attr
@@ -357,7 +357,7 @@ class JSONPrinter(object):
         self,
         data: List[Union[str, gitlab.base.RESTObject]],
         fields: List[str],
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         import json  # noqa
 
@@ -381,7 +381,7 @@ class YAMLPrinter(object):
         self,
         data: List[Union[str, gitlab.base.RESTObject]],
         fields: List[str],
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         try:
             import yaml  # noqa
@@ -411,11 +411,11 @@ class LegacyPrinter(object):
             for k in sorted(d.keys()):
                 v = d[k]
                 if isinstance(v, dict):
-                    print("%s%s:" % (" " * padding, k.replace("_", "-")))
+                    print(f"{' ' * padding}{k.replace('_', '-')}:")
                     new_padding = padding + 2
                     self.display(v, verbose=True, padding=new_padding, obj=v)
                     continue
-                print("%s%s: %s" % (" " * padding, k.replace("_", "-"), v))
+                print(f"{' ' * padding}{k.replace('_', '-')}: {v}")
 
         if verbose:
             if isinstance(obj, dict):
@@ -425,7 +425,7 @@ class LegacyPrinter(object):
             # not a dict, we assume it's a RESTObject
             if obj._id_attr:
                 id = getattr(obj, obj._id_attr, None)
-                print("%s: %s" % (obj._id_attr, id))
+                print(f"{obj._id_attr}: {id}")
             attrs = obj.attributes
             if obj._id_attr:
                 attrs.pop(obj._id_attr)
@@ -436,23 +436,23 @@ class LegacyPrinter(object):
                 assert isinstance(obj, gitlab.base.RESTObject)
             if obj._id_attr:
                 id = getattr(obj, obj._id_attr)
-                print("%s: %s" % (obj._id_attr.replace("_", "-"), id))
+                print(f"{obj._id_attr.replace('_', '-')}: {id}")
             if obj._short_print_attr:
                 value = getattr(obj, obj._short_print_attr) or "None"
                 value = value.replace("\r", "").replace("\n", " ")
                 # If the attribute is a note (ProjectCommitComment) then we do
                 # some modifications to fit everything on one line
-                line = "%s: %s" % (obj._short_print_attr, value)
+                line = f"{obj._short_print_attr}: {value}"
                 # ellipsize long lines (comments)
                 if len(line) > 79:
-                    line = line[:76] + "..."
+                    line = f"{line[:76]}..."
                 print(line)
 
     def display_list(
         self,
         data: List[Union[str, gitlab.base.RESTObject]],
         fields: List[str],
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         verbose = kwargs.get("verbose", False)
         for obj in data:

--- a/gitlab/v4/objects/clusters.py
+++ b/gitlab/v4/objects/clusters.py
@@ -50,7 +50,7 @@ class GroupClusterManager(CRUDMixin, RESTManager):
             RESTObject: A new instance of the manage object class build with
                         the data sent by the server
         """
-        path = "%s/user" % (self.path)
+        path = f"{self.path}/user"
         return CreateMixin.create(self, data, path=path, **kwargs)
 
 
@@ -94,5 +94,5 @@ class ProjectClusterManager(CRUDMixin, RESTManager):
             RESTObject: A new instance of the manage object class build with
                         the data sent by the server
         """
-        path = "%s/user" % (self.path)
+        path = f"{self.path}/user"
         return CreateMixin.create(self, data, path=path, **kwargs)

--- a/gitlab/v4/objects/commits.py
+++ b/gitlab/v4/objects/commits.py
@@ -37,7 +37,7 @@ class ProjectCommit(RESTObject):
         Returns:
             list: The changes done in this commit
         """
-        path = "%s/%s/diff" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/diff"
         return self.manager.gitlab.http_get(path, **kwargs)
 
     @cli.register_custom_action("ProjectCommit", ("branch",))
@@ -53,7 +53,7 @@ class ProjectCommit(RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabCherryPickError: If the cherry-pick could not be performed
         """
-        path = "%s/%s/cherry_pick" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/cherry_pick"
         post_data = {"branch": branch}
         self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
 
@@ -73,7 +73,7 @@ class ProjectCommit(RESTObject):
         Returns:
             list: The references the commit is pushed to.
         """
-        path = "%s/%s/refs" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/refs"
         data = {"type": type}
         return self.manager.gitlab.http_get(path, query_data=data, **kwargs)
 
@@ -92,7 +92,7 @@ class ProjectCommit(RESTObject):
         Returns:
             list: The merge requests related to the commit.
         """
-        path = "%s/%s/merge_requests" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/merge_requests"
         return self.manager.gitlab.http_get(path, **kwargs)
 
     @cli.register_custom_action("ProjectCommit", ("branch",))
@@ -111,7 +111,7 @@ class ProjectCommit(RESTObject):
         Returns:
             dict: The new commit data (*not* a RESTObject)
         """
-        path = "%s/%s/revert" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/revert"
         post_data = {"branch": branch}
         return self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
 
@@ -130,7 +130,7 @@ class ProjectCommit(RESTObject):
         Returns:
             dict: The commit's signature data
         """
-        path = "%s/%s/signature" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/signature"
         return self.manager.gitlab.http_get(path, **kwargs)
 
 

--- a/gitlab/v4/objects/deploy_keys.py
+++ b/gitlab/v4/objects/deploy_keys.py
@@ -44,5 +44,5 @@ class ProjectKeyManager(CRUDMixin, RESTManager):
             GitlabAuthenticationError: If authentication is not correct
             GitlabProjectDeployKeyError: If the key could not be enabled
         """
-        path = "%s/%s/enable" % (self.path, key_id)
+        path = f"{self.path}/{key_id}/enable"
         self.gitlab.http_post(path, **kwargs)

--- a/gitlab/v4/objects/environments.py
+++ b/gitlab/v4/objects/environments.py
@@ -29,7 +29,7 @@ class ProjectEnvironment(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabStopError: If the operation failed
         """
-        path = "%s/%s/stop" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/stop"
         self.manager.gitlab.http_post(path, **kwargs)
 
 

--- a/gitlab/v4/objects/epics.py
+++ b/gitlab/v4/objects/epics.py
@@ -95,7 +95,7 @@ class GroupEpicIssueManager(
                         the data sent by the server
         """
         CreateMixin._check_missing_create_attrs(self, data)
-        path = "%s/%s" % (self.path, data.pop("issue_id"))
+        path = f"{self.path}/{data.pop('issue_id')}"
         server_data = self.gitlab.http_post(path, **kwargs)
         # The epic_issue_id attribute doesn't exist when creating the resource,
         # but is used everywhere elese. Let's create it to be consistent client

--- a/gitlab/v4/objects/features.py
+++ b/gitlab/v4/objects/features.py
@@ -26,7 +26,7 @@ class FeatureManager(ListMixin, DeleteMixin, RESTManager):
         user=None,
         group=None,
         project=None,
-        **kwargs
+        **kwargs,
     ):
         """Create or update the object.
 
@@ -46,7 +46,7 @@ class FeatureManager(ListMixin, DeleteMixin, RESTManager):
         Returns:
             obj: The created/updated attribute
         """
-        path = "%s/%s" % (self.path, name.replace("/", "%2F"))
+        path = f"{self.path}/{name.replace('/', '%2F')}"
         data = {
             "value": value,
             "feature_group": feature_group,

--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -123,7 +123,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         self._check_missing_create_attrs(data)
         new_data = data.copy()
         file_path = new_data.pop("file_path").replace("/", "%2F")
-        path = "%s/%s" % (self.path, file_path)
+        path = f"{self.path}/{file_path}"
         server_data = self.gitlab.http_post(path, post_data=new_data, **kwargs)
         return self._obj_cls(self, server_data)
 
@@ -147,7 +147,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         data = new_data.copy()
         file_path = file_path.replace("/", "%2F")
         data["file_path"] = file_path
-        path = "%s/%s" % (self.path, file_path)
+        path = f"{self.path}/{file_path}"
         self._check_missing_update_attrs(data)
         return self.gitlab.http_put(path, post_data=data, **kwargs)
 
@@ -168,7 +168,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server cannot perform the request
         """
-        path = "%s/%s" % (self.path, file_path.replace("/", "%2F"))
+        path = f"{self.path}/{file_path.replace('/', '%2F')}"
         data = {"branch": branch, "commit_message": commit_message}
         self.gitlab.http_delete(path, query_data=data, **kwargs)
 
@@ -198,7 +198,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
             str: The file content
         """
         file_path = file_path.replace("/", "%2F").replace(".", "%2E")
-        path = "%s/%s/raw" % (self.path, file_path)
+        path = f"{self.path}/{file_path}/raw"
         query_data = {"ref": ref}
         result = self.gitlab.http_get(
             path, query_data=query_data, streamed=streamed, raw=True, **kwargs
@@ -223,6 +223,6 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
             list(blame): a list of commits/lines matching the file
         """
         file_path = file_path.replace("/", "%2F").replace(".", "%2E")
-        path = "%s/%s/blame" % (self.path, file_path)
+        path = f"{self.path}/{file_path}/blame"
         query_data = {"ref": ref}
         return self.gitlab.http_list(path, query_data, **kwargs)

--- a/gitlab/v4/objects/geo_nodes.py
+++ b/gitlab/v4/objects/geo_nodes.py
@@ -28,7 +28,7 @@ class GeoNode(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabRepairError: If the server failed to perform the request
         """
-        path = "/geo_nodes/%s/repair" % self.get_id()
+        path = f"/geo_nodes/{self.get_id()}/repair"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         self._update_attrs(server_data)
 
@@ -47,7 +47,7 @@ class GeoNode(SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             dict: The status of the geo node
         """
-        path = "/geo_nodes/%s/status" % self.get_id()
+        path = f"/geo_nodes/{self.get_id()}/status"
         return self.manager.gitlab.http_get(path, **kwargs)
 
 

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -85,7 +85,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabTransferProjectError: If the project could not be transferred
         """
-        path = "/groups/%s/projects/%s" % (self.id, project_id)
+        path = f"/groups/{self.id}/projects/{project_id}"
         self.manager.gitlab.http_post(path, **kwargs)
 
     @cli.register_custom_action("Group", ("scope", "search"))
@@ -106,7 +106,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabList: A list of dicts describing the resources found.
         """
         data = {"scope": scope, "search": search}
-        path = "/groups/%s/search" % self.get_id()
+        path = f"/groups/{self.get_id()}/search"
         return self.manager.gitlab.http_list(path, query_data=data, **kwargs)
 
     @cli.register_custom_action("Group", ("cn", "group_access", "provider"))
@@ -125,7 +125,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabCreateError: If the server cannot perform the request
         """
-        path = "/groups/%s/ldap_group_links" % self.get_id()
+        path = f"/groups/{self.get_id()}/ldap_group_links"
         data = {"cn": cn, "group_access": group_access, "provider": provider}
         self.manager.gitlab.http_post(path, post_data=data, **kwargs)
 
@@ -143,10 +143,10 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server cannot perform the request
         """
-        path = "/groups/%s/ldap_group_links" % self.get_id()
+        path = f"/groups/{self.get_id()}/ldap_group_links"
         if provider is not None:
-            path += "/%s" % provider
-        path += "/%s" % cn
+            path += f"/{provider}"
+        path += f"/{cn}"
         self.manager.gitlab.http_delete(path)
 
     @cli.register_custom_action("Group")
@@ -161,7 +161,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabCreateError: If the server cannot perform the request
         """
-        path = "/groups/%s/ldap_sync" % self.get_id()
+        path = f"/groups/{self.get_id()}/ldap_sync"
         self.manager.gitlab.http_post(path, **kwargs)
 
     @cli.register_custom_action("Group", ("group_id", "group_access"), ("expires_at",))
@@ -178,7 +178,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabCreateError: If the server failed to perform the request
         """
-        path = "/groups/%s/share" % self.get_id()
+        path = f"/groups/{self.get_id()}/share"
         data = {
             "group_id": group_id,
             "group_access": group_access,
@@ -199,7 +199,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server failed to perform the request
         """
-        path = "/groups/%s/share/%s" % (self.get_id(), group_id)
+        path = f"/groups/{self.get_id()}/share/{group_id}"
         self.manager.gitlab.http_delete(path, **kwargs)
 
 

--- a/gitlab/v4/objects/issues.py
+++ b/gitlab/v4/objects/issues.py
@@ -127,7 +127,7 @@ class ProjectIssue(
             GitlabAuthenticationError: If authentication is not correct
             GitlabUpdateError: If the issue could not be moved
         """
-        path = "%s/%s/move" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/move"
         data = {"to_project_id": to_project_id}
         server_data = self.manager.gitlab.http_post(path, post_data=data, **kwargs)
         self._update_attrs(server_data)
@@ -147,7 +147,7 @@ class ProjectIssue(
         Returns:
             list: The list of merge requests.
         """
-        path = "%s/%s/related_merge_requests" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/related_merge_requests"
         return self.manager.gitlab.http_get(path, **kwargs)
 
     @cli.register_custom_action("ProjectIssue")
@@ -165,7 +165,7 @@ class ProjectIssue(
         Returns:
             list: The list of merge requests.
         """
-        path = "%s/%s/closed_by" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/closed_by"
         return self.manager.gitlab.http_get(path, **kwargs)
 
 

--- a/gitlab/v4/objects/jobs.py
+++ b/gitlab/v4/objects/jobs.py
@@ -23,7 +23,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabJobCancelError: If the job could not be canceled
         """
-        path = "%s/%s/cancel" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/cancel"
         return self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectJob")
@@ -38,7 +38,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabJobRetryError: If the job could not be retried
         """
-        path = "%s/%s/retry" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/retry"
         return self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectJob")
@@ -53,7 +53,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabJobPlayError: If the job could not be triggered
         """
-        path = "%s/%s/play" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/play"
         self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectJob")
@@ -68,7 +68,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabJobEraseError: If the job could not be erased
         """
-        path = "%s/%s/erase" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/erase"
         self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectJob")
@@ -83,7 +83,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabCreateError: If the request could not be performed
         """
-        path = "%s/%s/artifacts/keep" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/artifacts/keep"
         self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectJob")
@@ -98,7 +98,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the request could not be performed
         """
-        path = "%s/%s/artifacts" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/artifacts"
         self.manager.gitlab.http_delete(path)
 
     @cli.register_custom_action("ProjectJob")
@@ -122,7 +122,7 @@ class ProjectJob(RefreshMixin, RESTObject):
         Returns:
             str: The artifacts if `streamed` is False, None otherwise.
         """
-        path = "%s/%s/artifacts" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/artifacts"
         result = self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
@@ -150,7 +150,7 @@ class ProjectJob(RefreshMixin, RESTObject):
         Returns:
             str: The artifacts if `streamed` is False, None otherwise.
         """
-        path = "%s/%s/artifacts/%s" % (self.manager.path, self.get_id(), path)
+        path = f"{self.manager.path}/{self.get_id()}/artifacts/{path}"
         result = self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
@@ -177,7 +177,7 @@ class ProjectJob(RefreshMixin, RESTObject):
         Returns:
             str: The trace
         """
-        path = "%s/%s/trace" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/trace"
         result = self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )

--- a/gitlab/v4/objects/ldap.py
+++ b/gitlab/v4/objects/ldap.py
@@ -40,7 +40,7 @@ class LDAPGroupManager(RESTManager):
             data.setdefault("per_page", self.gitlab.per_page)
 
         if "provider" in data:
-            path = "/ldap/%s/groups" % data["provider"]
+            path = f"/ldap/{data['provider']}/groups"
         else:
             path = self._path
 

--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -58,7 +58,7 @@ class ProjectApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
         approver_ids = approver_ids or []
         approver_group_ids = approver_group_ids or []
 
-        path = "/projects/%s/approvers" % self._parent.get_id()
+        path = f"/projects/{self._parent.get_id()}/approvers"
         data = {"approver_ids": approver_ids, "approver_group_ids": approver_group_ids}
         self.gitlab.http_put(path, post_data=data, **kwargs)
 
@@ -97,7 +97,7 @@ class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTMan
         approver_ids=None,
         approver_group_ids=None,
         approval_rule_name="name",
-        **kwargs
+        **kwargs,
     ):
         """Change MR-level allowed approvers and approver groups.
 

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -166,9 +166,8 @@ class ProjectMergeRequest(
                 request
         """
 
-        path = "%s/%s/cancel_merge_when_pipeline_succeeds" % (
-            self.manager.path,
-            self.get_id(),
+        path = (
+            f"{self.manager.path}/{self.get_id()}/cancel_merge_when_pipeline_succeeds"
         )
         server_data = self.manager.gitlab.http_put(path, **kwargs)
         self._update_attrs(server_data)
@@ -193,7 +192,7 @@ class ProjectMergeRequest(
         Returns:
             RESTObjectList: List of issues
         """
-        path = "%s/%s/closes_issues" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/closes_issues"
         data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
         manager = ProjectIssueManager(self.manager.gitlab, parent=self.manager._parent)
         return RESTObjectList(manager, ProjectIssue, data_list)
@@ -219,7 +218,7 @@ class ProjectMergeRequest(
             RESTObjectList: The list of commits
         """
 
-        path = "%s/%s/commits" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/commits"
         data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
         manager = ProjectCommitManager(self.manager.gitlab, parent=self.manager._parent)
         return RESTObjectList(manager, ProjectCommit, data_list)
@@ -239,7 +238,7 @@ class ProjectMergeRequest(
         Returns:
             RESTObjectList: List of changes
         """
-        path = "%s/%s/changes" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/changes"
         return self.manager.gitlab.http_get(path, **kwargs)
 
     @cli.register_custom_action("ProjectMergeRequest", tuple(), ("sha",))
@@ -255,7 +254,7 @@ class ProjectMergeRequest(
             GitlabAuthenticationError: If authentication is not correct
             GitlabMRApprovalError: If the approval failed
         """
-        path = "%s/%s/approve" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/approve"
         data = {}
         if sha:
             data["sha"] = sha
@@ -275,7 +274,7 @@ class ProjectMergeRequest(
             GitlabAuthenticationError: If authentication is not correct
             GitlabMRApprovalError: If the unapproval failed
         """
-        path = "%s/%s/unapprove" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/unapprove"
         data = {}
 
         server_data = self.manager.gitlab.http_post(path, post_data=data, **kwargs)
@@ -293,7 +292,7 @@ class ProjectMergeRequest(
             GitlabAuthenticationError: If authentication is not correct
             GitlabMRRebaseError: If rebasing failed
         """
-        path = "%s/%s/rebase" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/rebase"
         data = {}
         return self.manager.gitlab.http_put(path, post_data=data, **kwargs)
 
@@ -309,7 +308,7 @@ class ProjectMergeRequest(
         Raises:
             GitlabGetError: If cannot be merged
         """
-        path = "%s/%s/merge_ref" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/merge_ref"
         return self.manager.gitlab.http_get(path, **kwargs)
 
     @cli.register_custom_action(
@@ -327,7 +326,7 @@ class ProjectMergeRequest(
         merge_commit_message=None,
         should_remove_source_branch=False,
         merge_when_pipeline_succeeds=False,
-        **kwargs
+        **kwargs,
     ):
         """Accept the merge request.
 
@@ -343,7 +342,7 @@ class ProjectMergeRequest(
             GitlabAuthenticationError: If authentication is not correct
             GitlabMRClosedError: If the merge failed
         """
-        path = "%s/%s/merge" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/merge"
         data = {}
         if merge_commit_message:
             data["merge_commit_message"] = merge_commit_message

--- a/gitlab/v4/objects/milestones.py
+++ b/gitlab/v4/objects/milestones.py
@@ -43,7 +43,7 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
             RESTObjectList: The list of issues
         """
 
-        path = "%s/%s/issues" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/issues"
         data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
         manager = GroupIssueManager(self.manager.gitlab, parent=self.manager._parent)
         # FIXME(gpocentek): the computed manager path is not correct
@@ -69,7 +69,7 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             RESTObjectList: The list of merge requests
         """
-        path = "%s/%s/merge_requests" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/merge_requests"
         data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
         manager = GroupIssueManager(self.manager.gitlab, parent=self.manager._parent)
         # FIXME(gpocentek): the computed manager path is not correct
@@ -115,7 +115,7 @@ class ProjectMilestone(PromoteMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
             RESTObjectList: The list of issues
         """
 
-        path = "%s/%s/issues" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/issues"
         data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
         manager = ProjectIssueManager(self.manager.gitlab, parent=self.manager._parent)
         # FIXME(gpocentek): the computed manager path is not correct
@@ -141,7 +141,7 @@ class ProjectMilestone(PromoteMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             RESTObjectList: The list of merge requests
         """
-        path = "%s/%s/merge_requests" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/merge_requests"
         data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
         manager = ProjectMergeRequestManager(
             self.manager.gitlab, parent=self.manager._parent

--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -62,7 +62,7 @@ class ProjectPipeline(RefreshMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabPipelineCancelError: If the request failed
         """
-        path = "%s/%s/cancel" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/cancel"
         return self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectPipeline")
@@ -77,7 +77,7 @@ class ProjectPipeline(RefreshMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabPipelineRetryError: If the request failed
         """
-        path = "%s/%s/retry" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/retry"
         return self.manager.gitlab.http_post(path)
 
 
@@ -182,7 +182,7 @@ class ProjectPipelineSchedule(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabOwnershipError: If the request failed
         """
-        path = "%s/%s/take_ownership" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/take_ownership"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         self._update_attrs(server_data)
 
@@ -199,7 +199,7 @@ class ProjectPipelineSchedule(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabPipelinePlayError: If the request failed
         """
-        path = "%s/%s/play" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/play"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         self._update_attrs(server_data)
         return server_data

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -176,7 +176,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabCreateError: If the relation could not be created
         """
-        path = "/projects/%s/fork/%s" % (self.get_id(), forked_from_id)
+        path = f"/projects/{self.get_id()}/fork/{forked_from_id}"
         self.manager.gitlab.http_post(path, **kwargs)
 
     @cli.register_custom_action("Project")
@@ -191,7 +191,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server failed to perform the request
         """
-        path = "/projects/%s/fork" % self.get_id()
+        path = f"/projects/{self.get_id()}/fork"
         self.manager.gitlab.http_delete(path, **kwargs)
 
     @cli.register_custom_action("Project")
@@ -206,7 +206,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabGetError: If the server failed to perform the request
         """
-        path = "/projects/%s/languages" % self.get_id()
+        path = f"/projects/{self.get_id()}/languages"
         return self.manager.gitlab.http_get(path, **kwargs)
 
     @cli.register_custom_action("Project")
@@ -221,7 +221,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabCreateError: If the server failed to perform the request
         """
-        path = "/projects/%s/star" % self.get_id()
+        path = f"/projects/{self.get_id()}/star"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(server_data, dict)
@@ -239,7 +239,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server failed to perform the request
         """
-        path = "/projects/%s/unstar" % self.get_id()
+        path = f"/projects/{self.get_id()}/unstar"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(server_data, dict)
@@ -257,7 +257,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabCreateError: If the server failed to perform the request
         """
-        path = "/projects/%s/archive" % self.get_id()
+        path = f"/projects/{self.get_id()}/archive"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(server_data, dict)
@@ -275,7 +275,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server failed to perform the request
         """
-        path = "/projects/%s/unarchive" % self.get_id()
+        path = f"/projects/{self.get_id()}/unarchive"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(server_data, dict)
@@ -290,7 +290,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         group_id: int,
         group_access: int,
         expires_at: Optional[str] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Share the project with a group.
 
@@ -303,7 +303,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabCreateError: If the server failed to perform the request
         """
-        path = "/projects/%s/share" % self.get_id()
+        path = f"/projects/{self.get_id()}/share"
         data = {
             "group_id": group_id,
             "group_access": group_access,
@@ -324,7 +324,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server failed to perform the request
         """
-        path = "/projects/%s/share/%s" % (self.get_id(), group_id)
+        path = f"/projects/{self.get_id()}/share/{group_id}"
         self.manager.gitlab.http_delete(path, **kwargs)
 
     # variables not supported in CLI
@@ -335,7 +335,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         ref: str,
         token: str,
         variables: Optional[Dict[str, Any]] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> ProjectPipeline:
         """Trigger a CI build.
 
@@ -352,7 +352,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabCreateError: If the server failed to perform the request
         """
         variables = variables or {}
-        path = "/projects/%s/trigger/pipeline" % self.get_id()
+        path = f"/projects/{self.get_id()}/trigger/pipeline"
         post_data = {"ref": ref, "token": token, "variables": variables}
         attrs = self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
         if TYPE_CHECKING:
@@ -372,7 +372,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabHousekeepingError: If the server failed to perform the
                                      request
         """
-        path = "/projects/%s/housekeeping" % self.get_id()
+        path = f"/projects/{self.get_id()}/housekeeping"
         self.manager.gitlab.http_post(path, **kwargs)
 
     # see #56 - add file attachment features
@@ -383,7 +383,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         filename: str,
         filedata: Optional[bytes] = None,
         filepath: Optional[str] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> Dict[str, Any]:
         """Upload the specified file into the project.
 
@@ -420,7 +420,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             with open(filepath, "rb") as f:
                 filedata = f.read()
 
-        url = "/projects/%(id)s/uploads" % {"id": self.id}
+        url = f"/projects/{self.id}/uploads"
         file_info = {"file": (filename, filedata)}
         data = self.manager.gitlab.http_post(url, files=file_info)
 
@@ -436,7 +436,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         streamed: bool = False,
         action: Optional[Callable] = None,
         chunk_size: int = 1024,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> Optional[bytes]:
         """Return a snapshot of the repository.
 
@@ -457,7 +457,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         Returns:
             str: The uncompressed tar archive of the repository
         """
-        path = "/projects/%s/snapshot" % self.get_id()
+        path = f"/projects/{self.get_id()}/snapshot"
         result = self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
@@ -485,7 +485,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabList: A list of dicts describing the resources found.
         """
         data = {"scope": scope, "search": search}
-        path = "/projects/%s/search" % self.get_id()
+        path = f"/projects/{self.get_id()}/search"
         return self.manager.gitlab.http_list(path, query_data=data, **kwargs)
 
     @cli.register_custom_action("Project")
@@ -500,7 +500,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabCreateError: If the server failed to perform the request
         """
-        path = "/projects/%s/mirror/pull" % self.get_id()
+        path = f"/projects/{self.get_id()}/mirror/pull"
         self.manager.gitlab.http_post(path, **kwargs)
 
     @cli.register_custom_action("Project", ("to_namespace",))
@@ -517,7 +517,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabTransferProjectError: If the project could not be transferred
         """
-        path = "/projects/%s/transfer" % (self.id,)
+        path = f"/projects/{self.id}/transfer"
         self.manager.gitlab.http_put(
             path, post_data={"namespace": to_namespace}, **kwargs
         )
@@ -531,7 +531,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         streamed: bool = False,
         action: Optional[Callable] = None,
         chunk_size: int = 1024,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> Optional[bytes]:
         """Get the job artifacts archive from a specific tag or branch.
 
@@ -556,7 +556,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         Returns:
             str: The artifacts if `streamed` is False, None otherwise.
         """
-        path = "/projects/%s/jobs/artifacts/%s/download" % (self.get_id(), ref_name)
+        path = f"/projects/{self.get_id()}/jobs/artifacts/{ref_name}/download"
         result = self.manager.gitlab.http_get(
             path, job=job, streamed=streamed, raw=True, **kwargs
         )
@@ -574,7 +574,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         streamed: bool = False,
         action: Optional[Callable] = None,
         chunk_size: int = 1024,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> Optional[bytes]:
         """Download a single artifact file from a specific tag or branch from within the job’s artifacts archive.
 
@@ -598,12 +598,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             str: The artifacts if `streamed` is False, None otherwise.
         """
 
-        path = "/projects/%s/jobs/artifacts/%s/raw/%s?job=%s" % (
-            self.get_id(),
-            ref_name,
-            artifact_path,
-            job,
-        )
+        path = f"/projects/{self.get_id()}/jobs/artifacts/{ref_name}/raw/{artifact_path}?job={job}"
         result = self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
@@ -787,7 +782,7 @@ class ProjectManager(CRUDMixin, RESTManager):
         namespace: Optional[str] = None,
         overwrite: bool = False,
         override_params: Optional[Dict[str, Any]] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> Union[Dict[str, Any], requests.Response]:
         """Import a project from an archive file.
 
@@ -812,7 +807,7 @@ class ProjectManager(CRUDMixin, RESTManager):
         data = {"path": path, "overwrite": str(overwrite)}
         if override_params:
             for k, v in override_params.items():
-                data["override_params[%s]" % k] = v
+                data[f"override_params[{k}]"] = v
         if name is not None:
             data["name"] = name
         if namespace:
@@ -830,7 +825,7 @@ class ProjectManager(CRUDMixin, RESTManager):
         bitbucket_server_repo: str,
         new_name: Optional[str] = None,
         target_namespace: Optional[str] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> Union[Dict[str, Any], requests.Response]:
         """Import a project from BitBucket Server to Gitlab (schedule the import)
 
@@ -918,7 +913,7 @@ class ProjectManager(CRUDMixin, RESTManager):
         repo_id: int,
         target_namespace: str,
         new_name: Optional[str] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> Union[Dict[str, Any], requests.Response]:
         """Import a project from Github to Gitlab (schedule the import)
 

--- a/gitlab/v4/objects/repositories.py
+++ b/gitlab/v4/objects/repositories.py
@@ -27,7 +27,7 @@ class RepositoryMixin:
         """
 
         submodule = submodule.replace("/", "%2F")  # .replace('.', '%2E')
-        path = "/projects/%s/repository/submodules/%s" % (self.get_id(), submodule)
+        path = f"/projects/{self.get_id()}/repository/submodules/{submodule}"
         data = {"branch": branch, "commit_sha": commit_sha}
         if "commit_message" in kwargs:
             data["commit_message"] = kwargs["commit_message"]
@@ -56,7 +56,7 @@ class RepositoryMixin:
         Returns:
             list: The representation of the tree
         """
-        gl_path = "/projects/%s/repository/tree" % self.get_id()
+        gl_path = f"/projects/{self.get_id()}/repository/tree"
         query_data = {"recursive": recursive}
         if path:
             query_data["path"] = path
@@ -81,7 +81,7 @@ class RepositoryMixin:
             dict: The blob content and metadata
         """
 
-        path = "/projects/%s/repository/blobs/%s" % (self.get_id(), sha)
+        path = f"/projects/{self.get_id()}/repository/blobs/{sha}"
         return self.manager.gitlab.http_get(path, **kwargs)
 
     @cli.register_custom_action("Project", ("sha",))
@@ -108,7 +108,7 @@ class RepositoryMixin:
         Returns:
             str: The blob content if streamed is False, None otherwise
         """
-        path = "/projects/%s/repository/blobs/%s/raw" % (self.get_id(), sha)
+        path = f"/projects/{self.get_id()}/repository/blobs/{sha}/raw"
         result = self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
@@ -131,7 +131,7 @@ class RepositoryMixin:
         Returns:
             str: The diff
         """
-        path = "/projects/%s/repository/compare" % self.get_id()
+        path = f"/projects/{self.get_id()}/repository/compare"
         query_data = {"from": from_, "to": to}
         return self.manager.gitlab.http_get(path, query_data=query_data, **kwargs)
 
@@ -155,7 +155,7 @@ class RepositoryMixin:
         Returns:
             list: The contributors
         """
-        path = "/projects/%s/repository/contributors" % self.get_id()
+        path = f"/projects/{self.get_id()}/repository/contributors"
         return self.manager.gitlab.http_list(path, **kwargs)
 
     @cli.register_custom_action("Project", tuple(), ("sha",))
@@ -182,7 +182,7 @@ class RepositoryMixin:
         Returns:
             bytes: The binary data of the archive
         """
-        path = "/projects/%s/repository/archive" % self.get_id()
+        path = f"/projects/{self.get_id()}/repository/archive"
         query_data = {}
         if sha:
             query_data["sha"] = sha
@@ -203,5 +203,5 @@ class RepositoryMixin:
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server failed to perform the request
         """
-        path = "/projects/%s/repository/merged_branches" % self.get_id()
+        path = f"/projects/{self.get_id()}/repository/merged_branches"
         self.manager.gitlab.http_delete(path, **kwargs)

--- a/gitlab/v4/objects/snippets.py
+++ b/gitlab/v4/objects/snippets.py
@@ -40,7 +40,7 @@ class Snippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             str: The snippet content
         """
-        path = "/snippets/%s/raw" % self.get_id()
+        path = f"/snippets/{self.get_id()}/raw"
         result = self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
@@ -103,7 +103,7 @@ class ProjectSnippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObj
         Returns:
             str: The snippet content
         """
-        path = "%s/%s/raw" % (self.manager.path, self.get_id())
+        path = f"{self.manager.path}/{self.get_id()}/raw"
         result = self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )

--- a/gitlab/v4/objects/todos.py
+++ b/gitlab/v4/objects/todos.py
@@ -22,7 +22,7 @@ class Todo(ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabTodoError: If the server failed to perform the request
         """
-        path = "%s/%s/mark_as_done" % (self.manager.path, self.id)
+        path = f"{self.manager.path}/{self.id}/mark_as_done"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         self._update_attrs(server_data)
 

--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -154,7 +154,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             bool: Whether the user status has been changed
         """
-        path = "/users/%s/block" % self.id
+        path = f"/users/{self.id}/block"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if server_data is True:
             self._attrs["state"] = "blocked"
@@ -175,7 +175,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             dict: The new object data (*not* a RESTObject)
         """
-        path = "/users/%s/follow" % self.id
+        path = f"/users/{self.id}/follow"
         return self.manager.gitlab.http_post(path, **kwargs)
 
     @cli.register_custom_action("User")
@@ -193,7 +193,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             dict: The new object data (*not* a RESTObject)
         """
-        path = "/users/%s/unfollow" % self.id
+        path = f"/users/{self.id}/unfollow"
         return self.manager.gitlab.http_post(path, **kwargs)
 
     @cli.register_custom_action("User")
@@ -211,7 +211,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             bool: Whether the user status has been changed
         """
-        path = "/users/%s/unblock" % self.id
+        path = f"/users/{self.id}/unblock"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if server_data is True:
             self._attrs["state"] = "active"
@@ -232,7 +232,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             bool: Whether the user status has been changed
         """
-        path = "/users/%s/deactivate" % self.id
+        path = f"/users/{self.id}/deactivate"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if server_data:
             self._attrs["state"] = "deactivated"
@@ -253,7 +253,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             bool: Whether the user status has been changed
         """
-        path = "/users/%s/activate" % self.id
+        path = f"/users/{self.id}/activate"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if server_data:
             self._attrs["state"] = "active"
@@ -504,9 +504,9 @@ class UserProjectManager(ListMixin, CreateMixin, RESTManager):
             GitlabListError: If the server cannot perform the request
         """
         if self._parent:
-            path = "/users/%s/projects" % self._parent.id
+            path = f"/users/{self._parent.id}/projects"
         else:
-            path = "/users/%s/projects" % kwargs["user_id"]
+            path = f"/users/{kwargs['user_id']}/projects"
         return ListMixin.list(self, path=path, **kwargs)
 
 

--- a/tests/functional/api/test_gitlab.py
+++ b/tests/functional/api/test_gitlab.py
@@ -166,13 +166,13 @@ def test_rate_limits(gl):
 
     projects = list()
     for i in range(0, 20):
-        projects.append(gl.projects.create({"name": str(i) + "ok"}))
+        projects.append(gl.projects.create({"name": f"{str(i)}ok"}))
 
     with pytest.raises(gitlab.GitlabCreateError) as e:
         for i in range(20, 40):
             projects.append(
                 gl.projects.create(
-                    {"name": str(i) + "shouldfail"}, obey_rate_limit=False
+                    {"name": f"{str(i)}shouldfail"}, obey_rate_limit=False
                 )
             )
 

--- a/tests/functional/api/test_keys.py
+++ b/tests/functional/api/test_keys.py
@@ -10,7 +10,7 @@ def key_fingerprint(key):
     key_part = key.split()[1]
     decoded = base64.b64decode(key_part.encode("ascii"))
     digest = hashlib.sha256(decoded).digest()
-    return "SHA256:" + base64.b64encode(digest).rstrip(b"=").decode("utf-8")
+    return f"SHA256:{base64.b64encode(digest).rstrip(b'=').decode('utf-8')}"
 
 
 def test_keys_ssh(gl, user, SSH_KEY):

--- a/tests/functional/api/test_projects.py
+++ b/tests/functional/api/test_projects.py
@@ -108,7 +108,7 @@ def test_project_file_uploads(project):
     uploaded_file = project.upload(filename, file_contents)
     assert uploaded_file["alt"] == filename
     assert uploaded_file["url"].startswith("/uploads/")
-    assert uploaded_file["url"].endswith("/" + filename)
+    assert uploaded_file["url"].endswith(f"/{filename}")
     assert uploaded_file["markdown"] == "[{}]({})".format(
         uploaded_file["alt"], uploaded_file["url"]
     )

--- a/tests/functional/api/test_repository.py
+++ b/tests/functional/api/test_repository.py
@@ -116,9 +116,7 @@ def test_revert_commit(project):
     commit = project.commits.list()[0]
     revert_commit = commit.revert(branch="main")
 
-    expected_message = 'Revert "{}"\n\nThis reverts commit {}'.format(
-        commit.message, commit.id
-    )
+    expected_message = f'Revert "{commit.message}"\n\nThis reverts commit {commit.id}'
     assert revert_commit["message"] == expected_message
 
     with pytest.raises(gitlab.GitlabRevertError):

--- a/tests/functional/ee-test.py
+++ b/tests/functional/ee-test.py
@@ -14,7 +14,7 @@ LDAP_PROVIDER = "ldapmain"
 
 
 def start_log(message):
-    print("Testing %s... " % message, end="")
+    print(f"Testing {message}... ", end="")
 
 
 def end_log():

--- a/tests/unit/objects/test_todos.py
+++ b/tests/unit/objects/test_todos.py
@@ -10,7 +10,7 @@ import responses
 
 from gitlab.v4.objects import Todo
 
-with open(os.path.dirname(__file__) + "/../data/todo.json", "r") as json_file:
+with open(f"{os.path.dirname(__file__)}/../data/todo.json", "r") as json_file:
     todo_content = json_file.read()
     json_content = json.loads(todo_content)
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -91,7 +91,7 @@ def test_parse_value():
     fd, temp_path = tempfile.mkstemp()
     os.write(fd, b"content")
     os.close(fd)
-    ret = cli._parse_value("@%s" % temp_path)
+    ret = cli._parse_value(f"@{temp_path}")
     assert ret == "content"
     os.unlink(temp_path)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -26,7 +26,7 @@ from gitlab import config, USER_AGENT
 
 custom_user_agent = "my-package/1.0.0"
 
-valid_config = u"""[global]
+valid_config = """[global]
 default = one
 ssl_verify = true
 timeout = 2
@@ -52,24 +52,22 @@ url = https://four.url
 oauth_token = STUV
 """
 
-custom_user_agent_config = """[global]
+custom_user_agent_config = f"""[global]
 default = one
-user_agent = {}
+user_agent = {custom_user_agent}
 
 [one]
 url = http://one.url
 private_token = ABCDEF
-""".format(
-    custom_user_agent
-)
+"""
 
-no_default_config = u"""[global]
+no_default_config = """[global]
 [there]
 url = http://there.url
 private_token = ABCDEF
 """
 
-missing_attr_config = u"""[global]
+missing_attr_config = """[global]
 [one]
 url = http://one.url
 
@@ -87,28 +85,24 @@ per_page = 200
 
 
 def global_retry_transient_errors(value: bool) -> str:
-    return u"""[global]
+    return f"""[global]
 default = one
-retry_transient_errors={}
+retry_transient_errors={value}
 [one]
 url = http://one.url
-private_token = ABCDEF""".format(
-        value
-    )
+private_token = ABCDEF"""
 
 
 def global_and_gitlab_retry_transient_errors(
     global_value: bool, gitlab_value: bool
 ) -> str:
-    return u"""[global]
+    return f"""[global]
     default = one
     retry_transient_errors={global_value}
     [one]
     url = http://one.url
     private_token = ABCDEF
-    retry_transient_errors={gitlab_value}""".format(
-        global_value=global_value, gitlab_value=gitlab_value
-    )
+    retry_transient_errors={gitlab_value}"""
 
 
 @mock.patch.dict(os.environ, {"PYTHON_GITLAB_CFG": "/some/path"})
@@ -233,16 +227,15 @@ def test_data_from_helper(m_open, path_exists, tmp_path):
 
     fd = io.StringIO(
         dedent(
-            """\
+            f"""\
             [global]
             default = helper
 
             [helper]
             url = https://helper.url
-            oauth_token = helper: %s
+            oauth_token = helper: {helper}
             """
         )
-        % helper
     )
 
     fd.close = mock.Mock(return_value=None)

--- a/tests/unit/test_gitlab.py
+++ b/tests/unit/test_gitlab.py
@@ -33,9 +33,7 @@ token = "abc123"
 @urlmatch(scheme="http", netloc="localhost", path="/api/v4/user", method="get")
 def resp_get_user(url, request):
     headers = {"content-type": "application/json"}
-    content = '{{"id": {0:d}, "username": "{1:s}"}}'.format(user_id, username).encode(
-        "utf-8"
-    )
+    content = f'{{"id": {user_id:d}, "username": "{username:s}"}}'.encode("utf-8")
     return response(200, content, headers, None, 5, request)
 
 


### PR DESCRIPTION
I just did a `flynt --transform-concats gitlab/ tests/` for this one using https://github.com/ikamensh/flynt. (with a bit of manual touch-up).

---

To keep it a reasonable size (it's 40 files), I'll do named placeholders in a follow-up PR, e.g. for:
`"/projects/%(project_id)s/issues/%(issue_iid)s/notes/%(note_id)s"`
->
`"/projects/{project_id}/issues/{issue_iid}/notes/{note_id}"`