### PR TITLE
refactor: use new-style formatting for named placeholders

### DIFF
--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -320,7 +320,7 @@ class RESTManager(object):
             for self_attr, parent_attr in self._from_parent_attrs.items()
         }
         self._parent_attrs = data
-        return path % data
+        return path.format(**data)
 
     @property
     def path(self) -> Optional[str]:

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -53,7 +53,7 @@ class GitlabCLI(object):
         # the class _path attribute, and replace the value with the result.
         if TYPE_CHECKING:
             assert self.mgr_cls._path is not None
-        self.mgr_cls._path = self.mgr_cls._path % self.args
+        self.mgr_cls._path = self.mgr_cls._path.format(**self.args)
         self.mgr = self.mgr_cls(gl)
 
         if self.mgr_cls._types:

--- a/gitlab/v4/objects/access_requests.py
+++ b/gitlab/v4/objects/access_requests.py
@@ -20,7 +20,7 @@ class GroupAccessRequest(AccessRequestMixin, ObjectDeleteMixin, RESTObject):
 
 
 class GroupAccessRequestManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
-    _path = "/groups/%(group_id)s/access_requests"
+    _path = "/groups/{group_id}/access_requests"
     _obj_cls = GroupAccessRequest
     _from_parent_attrs = {"group_id": "id"}
 
