### PR TITLE
chore: add type-hints to gitlab/v4/objects/merge_requests.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ ignore_errors = true
 
 [[tool.mypy.overrides]] # Overrides to negate above patterns
 module = [
+    "gitlab.v4.objects.merge_requests",
     "gitlab.v4.objects.projects",
     "gitlab.v4.objects.users"
 ]


### PR DESCRIPTION
 * Add type-hints to gitlab/v4/objects/merge_requests.py
 * Add return value to cancel_merge_when_pipeline_succeeds() function
   as GitLab docs show it returns a value.
 * Add return value to approve() function as GitLab docs show it
   returns a value.
 * Add 'get()' method so that type-checkers will understand that
   getting a project merge request is of type ProjectMergeRequest.