### PR TITLE
chore: add type-hints to gitlab/v4/objects/groups.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,10 @@ ignore_errors = true
 
 [[tool.mypy.overrides]] # Overrides to negate above patterns
 module = [
+    "gitlab.v4.objects.groups",
     "gitlab.v4.objects.merge_requests",
     "gitlab.v4.objects.projects",
-    "gitlab.v4.objects.users"
+    "gitlab.v4.objects.users",
 ]
 ignore_errors = false
 


### PR DESCRIPTION
     * Add type-hints to gitlab/v4/objects/groups.py
     * Add return value to share() function as GitLab docs show it returns
       a value.
     * Add 'get()' method so that type-checkers will understand that
       getting a group is of type Group.