@@ -30,6 +30,6 @@ class ProjectAccessRequest(AccessRequestMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectAccessRequestManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
-    _path = "/projects/%(project_id)s/access_requests"
+    _path = "/projects/{project_id}/access_requests"
     _obj_cls = ProjectAccessRequest
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/audit_events.py
+++ b/gitlab/v4/objects/audit_events.py
@@ -32,7 +32,7 @@ class GroupAuditEvent(RESTObject):
 
 
 class GroupAuditEventManager(RetrieveMixin, RESTManager):
-    _path = "/groups/%(group_id)s/audit_events"
+    _path = "/groups/{group_id}/audit_events"
     _obj_cls = GroupAuditEvent
     _from_parent_attrs = {"group_id": "id"}
     _list_filters = ("created_after", "created_before")
@@ -43,7 +43,7 @@ class ProjectAuditEvent(RESTObject):
 
 
 class ProjectAuditEventManager(RetrieveMixin, RESTManager):
-    _path = "/projects/%(project_id)s/audit_events"
+    _path = "/projects/{project_id}/audit_events"
     _obj_cls = ProjectAuditEvent
     _from_parent_attrs = {"project_id": "id"}
     _list_filters = ("created_after", "created_before")

--- a/gitlab/v4/objects/award_emojis.py
+++ b/gitlab/v4/objects/award_emojis.py
@@ -22,7 +22,7 @@ class ProjectIssueAwardEmoji(ObjectDeleteMixin, RESTObject):
 
 
 class ProjectIssueAwardEmojiManager(NoUpdateMixin, RESTManager):
-    _path = "/projects/%(project_id)s/issues/%(issue_iid)s/award_emoji"
+    _path = "/projects/{project_id}/issues/{issue_iid}/award_emoji"
     _obj_cls = ProjectIssueAwardEmoji
     _from_parent_attrs = {"project_id": "project_id", "issue_iid": "iid"}
     _create_attrs = RequiredOptional(required=("name",))
@@ -33,9 +33,7 @@ class ProjectIssueNoteAwardEmoji(ObjectDeleteMixin, RESTObject):
 
 
 class ProjectIssueNoteAwardEmojiManager(NoUpdateMixin, RESTManager):
-    _path = (
-        "/projects/%(project_id)s/issues/%(issue_iid)s" "/notes/%(note_id)s/award_emoji"
-    )
+    _path = "/projects/{project_id}/issues/{issue_iid}/notes/{note_id}/award_emoji"
     _obj_cls = ProjectIssueNoteAwardEmoji
     _from_parent_attrs = {
         "project_id": "project_id",
@@ -50,7 +48,7 @@ class ProjectMergeRequestAwardEmoji(ObjectDeleteMixin, RESTObject):
 
 
 class ProjectMergeRequestAwardEmojiManager(NoUpdateMixin, RESTManager):
-    _path = "/projects/%(project_id)s/merge_requests/%(mr_iid)s/award_emoji"
+    _path = "/projects/{project_id}/merge_requests/{mr_iid}/award_emoji"
     _obj_cls = ProjectMergeRequestAwardEmoji
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}
     _create_attrs = RequiredOptional(required=("name",))
@@ -61,10 +59,7 @@ class ProjectMergeRequestNoteAwardEmoji(ObjectDeleteMixin, RESTObject):
 
 
 class ProjectMergeRequestNoteAwardEmojiManager(NoUpdateMixin, RESTManager):
-    _path = (
-        "/projects/%(project_id)s/merge_requests/%(mr_iid)s"
-        "/notes/%(note_id)s/award_emoji"
-    )
+    _path = "/projects/{project_id}/merge_requests/{mr_iid}/notes/{note_id}/award_emoji"
     _obj_cls = ProjectMergeRequestNoteAwardEmoji
     _from_parent_attrs = {
         "project_id": "project_id",
@@ -79,7 +74,7 @@ class ProjectSnippetAwardEmoji(ObjectDeleteMixin, RESTObject):
 
 
 class ProjectSnippetAwardEmojiManager(NoUpdateMixin, RESTManager):
-    _path = "/projects/%(project_id)s/snippets/%(snippet_id)s/award_emoji"
+    _path = "/projects/{project_id}/snippets/{snippet_id}/award_emoji"
     _obj_cls = ProjectSnippetAwardEmoji
     _from_parent_attrs = {"project_id": "project_id", "snippet_id": "id"}
     _create_attrs = RequiredOptional(required=("name",))
@@ -90,10 +85,7 @@ class ProjectSnippetNoteAwardEmoji(ObjectDeleteMixin, RESTObject):
 
 
 class ProjectSnippetNoteAwardEmojiManager(NoUpdateMixin, RESTManager):
-    _path = (
-        "/projects/%(project_id)s/snippets/%(snippet_id)s"
-        "/notes/%(note_id)s/award_emoji"
-    )
+    _path = "/projects/{project_id}/snippets/{snippet_id}/notes/{note_id}/award_emoji"
     _obj_cls = ProjectSnippetNoteAwardEmoji
     _from_parent_attrs = {
         "project_id": "project_id",

--- a/gitlab/v4/objects/badges.py
+++ b/gitlab/v4/objects/badges.py
@@ -16,7 +16,7 @@ class GroupBadge(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class GroupBadgeManager(BadgeRenderMixin, CRUDMixin, RESTManager):
-    _path = "/groups/%(group_id)s/badges"
+    _path = "/groups/{group_id}/badges"
     _obj_cls = GroupBadge
     _from_parent_attrs = {"group_id": "id"}
     _create_attrs = RequiredOptional(required=("link_url", "image_url"))
@@ -28,7 +28,7 @@ class ProjectBadge(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectBadgeManager(BadgeRenderMixin, CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/badges"
+    _path = "/projects/{project_id}/badges"
     _obj_cls = ProjectBadge
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(required=("link_url", "image_url"))

--- a/gitlab/v4/objects/boards.py
+++ b/gitlab/v4/objects/boards.py
@@ -20,7 +20,7 @@ class GroupBoardList(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class GroupBoardListManager(CRUDMixin, RESTManager):
-    _path = "/groups/%(group_id)s/boards/%(board_id)s/lists"
+    _path = "/groups/{group_id}/boards/{board_id}/lists"
     _obj_cls = GroupBoardList
     _from_parent_attrs = {"group_id": "group_id", "board_id": "id"}
     _create_attrs = RequiredOptional(required=("label_id",))
@@ -37,7 +37,7 @@ class GroupBoard(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class GroupBoardManager(CRUDMixin, RESTManager):
-    _path = "/groups/%(group_id)s/boards"
+    _path = "/groups/{group_id}/boards"
     _obj_cls = GroupBoard
     _from_parent_attrs = {"group_id": "id"}
     _create_attrs = RequiredOptional(required=("name",))
@@ -51,7 +51,7 @@ class ProjectBoardList(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectBoardListManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/boards/%(board_id)s/lists"
+    _path = "/projects/{project_id}/boards/{board_id}/lists"
     _obj_cls = ProjectBoardList
     _from_parent_attrs = {"project_id": "project_id", "board_id": "id"}
     _create_attrs = RequiredOptional(required=("label_id",))
@@ -68,7 +68,7 @@ class ProjectBoard(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectBoardManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/boards"
+    _path = "/projects/{project_id}/boards"
     _obj_cls = ProjectBoard
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(required=("name",))

--- a/gitlab/v4/objects/branches.py
+++ b/gitlab/v4/objects/branches.py
@@ -14,7 +14,7 @@ class ProjectBranch(ObjectDeleteMixin, RESTObject):
 
 
 class ProjectBranchManager(NoUpdateMixin, RESTManager):
-    _path = "/projects/%(project_id)s/repository/branches"
+    _path = "/projects/{project_id}/repository/branches"
     _obj_cls = ProjectBranch
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(required=("branch", "ref"))
@@ -25,7 +25,7 @@ class ProjectProtectedBranch(ObjectDeleteMixin, RESTObject):
 
 
 class ProjectProtectedBranchManager(NoUpdateMixin, RESTManager):
-    _path = "/projects/%(project_id)s/protected_branches"
+    _path = "/projects/{project_id}/protected_branches"
     _obj_cls = ProjectProtectedBranch
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(

--- a/gitlab/v4/objects/clusters.py
+++ b/gitlab/v4/objects/clusters.py
@@ -17,7 +17,7 @@ class GroupCluster(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class GroupClusterManager(CRUDMixin, RESTManager):
-    _path = "/groups/%(group_id)s/clusters"
+    _path = "/groups/{group_id}/clusters"
     _obj_cls = GroupCluster
     _from_parent_attrs = {"group_id": "id"}
     _create_attrs = RequiredOptional(
@@ -63,7 +63,7 @@ class ProjectCluster(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectClusterManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/clusters"
+    _path = "/projects/{project_id}/clusters"
     _obj_cls = ProjectCluster
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(

--- a/gitlab/v4/objects/commits.py
+++ b/gitlab/v4/objects/commits.py
@@ -143,7 +143,7 @@ class ProjectCommit(RESTObject):
 
 
 class ProjectCommitManager(RetrieveMixin, CreateMixin, RESTManager):
-    _path = "/projects/%(project_id)s/repository/commits"
+    _path = "/projects/{project_id}/repository/commits"
     _obj_cls = ProjectCommit
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(
@@ -158,7 +158,7 @@ class ProjectCommitComment(RESTObject):
 
 
 class ProjectCommitCommentManager(ListMixin, CreateMixin, RESTManager):
-    _path = "/projects/%(project_id)s/repository/commits/%(commit_id)s" "/comments"
+    _path = "/projects/{project_id}/repository/commits/{commit_id}/comments"
     _obj_cls = ProjectCommitComment
     _from_parent_attrs = {"project_id": "project_id", "commit_id": "id"}
     _create_attrs = RequiredOptional(
@@ -171,7 +171,7 @@ class ProjectCommitStatus(RefreshMixin, RESTObject):
 
 
 class ProjectCommitStatusManager(ListMixin, CreateMixin, RESTManager):
-    _path = "/projects/%(project_id)s/repository/commits/%(commit_id)s" "/statuses"
+    _path = "/projects/{project_id}/repository/commits/{commit_id}/statuses"
     _obj_cls = ProjectCommitStatus
     _from_parent_attrs = {"project_id": "project_id", "commit_id": "id"}
     _create_attrs = RequiredOptional(
@@ -202,10 +202,10 @@ class ProjectCommitStatusManager(ListMixin, CreateMixin, RESTManager):
         # project_id and commit_id are in the data dict when using the CLI, but
         # they are missing when using only the API
         # See #511
-        base_path = "/projects/%(project_id)s/statuses/%(commit_id)s"
+        base_path = "/projects/{project_id}/statuses/{commit_id}"
         path: Optional[str]
         if data is not None and "project_id" in data and "commit_id" in data:
-            path = base_path % data
+            path = base_path.format(**data)
         else:
             path = self._compute_path(base_path)
         if TYPE_CHECKING:

--- a/gitlab/v4/objects/container_registry.py
+++ b/gitlab/v4/objects/container_registry.py
@@ -18,7 +18,7 @@ class ProjectRegistryRepository(ObjectDeleteMixin, RESTObject):
 
 
 class ProjectRegistryRepositoryManager(DeleteMixin, ListMixin, RESTManager):
-    _path = "/projects/%(project_id)s/registry/repositories"
+    _path = "/projects/{project_id}/registry/repositories"
     _obj_cls = ProjectRegistryRepository
     _from_parent_attrs = {"project_id": "id"}
 
@@ -30,7 +30,7 @@ class ProjectRegistryTag(ObjectDeleteMixin, RESTObject):
 class ProjectRegistryTagManager(DeleteMixin, RetrieveMixin, RESTManager):
     _obj_cls = ProjectRegistryTag
     _from_parent_attrs = {"project_id": "project_id", "repository_id": "id"}
-    _path = "/projects/%(project_id)s/registry/repositories/%(repository_id)s/tags"
+    _path = "/projects/{project_id}/registry/repositories/{repository_id}/tags"
 
     @cli.register_custom_action(
         "ProjectRegistryTagManager",

--- a/gitlab/v4/objects/custom_attributes.py
+++ b/gitlab/v4/objects/custom_attributes.py
@@ -16,7 +16,7 @@ class GroupCustomAttribute(ObjectDeleteMixin, RESTObject):
 
 
 class GroupCustomAttributeManager(RetrieveMixin, SetMixin, DeleteMixin, RESTManager):
-    _path = "/groups/%(group_id)s/custom_attributes"
+    _path = "/groups/{group_id}/custom_attributes"
     _obj_cls = GroupCustomAttribute
     _from_parent_attrs = {"group_id": "id"}
 
@@ -26,7 +26,7 @@ class ProjectCustomAttribute(ObjectDeleteMixin, RESTObject):
 
 
 class ProjectCustomAttributeManager(RetrieveMixin, SetMixin, DeleteMixin, RESTManager):
-    _path = "/projects/%(project_id)s/custom_attributes"
+    _path = "/projects/{project_id}/custom_attributes"
     _obj_cls = ProjectCustomAttribute
     _from_parent_attrs = {"project_id": "id"}
 
@@ -36,6 +36,6 @@ class UserCustomAttribute(ObjectDeleteMixin, RESTObject):
 
 
 class UserCustomAttributeManager(RetrieveMixin, SetMixin, DeleteMixin, RESTManager):
-    _path = "/users/%(user_id)s/custom_attributes"
+    _path = "/users/{user_id}/custom_attributes"
     _obj_cls = UserCustomAttribute
     _from_parent_attrs = {"user_id": "id"}

--- a/gitlab/v4/objects/deploy_keys.py
+++ b/gitlab/v4/objects/deploy_keys.py
@@ -29,7 +29,7 @@ class ProjectKey(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectKeyManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/deploy_keys"
+    _path = "/projects/{project_id}/deploy_keys"
     _obj_cls = ProjectKey
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(required=("title", "key"), optional=("can_push",))

--- a/gitlab/v4/objects/deploy_tokens.py
+++ b/gitlab/v4/objects/deploy_tokens.py
@@ -26,7 +26,7 @@ class GroupDeployToken(ObjectDeleteMixin, RESTObject):
 
 
 class GroupDeployTokenManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
-    _path = "/groups/%(group_id)s/deploy_tokens"
+    _path = "/groups/{group_id}/deploy_tokens"
     _from_parent_attrs = {"group_id": "id"}
     _obj_cls = GroupDeployToken
     _create_attrs = RequiredOptional(
@@ -47,7 +47,7 @@ class ProjectDeployToken(ObjectDeleteMixin, RESTObject):
 
 
 class ProjectDeployTokenManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
-    _path = "/projects/%(project_id)s/deploy_tokens"
+    _path = "/projects/{project_id}/deploy_tokens"
     _from_parent_attrs = {"project_id": "id"}
     _obj_cls = ProjectDeployToken
     _create_attrs = RequiredOptional(

--- a/gitlab/v4/objects/deployments.py
+++ b/gitlab/v4/objects/deployments.py
@@ -14,7 +14,7 @@ class ProjectDeployment(SaveMixin, RESTObject):
 
 
 class ProjectDeploymentManager(RetrieveMixin, CreateMixin, UpdateMixin, RESTManager):
-    _path = "/projects/%(project_id)s/deployments"
+    _path = "/projects/{project_id}/deployments"
     _obj_cls = ProjectDeployment
     _from_parent_attrs = {"project_id": "id"}
     _list_filters = (

--- a/gitlab/v4/objects/discussions.py
+++ b/gitlab/v4/objects/discussions.py
@@ -25,7 +25,7 @@ class ProjectCommitDiscussion(RESTObject):
 
 
 class ProjectCommitDiscussionManager(RetrieveMixin, CreateMixin, RESTManager):
-    _path = "/projects/%(project_id)s/repository/commits/%(commit_id)s/" "discussions"
+    _path = "/projects/{project_id}/repository/commits/{commit_id}/discussions"
     _obj_cls = ProjectCommitDiscussion
     _from_parent_attrs = {"project_id": "project_id", "commit_id": "id"}
     _create_attrs = RequiredOptional(required=("body",), optional=("created_at",))
@@ -36,7 +36,7 @@ class ProjectIssueDiscussion(RESTObject):
 
 
 class ProjectIssueDiscussionManager(RetrieveMixin, CreateMixin, RESTManager):
-    _path = "/projects/%(project_id)s/issues/%(issue_iid)s/discussions"
+    _path = "/projects/{project_id}/issues/{issue_iid}/discussions"
     _obj_cls = ProjectIssueDiscussion
     _from_parent_attrs = {"project_id": "project_id", "issue_iid": "iid"}
     _create_attrs = RequiredOptional(required=("body",), optional=("created_at",))
@@ -49,7 +49,7 @@ class ProjectMergeRequestDiscussion(SaveMixin, RESTObject):
 class ProjectMergeRequestDiscussionManager(
     RetrieveMixin, CreateMixin, UpdateMixin, RESTManager
 ):
-    _path = "/projects/%(project_id)s/merge_requests/%(mr_iid)s/discussions"
+    _path = "/projects/{project_id}/merge_requests/{mr_iid}/discussions"
     _obj_cls = ProjectMergeRequestDiscussion
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}
     _create_attrs = RequiredOptional(
@@ -63,7 +63,7 @@ class ProjectSnippetDiscussion(RESTObject):
 
 
 class ProjectSnippetDiscussionManager(RetrieveMixin, CreateMixin, RESTManager):
-    _path = "/projects/%(project_id)s/snippets/%(snippet_id)s/discussions"
+    _path = "/projects/{project_id}/snippets/{snippet_id}/discussions"
     _obj_cls = ProjectSnippetDiscussion
     _from_parent_attrs = {"project_id": "project_id", "snippet_id": "id"}
     _create_attrs = RequiredOptional(required=("body",), optional=("created_at",))

--- a/gitlab/v4/objects/environments.py
+++ b/gitlab/v4/objects/environments.py
@@ -43,7 +43,7 @@ class ProjectEnvironment(SaveMixin, ObjectDeleteMixin, RESTObject):
 class ProjectEnvironmentManager(
     RetrieveMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
 ):
-    _path = "/projects/%(project_id)s/environments"
+    _path = "/projects/{project_id}/environments"
     _obj_cls = ProjectEnvironment
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(required=("name",), optional=("external_url",))

--- a/gitlab/v4/objects/epics.py
+++ b/gitlab/v4/objects/epics.py
@@ -29,7 +29,7 @@ class GroupEpic(ObjectDeleteMixin, SaveMixin, RESTObject):
 
 
 class GroupEpicManager(CRUDMixin, RESTManager):
-    _path = "/groups/%(group_id)s/epics"
+    _path = "/groups/{group_id}/epics"
     _obj_cls = GroupEpic
     _from_parent_attrs = {"group_id": "id"}
     _list_filters = ("author_id", "labels", "order_by", "sort", "search")
@@ -71,7 +71,7 @@ class GroupEpicIssue(ObjectDeleteMixin, SaveMixin, RESTObject):
 class GroupEpicIssueManager(
     ListMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
 ):
-    _path = "/groups/%(group_id)s/epics/%(epic_iid)s/issues"
+    _path = "/groups/{group_id}/epics/{epic_iid}/issues"
     _obj_cls = GroupEpicIssue
     _from_parent_attrs = {"group_id": "group_id", "epic_iid": "iid"}
     _create_attrs = RequiredOptional(required=("issue_id",))

--- a/gitlab/v4/objects/events.py
+++ b/gitlab/v4/objects/events.py
@@ -41,7 +41,7 @@ class GroupEpicResourceLabelEvent(RESTObject):
 
 
 class GroupEpicResourceLabelEventManager(RetrieveMixin, RESTManager):
-    _path = "/groups/%(group_id)s/epics/%(epic_id)s/resource_label_events"
+    _path = "/groups/{group_id}/epics/{epic_id}/resource_label_events"
     _obj_cls = GroupEpicResourceLabelEvent
     _from_parent_attrs = {"group_id": "group_id", "epic_id": "id"}
 
@@ -51,7 +51,7 @@ class ProjectEvent(Event):
 
 
 class ProjectEventManager(EventManager):
-    _path = "/projects/%(project_id)s/events"
+    _path = "/projects/{project_id}/events"
     _obj_cls = ProjectEvent
     _from_parent_attrs = {"project_id": "id"}
 
@@ -61,7 +61,7 @@ class ProjectIssueResourceLabelEvent(RESTObject):
 
 
 class ProjectIssueResourceLabelEventManager(RetrieveMixin, RESTManager):
-    _path = "/projects/%(project_id)s/issues/%(issue_iid)s" "/resource_label_events"
+    _path = "/projects/{project_id}/issues/{issue_iid}/resource_label_events"
     _obj_cls = ProjectIssueResourceLabelEvent
     _from_parent_attrs = {"project_id": "project_id", "issue_iid": "iid"}
 
@@ -71,7 +71,7 @@ class ProjectIssueResourceMilestoneEvent(RESTObject):
 
 
 class ProjectIssueResourceMilestoneEventManager(RetrieveMixin, RESTManager):
-    _path = "/projects/%(project_id)s/issues/%(issue_iid)s/resource_milestone_events"
+    _path = "/projects/{project_id}/issues/{issue_iid}/resource_milestone_events"
     _obj_cls = ProjectIssueResourceMilestoneEvent
     _from_parent_attrs = {"project_id": "project_id", "issue_iid": "iid"}
 
@@ -81,7 +81,7 @@ class ProjectIssueResourceStateEvent(RESTObject):
 
 
 class ProjectIssueResourceStateEventManager(RetrieveMixin, RESTManager):
-    _path = "/projects/%(project_id)s/issues/%(issue_iid)s/resource_state_events"
+    _path = "/projects/{project_id}/issues/{issue_iid}/resource_state_events"
     _obj_cls = ProjectIssueResourceStateEvent
     _from_parent_attrs = {"project_id": "project_id", "issue_iid": "iid"}
 
@@ -91,9 +91,7 @@ class ProjectMergeRequestResourceLabelEvent(RESTObject):
 
 
 class ProjectMergeRequestResourceLabelEventManager(RetrieveMixin, RESTManager):
-    _path = (
-        "/projects/%(project_id)s/merge_requests/%(mr_iid)s" "/resource_label_events"
-    )
+    _path = "/projects/{project_id}/merge_requests/{mr_iid}/resource_label_events"
     _obj_cls = ProjectMergeRequestResourceLabelEvent
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}
 
@@ -103,9 +101,7 @@ class ProjectMergeRequestResourceMilestoneEvent(RESTObject):
 
 
 class ProjectMergeRequestResourceMilestoneEventManager(RetrieveMixin, RESTManager):
-    _path = (
-        "/projects/%(project_id)s/merge_requests/%(mr_iid)s/resource_milestone_events"
-    )
+    _path = "/projects/{project_id}/merge_requests/{mr_iid}/resource_milestone_events"
     _obj_cls = ProjectMergeRequestResourceMilestoneEvent
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}
 
@@ -115,7 +111,7 @@ class ProjectMergeRequestResourceStateEvent(RESTObject):
 
 
 class ProjectMergeRequestResourceStateEventManager(RetrieveMixin, RESTManager):
-    _path = "/projects/%(project_id)s/merge_requests/%(mr_iid)s/resource_state_events"
+    _path = "/projects/{project_id}/merge_requests/{mr_iid}/resource_state_events"
     _obj_cls = ProjectMergeRequestResourceStateEvent
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}
 
@@ -125,6 +121,6 @@ class UserEvent(Event):
 
 
 class UserEventManager(EventManager):
-    _path = "/users/%(user_id)s/events"
+    _path = "/users/{user_id}/events"
     _obj_cls = UserEvent
     _from_parent_attrs = {"user_id": "id"}

--- a/gitlab/v4/objects/export_import.py
+++ b/gitlab/v4/objects/export_import.py
@@ -20,7 +20,7 @@ class GroupExport(DownloadMixin, RESTObject):
 
 
 class GroupExportManager(GetWithoutIdMixin, CreateMixin, RESTManager):
-    _path = "/groups/%(group_id)s/export"
+    _path = "/groups/{group_id}/export"
     _obj_cls = GroupExport
     _from_parent_attrs = {"group_id": "id"}
 
@@ -35,7 +35,7 @@ class GroupImport(RESTObject):
 
 
 class GroupImportManager(GetWithoutIdMixin, RESTManager):
-    _path = "/groups/%(group_id)s/import"
+    _path = "/groups/{group_id}/import"
     _obj_cls = GroupImport
     _from_parent_attrs = {"group_id": "id"}
 
@@ -50,7 +50,7 @@ class ProjectExport(DownloadMixin, RefreshMixin, RESTObject):
 
 
 class ProjectExportManager(GetWithoutIdMixin, CreateMixin, RESTManager):
-    _path = "/projects/%(project_id)s/export"
+    _path = "/projects/{project_id}/export"
     _obj_cls = ProjectExport
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(optional=("description",))
@@ -66,7 +66,7 @@ class ProjectImport(RefreshMixin, RESTObject):
 
 
 class ProjectImportManager(GetWithoutIdMixin, RESTManager):
-    _path = "/projects/%(project_id)s/import"
+    _path = "/projects/{project_id}/import"
     _obj_cls = ProjectImport
     _from_parent_attrs = {"project_id": "id"}
 

--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -67,7 +67,7 @@ class ProjectFile(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager):
-    _path = "/projects/%(project_id)s/repository/files"
+    _path = "/projects/{project_id}/repository/files"
     _obj_cls = ProjectFile
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -336,7 +336,7 @@ class GroupSubgroup(RESTObject):
 
 
 class GroupSubgroupManager(ListMixin, RESTManager):
-    _path = "/groups/%(group_id)s/subgroups"
+    _path = "/groups/{group_id}/subgroups"
     _obj_cls: Union[Type["GroupDescendantGroup"], Type[GroupSubgroup]] = GroupSubgroup
     _from_parent_attrs = {"group_id": "id"}
     _list_filters = (
@@ -363,5 +363,5 @@ class GroupDescendantGroupManager(GroupSubgroupManager):
     share all attributes with subgroups, except the path and object class.
     """
 
-    _path = "/groups/%(group_id)s/descendant_groups"
+    _path = "/groups/{group_id}/descendant_groups"
     _obj_cls: Type[GroupDescendantGroup] = GroupDescendantGroup

--- a/gitlab/v4/objects/hooks.py
+++ b/gitlab/v4/objects/hooks.py
@@ -27,7 +27,7 @@ class ProjectHook(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectHookManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/hooks"
+    _path = "/projects/{project_id}/hooks"
     _obj_cls = ProjectHook
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(
@@ -69,7 +69,7 @@ class GroupHook(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class GroupHookManager(CRUDMixin, RESTManager):
-    _path = "/groups/%(group_id)s/hooks"
+    _path = "/groups/{group_id}/hooks"
     _obj_cls = GroupHook
     _from_parent_attrs = {"group_id": "id"}
     _create_attrs = RequiredOptional(

--- a/gitlab/v4/objects/issues.py
+++ b/gitlab/v4/objects/issues.py
@@ -71,7 +71,7 @@ class GroupIssue(RESTObject):
 
 
 class GroupIssueManager(ListMixin, RESTManager):
-    _path = "/groups/%(group_id)s/issues"
+    _path = "/groups/{group_id}/issues"
     _obj_cls = GroupIssue
     _from_parent_attrs = {"group_id": "id"}
     _list_filters = (
@@ -170,7 +170,7 @@ class ProjectIssue(
 
 
 class ProjectIssueManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/issues"
+    _path = "/projects/{project_id}/issues"
     _obj_cls = ProjectIssue
     _from_parent_attrs = {"project_id": "id"}
     _list_filters = (
@@ -228,7 +228,7 @@ class ProjectIssueLink(ObjectDeleteMixin, RESTObject):
 
 
 class ProjectIssueLinkManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
-    _path = "/projects/%(project_id)s/issues/%(issue_iid)s/links"
+    _path = "/projects/{project_id}/issues/{issue_iid}/links"
     _obj_cls = ProjectIssueLink
     _from_parent_attrs = {"project_id": "project_id", "issue_iid": "iid"}
     _create_attrs = RequiredOptional(required=("target_project_id", "target_issue_iid"))

--- a/gitlab/v4/objects/jobs.py
+++ b/gitlab/v4/objects/jobs.py
@@ -185,6 +185,6 @@ class ProjectJob(RefreshMixin, RESTObject):
 
 
 class ProjectJobManager(RetrieveMixin, RESTManager):
-    _path = "/projects/%(project_id)s/jobs"
+    _path = "/projects/{project_id}/jobs"
     _obj_cls = ProjectJob
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/labels.py
+++ b/gitlab/v4/objects/labels.py
@@ -45,7 +45,7 @@ class GroupLabel(SubscribableMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class GroupLabelManager(ListMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager):
-    _path = "/groups/%(group_id)s/labels"
+    _path = "/groups/{group_id}/labels"
     _obj_cls = GroupLabel
     _from_parent_attrs = {"group_id": "id"}
     _create_attrs = RequiredOptional(
@@ -113,7 +113,7 @@ class ProjectLabel(
 class ProjectLabelManager(
     RetrieveMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
 ):
-    _path = "/projects/%(project_id)s/labels"
+    _path = "/projects/{project_id}/labels"
     _obj_cls = ProjectLabel
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(

--- a/gitlab/v4/objects/members.py
+++ b/gitlab/v4/objects/members.py
@@ -28,7 +28,7 @@ class GroupMember(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class GroupMemberManager(CRUDMixin, RESTManager):
-    _path = "/groups/%(group_id)s/members"
+    _path = "/groups/{group_id}/members"
     _obj_cls = GroupMember
     _from_parent_attrs = {"group_id": "id"}
     _create_attrs = RequiredOptional(
@@ -47,7 +47,7 @@ class GroupBillableMember(ObjectDeleteMixin, RESTObject):
 
 
 class GroupBillableMemberManager(ListMixin, DeleteMixin, RESTManager):
-    _path = "/groups/%(group_id)s/billable_members"
+    _path = "/groups/{group_id}/billable_members"
     _obj_cls = GroupBillableMember
     _from_parent_attrs = {"group_id": "id"}
     _list_filters = ("search", "sort")
@@ -58,13 +58,13 @@ class GroupBillableMemberMembership(RESTObject):
 
 
 class GroupBillableMemberMembershipManager(ListMixin, RESTManager):
-    _path = "/groups/%(group_id)s/billable_members/%(user_id)s/memberships"
+    _path = "/groups/{group_id}/billable_members/{user_id}/memberships"
     _obj_cls = GroupBillableMemberMembership
     _from_parent_attrs = {"group_id": "group_id", "user_id": "id"}
 
 
 class GroupMemberAllManager(RetrieveMixin, RESTManager):
-    _path = "/groups/%(group_id)s/members/all"
+    _path = "/groups/{group_id}/members/all"
     _obj_cls = GroupMember
     _from_parent_attrs = {"group_id": "id"}
 
@@ -74,7 +74,7 @@ class ProjectMember(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectMemberManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/members"
+    _path = "/projects/{project_id}/members"
     _obj_cls = ProjectMember
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(
@@ -87,6 +87,6 @@ class ProjectMemberManager(CRUDMixin, RESTManager):
 
 
 class ProjectMemberAllManager(RetrieveMixin, RESTManager):
-    _path = "/projects/%(project_id)s/members/all"
+    _path = "/projects/{project_id}/members/all"
     _obj_cls = ProjectMember
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -29,7 +29,7 @@ class ProjectApproval(SaveMixin, RESTObject):
 
 
 class ProjectApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
-    _path = "/projects/%(project_id)s/approvals"
+    _path = "/projects/{project_id}/approvals"
     _obj_cls = ProjectApproval
     _from_parent_attrs = {"project_id": "id"}
     _update_attrs = RequiredOptional(
@@ -70,7 +70,7 @@ class ProjectApprovalRule(SaveMixin, ObjectDeleteMixin, RESTObject):
 class ProjectApprovalRuleManager(
     ListMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
 ):
-    _path = "/projects/%(project_id)s/approval_rules"
+    _path = "/projects/{project_id}/approval_rules"
     _obj_cls = ProjectApprovalRule
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(
@@ -84,7 +84,7 @@ class ProjectMergeRequestApproval(SaveMixin, RESTObject):
 
 
 class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
-    _path = "/projects/%(project_id)s/merge_requests/%(mr_iid)s/approvals"
+    _path = "/projects/{project_id}/merge_requests/{mr_iid}/approvals"
     _obj_cls = ProjectMergeRequestApproval
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}
     _update_attrs = RequiredOptional(required=("approvals_required",))
@@ -164,7 +164,7 @@ class ProjectMergeRequestApprovalRule(SaveMixin, RESTObject):
 class ProjectMergeRequestApprovalRuleManager(
     ListMixin, UpdateMixin, CreateMixin, RESTManager
 ):
-    _path = "/projects/%(project_id)s/merge_requests/%(mr_iid)s/approval_rules"
+    _path = "/projects/{project_id}/merge_requests/{mr_iid}/approval_rules"
     _obj_cls = ProjectMergeRequestApprovalRule
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}
     _list_filters = ("name", "rule_type")
@@ -213,6 +213,6 @@ class ProjectMergeRequestApprovalState(RESTObject):
 
 
 class ProjectMergeRequestApprovalStateManager(GetWithoutIdMixin, RESTManager):
-    _path = "/projects/%(project_id)s/merge_requests/%(mr_iid)s/approval_state"
+    _path = "/projects/{project_id}/merge_requests/{mr_iid}/approval_state"
     _obj_cls = ProjectMergeRequestApprovalState
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -107,7 +107,7 @@ class GroupMergeRequest(RESTObject):
 
 
 class GroupMergeRequestManager(ListMixin, RESTManager):
-    _path = "/groups/%(group_id)s/merge_requests"
+    _path = "/groups/{group_id}/merge_requests"
     _obj_cls = GroupMergeRequest
     _from_parent_attrs = {"group_id": "id"}
     _list_filters = (
@@ -393,7 +393,7 @@ class ProjectMergeRequest(
 
 
 class ProjectMergeRequestManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/merge_requests"
+    _path = "/projects/{project_id}/merge_requests"
     _obj_cls = ProjectMergeRequest
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(
@@ -467,7 +467,7 @@ class ProjectDeploymentMergeRequest(MergeRequest):
 
 
 class ProjectDeploymentMergeRequestManager(MergeRequestManager):
-    _path = "/projects/%(project_id)s/deployments/%(deployment_id)s/merge_requests"
+    _path = "/projects/{project_id}/deployments/{deployment_id}/merge_requests"
     _obj_cls = ProjectDeploymentMergeRequest
     _from_parent_attrs = {"deployment_id": "id", "project_id": "project_id"}
 
@@ -477,6 +477,6 @@ class ProjectMergeRequestDiff(RESTObject):
 
 
 class ProjectMergeRequestDiffManager(RetrieveMixin, RESTManager):
-    _path = "/projects/%(project_id)s/merge_requests/%(mr_iid)s/versions"
+    _path = "/projects/{project_id}/merge_requests/{mr_iid}/versions"
     _obj_cls = ProjectMergeRequestDiff
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}

--- a/gitlab/v4/objects/merge_trains.py
+++ b/gitlab/v4/objects/merge_trains.py
@@ -12,7 +12,7 @@ class ProjectMergeTrain(RESTObject):
 
 
 class ProjectMergeTrainManager(ListMixin, RESTManager):
-    _path = "/projects/%(project_id)s/merge_trains"
+    _path = "/projects/{project_id}/merge_trains"
     _obj_cls = ProjectMergeTrain
     _from_parent_attrs = {"project_id": "id"}
     _list_filters = ("scope",)

--- a/gitlab/v4/objects/milestones.py
+++ b/gitlab/v4/objects/milestones.py
@@ -79,7 +79,7 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class GroupMilestoneManager(CRUDMixin, RESTManager):
-    _path = "/groups/%(group_id)s/milestones"
+    _path = "/groups/{group_id}/milestones"
     _obj_cls = GroupMilestone
     _from_parent_attrs = {"group_id": "id"}
     _create_attrs = RequiredOptional(
@@ -153,7 +153,7 @@ class ProjectMilestone(PromoteMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectMilestoneManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/milestones"
+    _path = "/projects/{project_id}/milestones"
     _obj_cls = ProjectMilestone
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(

--- a/gitlab/v4/objects/notes.py
+++ b/gitlab/v4/objects/notes.py
@@ -41,7 +41,7 @@ class ProjectNote(RESTObject):
 
 
 class ProjectNoteManager(RetrieveMixin, RESTManager):
-    _path = "/projects/%(project_id)s/notes"
+    _path = "/projects/{project_id}/notes"
     _obj_cls = ProjectNote
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(required=("body",))
@@ -55,8 +55,8 @@ class ProjectCommitDiscussionNoteManager(
     GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
 ):
     _path = (
-        "/projects/%(project_id)s/repository/commits/%(commit_id)s/"
-        "discussions/%(discussion_id)s/notes"
+        "/projects/{project_id}/repository/commits/{commit_id}/"
+        "discussions/{discussion_id}/notes"
     )
     _obj_cls = ProjectCommitDiscussionNote
     _from_parent_attrs = {
@@ -75,7 +75,7 @@ class ProjectIssueNote(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectIssueNoteManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/issues/%(issue_iid)s/notes"
+    _path = "/projects/{project_id}/issues/{issue_iid}/notes"
     _obj_cls = ProjectIssueNote
     _from_parent_attrs = {"project_id": "project_id", "issue_iid": "iid"}
     _create_attrs = RequiredOptional(required=("body",), optional=("created_at",))
@@ -90,8 +90,7 @@ class ProjectIssueDiscussionNoteManager(
     GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
 ):
     _path = (
-        "/projects/%(project_id)s/issues/%(issue_iid)s/"
-        "discussions/%(discussion_id)s/notes"
+        "/projects/{project_id}/issues/{issue_iid}/discussions/{discussion_id}/notes"
     )
     _obj_cls = ProjectIssueDiscussionNote
     _from_parent_attrs = {
@@ -108,7 +107,7 @@ class ProjectMergeRequestNote(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectMergeRequestNoteManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/merge_requests/%(mr_iid)s/notes"
+    _path = "/projects/{project_id}/merge_requests/{mr_iid}/notes"
     _obj_cls = ProjectMergeRequestNote
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}
     _create_attrs = RequiredOptional(required=("body",))
@@ -123,8 +122,8 @@ class ProjectMergeRequestDiscussionNoteManager(
     GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
 ):
     _path = (
-        "/projects/%(project_id)s/merge_requests/%(mr_iid)s/"
-        "discussions/%(discussion_id)s/notes"
+        "/projects/{project_id}/merge_requests/{mr_iid}/"
+        "discussions/{discussion_id}/notes"
     )
     _obj_cls = ProjectMergeRequestDiscussionNote
     _from_parent_attrs = {
@@ -141,7 +140,7 @@ class ProjectSnippetNote(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectSnippetNoteManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/snippets/%(snippet_id)s/notes"
+    _path = "/projects/{project_id}/snippets/{snippet_id}/notes"
     _obj_cls = ProjectSnippetNote
     _from_parent_attrs = {"project_id": "project_id", "snippet_id": "id"}
     _create_attrs = RequiredOptional(required=("body",))
@@ -156,8 +155,8 @@ class ProjectSnippetDiscussionNoteManager(
     GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
 ):
     _path = (
-        "/projects/%(project_id)s/snippets/%(snippet_id)s/"
-        "discussions/%(discussion_id)s/notes"
+        "/projects/{project_id}/snippets/{snippet_id}/"
+        "discussions/{discussion_id}/notes"
     )
     _obj_cls = ProjectSnippetDiscussionNote
     _from_parent_attrs = {

--- a/gitlab/v4/objects/notification_settings.py
+++ b/gitlab/v4/objects/notification_settings.py
@@ -42,7 +42,7 @@ class GroupNotificationSettings(NotificationSettings):
 
 
 class GroupNotificationSettingsManager(NotificationSettingsManager):
-    _path = "/groups/%(group_id)s/notification_settings"
+    _path = "/groups/{group_id}/notification_settings"
     _obj_cls = GroupNotificationSettings
     _from_parent_attrs = {"group_id": "id"}
 
@@ -52,6 +52,6 @@ class ProjectNotificationSettings(NotificationSettings):
 
 
 class ProjectNotificationSettingsManager(NotificationSettingsManager):
-    _path = "/projects/%(project_id)s/notification_settings"
+    _path = "/projects/{project_id}/notification_settings"
     _obj_cls = ProjectNotificationSettings
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/packages.py
+++ b/gitlab/v4/objects/packages.py
@@ -32,7 +32,7 @@ class GenericPackage(RESTObject):
 
 
 class GenericPackageManager(RESTManager):
-    _path = "/projects/%(project_id)s/packages/generic"
+    _path = "/projects/{project_id}/packages/generic"
     _obj_cls = GenericPackage
     _from_parent_attrs = {"project_id": "id"}
 
@@ -140,7 +140,7 @@ class GroupPackage(RESTObject):
 
 
 class GroupPackageManager(ListMixin, RESTManager):
-    _path = "/groups/%(group_id)s/packages"
+    _path = "/groups/{group_id}/packages"
     _obj_cls = GroupPackage
     _from_parent_attrs = {"group_id": "id"}
     _list_filters = (
@@ -157,7 +157,7 @@ class ProjectPackage(ObjectDeleteMixin, RESTObject):
 
 
 class ProjectPackageManager(ListMixin, GetMixin, DeleteMixin, RESTManager):
-    _path = "/projects/%(project_id)s/packages"
+    _path = "/projects/{project_id}/packages"
     _obj_cls = ProjectPackage
     _from_parent_attrs = {"project_id": "id"}
     _list_filters = (
@@ -173,6 +173,6 @@ class ProjectPackageFile(RESTObject):
 
 
 class ProjectPackageFileManager(DeleteMixin, ListMixin, RESTManager):
-    _path = "/projects/%(project_id)s/packages/%(package_id)s/package_files"
+    _path = "/projects/{project_id}/packages/{package_id}/package_files"
     _obj_cls = ProjectPackageFile
     _from_parent_attrs = {"project_id": "project_id", "package_id": "id"}

--- a/gitlab/v4/objects/pages.py
+++ b/gitlab/v4/objects/pages.py
@@ -25,7 +25,7 @@ class ProjectPagesDomain(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectPagesDomainManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/pages/domains"
+    _path = "/projects/{project_id}/pages/domains"
     _obj_cls = ProjectPagesDomain
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(

--- a/gitlab/v4/objects/personal_access_tokens.py
+++ b/gitlab/v4/objects/personal_access_tokens.py
@@ -24,7 +24,7 @@ class UserPersonalAccessToken(RESTObject):
 
 
 class UserPersonalAccessTokenManager(CreateMixin, RESTManager):
-    _path = "/users/%(user_id)s/personal_access_tokens"
+    _path = "/users/{user_id}/personal_access_tokens"
     _obj_cls = UserPersonalAccessToken
     _from_parent_attrs = {"user_id": "id"}
     _create_attrs = RequiredOptional(

--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -39,7 +39,7 @@ class ProjectMergeRequestPipeline(RESTObject):
 
 
 class ProjectMergeRequestPipelineManager(CreateMixin, ListMixin, RESTManager):
-    _path = "/projects/%(project_id)s/merge_requests/%(mr_iid)s/pipelines"
+    _path = "/projects/{project_id}/merge_requests/{mr_iid}/pipelines"
     _obj_cls = ProjectMergeRequestPipeline
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}
 
@@ -82,7 +82,7 @@ class ProjectPipeline(RefreshMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectPipelineManager(RetrieveMixin, CreateMixin, DeleteMixin, RESTManager):
-    _path = "/projects/%(project_id)s/pipelines"
+    _path = "/projects/{project_id}/pipelines"
     _obj_cls = ProjectPipeline
     _from_parent_attrs = {"project_id": "id"}
     _list_filters = (
@@ -123,7 +123,7 @@ class ProjectPipelineJob(RESTObject):
 
 
 class ProjectPipelineJobManager(ListMixin, RESTManager):
-    _path = "/projects/%(project_id)s/pipelines/%(pipeline_id)s/jobs"
+    _path = "/projects/{project_id}/pipelines/{pipeline_id}/jobs"
     _obj_cls = ProjectPipelineJob
     _from_parent_attrs = {"project_id": "project_id", "pipeline_id": "id"}
     _list_filters = ("scope", "include_retried")
@@ -134,7 +134,7 @@ class ProjectPipelineBridge(RESTObject):
 
 
 class ProjectPipelineBridgeManager(ListMixin, RESTManager):
-    _path = "/projects/%(project_id)s/pipelines/%(pipeline_id)s/bridges"
+    _path = "/projects/{project_id}/pipelines/{pipeline_id}/bridges"
     _obj_cls = ProjectPipelineBridge
     _from_parent_attrs = {"project_id": "project_id", "pipeline_id": "id"}
     _list_filters = ("scope",)
@@ -145,7 +145,7 @@ class ProjectPipelineVariable(RESTObject):
 
 
 class ProjectPipelineVariableManager(ListMixin, RESTManager):
-    _path = "/projects/%(project_id)s/pipelines/%(pipeline_id)s/variables"
+    _path = "/projects/{project_id}/pipelines/{pipeline_id}/variables"
     _obj_cls = ProjectPipelineVariable
     _from_parent_attrs = {"project_id": "project_id", "pipeline_id": "id"}
 
@@ -157,10 +157,7 @@ class ProjectPipelineScheduleVariable(SaveMixin, ObjectDeleteMixin, RESTObject):
 class ProjectPipelineScheduleVariableManager(
     CreateMixin, UpdateMixin, DeleteMixin, RESTManager
 ):
-    _path = (
-        "/projects/%(project_id)s/pipeline_schedules/"
-        "%(pipeline_schedule_id)s/variables"
-    )
+    _path = "/projects/{project_id}/pipeline_schedules/{pipeline_schedule_id}/variables"
     _obj_cls = ProjectPipelineScheduleVariable
     _from_parent_attrs = {"project_id": "project_id", "pipeline_schedule_id": "id"}
     _create_attrs = RequiredOptional(required=("key", "value"))
@@ -206,7 +203,7 @@ class ProjectPipelineSchedule(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectPipelineScheduleManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/pipeline_schedules"
+    _path = "/projects/{project_id}/pipeline_schedules"
     _obj_cls = ProjectPipelineSchedule
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(
@@ -222,6 +219,6 @@ class ProjectPipelineTestReport(RESTObject):
 
 
 class ProjectPipelineTestReportManager(GetWithoutIdMixin, RESTManager):
-    _path = "/projects/%(project_id)s/pipelines/%(pipeline_id)s/test_report"
+    _path = "/projects/{project_id}/pipelines/{pipeline_id}/test_report"
     _obj_cls = ProjectPipelineTestReport
     _from_parent_attrs = {"project_id": "project_id", "pipeline_id": "id"}

--- a/gitlab/v4/objects/project_access_tokens.py
+++ b/gitlab/v4/objects/project_access_tokens.py
@@ -12,6 +12,6 @@ class ProjectAccessToken(ObjectDeleteMixin, RESTObject):
 
 
 class ProjectAccessTokenManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
-    _path = "/projects/%(project_id)s/access_tokens"
+    _path = "/projects/{project_id}/access_tokens"
     _obj_cls = ProjectAccessToken
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -87,7 +87,7 @@ class GroupProject(RESTObject):
 
 
 class GroupProjectManager(ListMixin, RESTManager):
-    _path = "/groups/%(group_id)s/projects"
+    _path = "/groups/{group_id}/projects"
     _obj_cls = GroupProject
     _from_parent_attrs = {"group_id": "id"}
     _list_filters = (
@@ -986,7 +986,7 @@ class ProjectFork(RESTObject):
 
 
 class ProjectForkManager(CreateMixin, ListMixin, RESTManager):
-    _path = "/projects/%(project_id)s/forks"
+    _path = "/projects/{project_id}/forks"
     _obj_cls = ProjectFork
     _from_parent_attrs = {"project_id": "id"}
     _list_filters = (
@@ -1035,7 +1035,7 @@ class ProjectRemoteMirror(SaveMixin, RESTObject):
 
 
 class ProjectRemoteMirrorManager(ListMixin, CreateMixin, UpdateMixin, RESTManager):
-    _path = "/projects/%(project_id)s/remote_mirrors"
+    _path = "/projects/{project_id}/remote_mirrors"
     _obj_cls = ProjectRemoteMirror
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(

--- a/gitlab/v4/objects/push_rules.py
+++ b/gitlab/v4/objects/push_rules.py
@@ -23,7 +23,7 @@ class ProjectPushRules(SaveMixin, ObjectDeleteMixin, RESTObject):
 class ProjectPushRulesManager(
     GetWithoutIdMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
 ):
-    _path = "/projects/%(project_id)s/push_rule"
+    _path = "/projects/{project_id}/push_rule"
     _obj_cls = ProjectPushRules
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(

--- a/gitlab/v4/objects/releases.py
+++ b/gitlab/v4/objects/releases.py
@@ -18,7 +18,7 @@ class ProjectRelease(SaveMixin, RESTObject):
 
 
 class ProjectReleaseManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/releases"
+    _path = "/projects/{project_id}/releases"
     _obj_cls = ProjectRelease
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(
@@ -39,7 +39,7 @@ class ProjectReleaseLink(ObjectDeleteMixin, SaveMixin, RESTObject):
 
 
 class ProjectReleaseLinkManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/releases/%(tag_name)s/assets/links"
+    _path = "/projects/{project_id}/releases/{tag_name}/assets/links"
     _obj_cls = ProjectReleaseLink
     _from_parent_attrs = {"project_id": "project_id", "tag_name": "tag_name"}
     _create_attrs = RequiredOptional(

--- a/gitlab/v4/objects/runners.py
+++ b/gitlab/v4/objects/runners.py
@@ -30,7 +30,7 @@ class RunnerJob(RESTObject):
 
 
 class RunnerJobManager(ListMixin, RESTManager):
-    _path = "/runners/%(runner_id)s/jobs"
+    _path = "/runners/{runner_id}/jobs"
     _obj_cls = RunnerJob
     _from_parent_attrs = {"runner_id": "id"}
     _list_filters = ("status",)
@@ -125,7 +125,7 @@ class GroupRunner(RESTObject):
 
 
 class GroupRunnerManager(ListMixin, RESTManager):
-    _path = "/groups/%(group_id)s/runners"
+    _path = "/groups/{group_id}/runners"
     _obj_cls = GroupRunner
     _from_parent_attrs = {"group_id": "id"}
     _create_attrs = RequiredOptional(required=("runner_id",))
@@ -138,7 +138,7 @@ class ProjectRunner(ObjectDeleteMixin, RESTObject):
 
 
 class ProjectRunnerManager(CreateMixin, DeleteMixin, ListMixin, RESTManager):
-    _path = "/projects/%(project_id)s/runners"
+    _path = "/projects/{project_id}/runners"
     _obj_cls = ProjectRunner
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(required=("runner_id",))

--- a/gitlab/v4/objects/services.py
+++ b/gitlab/v4/objects/services.py
@@ -20,7 +20,7 @@ class ProjectService(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectServiceManager(GetMixin, UpdateMixin, DeleteMixin, ListMixin, RESTManager):
-    _path = "/projects/%(project_id)s/services"
+    _path = "/projects/{project_id}/services"
     _from_parent_attrs = {"project_id": "id"}
     _obj_cls = ProjectService
 

--- a/gitlab/v4/objects/snippets.py
+++ b/gitlab/v4/objects/snippets.py
@@ -75,7 +75,7 @@ class SnippetManager(CRUDMixin, RESTManager):
 
 
 class ProjectSnippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
-    _url = "/projects/%(project_id)s/snippets"
+    _url = "/projects/{project_id}/snippets"
     _short_print_attr = "title"
 
     awardemojis: ProjectSnippetAwardEmojiManager
@@ -111,7 +111,7 @@ class ProjectSnippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObj
 
 
 class ProjectSnippetManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/snippets"
+    _path = "/projects/{project_id}/snippets"
     _obj_cls = ProjectSnippet
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(

--- a/gitlab/v4/objects/statistics.py
+++ b/gitlab/v4/objects/statistics.py
@@ -18,7 +18,7 @@ class ProjectAdditionalStatistics(RefreshMixin, RESTObject):
 
 
 class ProjectAdditionalStatisticsManager(GetWithoutIdMixin, RESTManager):
-    _path = "/projects/%(project_id)s/statistics"
+    _path = "/projects/{project_id}/statistics"
     _obj_cls = ProjectAdditionalStatistics
     _from_parent_attrs = {"project_id": "id"}
 
@@ -37,7 +37,7 @@ class GroupIssuesStatistics(RefreshMixin, RESTObject):
 
 
 class GroupIssuesStatisticsManager(GetWithoutIdMixin, RESTManager):
-    _path = "/groups/%(group_id)s/issues_statistics"
+    _path = "/groups/{group_id}/issues_statistics"
     _obj_cls = GroupIssuesStatistics
     _from_parent_attrs = {"group_id": "id"}
 
@@ -47,6 +47,6 @@ class ProjectIssuesStatistics(RefreshMixin, RESTObject):
 
 
 class ProjectIssuesStatisticsManager(GetWithoutIdMixin, RESTManager):
-    _path = "/projects/%(project_id)s/issues_statistics"
+    _path = "/projects/{project_id}/issues_statistics"
     _obj_cls = ProjectIssuesStatistics
     _from_parent_attrs = {"project_id": "id"}

--- a/gitlab/v4/objects/tags.py
+++ b/gitlab/v4/objects/tags.py
@@ -15,7 +15,7 @@ class ProjectTag(ObjectDeleteMixin, RESTObject):
 
 
 class ProjectTagManager(NoUpdateMixin, RESTManager):
-    _path = "/projects/%(project_id)s/repository/tags"
+    _path = "/projects/{project_id}/repository/tags"
     _obj_cls = ProjectTag
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(
@@ -29,7 +29,7 @@ class ProjectProtectedTag(ObjectDeleteMixin, RESTObject):
 
 
 class ProjectProtectedTagManager(NoUpdateMixin, RESTManager):
-    _path = "/projects/%(project_id)s/protected_tags"
+    _path = "/projects/{project_id}/protected_tags"
     _obj_cls = ProjectProtectedTag
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(

--- a/gitlab/v4/objects/triggers.py
+++ b/gitlab/v4/objects/triggers.py
@@ -14,7 +14,7 @@ class ProjectTrigger(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectTriggerManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/triggers"
+    _path = "/projects/{project_id}/triggers"
     _obj_cls = ProjectTrigger
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(required=("description",))

--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -340,7 +340,7 @@ class ProjectUser(RESTObject):
 
 
 class ProjectUserManager(ListMixin, RESTManager):
-    _path = "/projects/%(project_id)s/users"
+    _path = "/projects/{project_id}/users"
     _obj_cls = ProjectUser
     _from_parent_attrs = {"project_id": "id"}
     _list_filters = ("search", "skip_users")
@@ -352,7 +352,7 @@ class UserEmail(ObjectDeleteMixin, RESTObject):
 
 
 class UserEmailManager(RetrieveMixin, CreateMixin, DeleteMixin, RESTManager):
-    _path = "/users/%(user_id)s/emails"
+    _path = "/users/{user_id}/emails"
     _obj_cls = UserEmail
     _from_parent_attrs = {"user_id": "id"}
     _create_attrs = RequiredOptional(required=("email",))
@@ -368,7 +368,7 @@ class UserStatus(RESTObject):
 
 
 class UserStatusManager(GetWithoutIdMixin, RESTManager):
-    _path = "/users/%(user_id)s/status"
+    _path = "/users/{user_id}/status"
     _obj_cls = UserStatus
     _from_parent_attrs = {"user_id": "id"}
 
@@ -383,7 +383,7 @@ class UserGPGKey(ObjectDeleteMixin, RESTObject):
 
 
 class UserGPGKeyManager(RetrieveMixin, CreateMixin, DeleteMixin, RESTManager):
-    _path = "/users/%(user_id)s/gpg_keys"
+    _path = "/users/{user_id}/gpg_keys"
     _obj_cls = UserGPGKey
     _from_parent_attrs = {"user_id": "id"}
     _create_attrs = RequiredOptional(required=("key",))
@@ -394,7 +394,7 @@ class UserKey(ObjectDeleteMixin, RESTObject):
 
 
 class UserKeyManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
-    _path = "/users/%(user_id)s/keys"
+    _path = "/users/{user_id}/keys"
     _obj_cls = UserKey
     _from_parent_attrs = {"user_id": "id"}
     _create_attrs = RequiredOptional(required=("title", "key"))
@@ -407,7 +407,7 @@ class UserIdentityProviderManager(DeleteMixin, RESTManager):
     functionality for deletion of user identities by provider.
     """
 
-    _path = "/users/%(user_id)s/identities"
+    _path = "/users/{user_id}/identities"
     _from_parent_attrs = {"user_id": "id"}
 
 
@@ -416,7 +416,7 @@ class UserImpersonationToken(ObjectDeleteMixin, RESTObject):
 
 
 class UserImpersonationTokenManager(NoUpdateMixin, RESTManager):
-    _path = "/users/%(user_id)s/impersonation_tokens"
+    _path = "/users/{user_id}/impersonation_tokens"
     _obj_cls = UserImpersonationToken
     _from_parent_attrs = {"user_id": "id"}
     _create_attrs = RequiredOptional(
@@ -430,7 +430,7 @@ class UserMembership(RESTObject):
 
 
 class UserMembershipManager(RetrieveMixin, RESTManager):
-    _path = "/users/%(user_id)s/memberships"
+    _path = "/users/{user_id}/memberships"
     _obj_cls = UserMembership
     _from_parent_attrs = {"user_id": "id"}
     _list_filters = ("type",)
@@ -442,7 +442,7 @@ class UserProject(RESTObject):
 
 
 class UserProjectManager(ListMixin, CreateMixin, RESTManager):
-    _path = "/projects/user/%(user_id)s"
+    _path = "/projects/user/{user_id}"
     _obj_cls = UserProject
     _from_parent_attrs = {"user_id": "id"}
     _create_attrs = RequiredOptional(
@@ -515,7 +515,7 @@ class StarredProject(RESTObject):
 
 
 class StarredProjectManager(ListMixin, RESTManager):
-    _path = "/users/%(user_id)s/starred_projects"
+    _path = "/users/{user_id}/starred_projects"
     _obj_cls = StarredProject
     _from_parent_attrs = {"user_id": "id"}
     _list_filters = (
@@ -537,12 +537,12 @@ class StarredProjectManager(ListMixin, RESTManager):
 
 
 class UserFollowersManager(ListMixin, RESTManager):
-    _path = "/users/%(user_id)s/followers"
+    _path = "/users/{user_id}/followers"
     _obj_cls = User
     _from_parent_attrs = {"user_id": "id"}
 
 
 class UserFollowingManager(ListMixin, RESTManager):
-    _path = "/users/%(user_id)s/following"
+    _path = "/users/{user_id}/following"
     _obj_cls = User
     _from_parent_attrs = {"user_id": "id"}

--- a/gitlab/v4/objects/variables.py
+++ b/gitlab/v4/objects/variables.py
@@ -42,7 +42,7 @@ class GroupVariable(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class GroupVariableManager(CRUDMixin, RESTManager):
-    _path = "/groups/%(group_id)s/variables"
+    _path = "/groups/{group_id}/variables"
     _obj_cls = GroupVariable
     _from_parent_attrs = {"group_id": "id"}
     _create_attrs = RequiredOptional(
@@ -63,7 +63,7 @@ class ProjectVariable(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectVariableManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/variables"
+    _path = "/projects/{project_id}/variables"
     _obj_cls = ProjectVariable
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(

--- a/gitlab/v4/objects/wikis.py
+++ b/gitlab/v4/objects/wikis.py
@@ -17,7 +17,7 @@ class ProjectWiki(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectWikiManager(CRUDMixin, RESTManager):
-    _path = "/projects/%(project_id)s/wikis"
+    _path = "/projects/{project_id}/wikis"
     _obj_cls = ProjectWiki
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(
@@ -38,7 +38,7 @@ class GroupWiki(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class GroupWikiManager(CRUDMixin, RESTManager):
-    _path = "/groups/%(group_id)s/wikis"
+    _path = "/groups/{group_id}/wikis"
     _obj_cls = GroupWiki
     _from_parent_attrs = {"group_id": "id"}
     _create_attrs = RequiredOptional(

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -57,7 +57,7 @@ class TestRESTManager:
 
     def test_computed_path_with_parent(self):
         class MGR(base.RESTManager):
-            _path = "/tests/%(test_id)s/cases"
+            _path = "/tests/{test_id}/cases"
             _obj_cls = object
             _from_parent_attrs = {"test_id": "id"}
 


### PR DESCRIPTION
Basically just https://pyformat.info/#named_placeholders with some sed. Similar to the f-strings, just getting rid of more python2 stuff. Although this one might have some performance penalty I'm not sure it's noticeable