### PR TITLE
chore: add type-hints to multiple files in gitlab/v4/objects/

### DIFF
--- a/gitlab/v4/objects/broadcast_messages.py
+++ b/gitlab/v4/objects/broadcast_messages.py
@@ -1,3 +1,5 @@
+from typing import Any, cast, Union
+
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
 
@@ -21,3 +23,8 @@ class BroadcastMessageManager(CRUDMixin, RESTManager):
     _update_attrs = RequiredOptional(
         optional=("message", "starts_at", "ends_at", "color", "font")
     )
+
+    def get(
+        self, id: Union[str, int], lazy: bool = False, **kwargs: Any
+    ) -> BroadcastMessage:
+        return cast(BroadcastMessage, super().get(id=id, lazy=lazy, **kwargs))

--- a/gitlab/v4/objects/keys.py
+++ b/gitlab/v4/objects/keys.py
@@ -1,3 +1,5 @@
+from typing import Any, cast, Optional, TYPE_CHECKING, Union
+
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import GetMixin
 
@@ -15,12 +17,18 @@ class KeyManager(GetMixin, RESTManager):
     _path = "/keys"
     _obj_cls = Key
 
-    def get(self, id=None, **kwargs):
+    def get(
+        self, id: Optional[Union[int, str]] = None, lazy: bool = False, **kwargs: Any
+    ) -> Key:
         if id is not None:
-            return super(KeyManager, self).get(id, **kwargs)
+            return cast(Key, super(KeyManager, self).get(id, lazy=lazy, **kwargs))
 
         if "fingerprint" not in kwargs:
             raise AttributeError("Missing attribute: id or fingerprint")
 
+        if TYPE_CHECKING:
+            assert self.path is not None
         server_data = self.gitlab.http_get(self.path, **kwargs)
-        return self._obj_cls(self, server_data)
+        if TYPE_CHECKING:
+            assert isinstance(server_data, dict)
+        return cast(Key, self._obj_cls(self, server_data))

--- a/gitlab/v4/objects/merge_trains.py
+++ b/gitlab/v4/objects/merge_trains.py
@@ -15,4 +15,4 @@ class ProjectMergeTrainManager(ListMixin, RESTManager):
     _path = "/projects/%(project_id)s/merge_trains"
     _obj_cls = ProjectMergeTrain
     _from_parent_attrs = {"project_id": "id"}
-    _list_filters = "scope"
+    _list_filters = ("scope",)

--- a/gitlab/v4/objects/namespaces.py
+++ b/gitlab/v4/objects/namespaces.py
@@ -1,3 +1,5 @@
+from typing import Any, cast, Union
+
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import RetrieveMixin
 
@@ -15,3 +17,6 @@ class NamespaceManager(RetrieveMixin, RESTManager):
     _path = "/namespaces"
     _obj_cls = Namespace
     _list_filters = ("search",)
+
+    def get(self, id: Union[str, int], lazy: bool = False, **kwargs: Any) -> Namespace:
+        return cast(Namespace, super().get(id=id, lazy=lazy, **kwargs))

--- a/gitlab/v4/objects/pages.py
+++ b/gitlab/v4/objects/pages.py
@@ -1,3 +1,5 @@
+from typing import Any, cast, Union
+
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ListMixin, ObjectDeleteMixin, SaveMixin
 
@@ -30,3 +32,8 @@ class ProjectPagesDomainManager(CRUDMixin, RESTManager):
         required=("domain",), optional=("certificate", "key")
     )
     _update_attrs = RequiredOptional(optional=("certificate", "key"))
+
+    def get(
+        self, id: Union[str, int], lazy: bool = False, **kwargs: Any
+    ) -> ProjectPagesDomain:
+        return cast(ProjectPagesDomain, super().get(id=id, lazy=lazy, **kwargs))

--- a/gitlab/v4/objects/triggers.py
+++ b/gitlab/v4/objects/triggers.py
@@ -1,3 +1,5 @@
+from typing import Any, cast, Union
+
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
 
@@ -17,3 +19,8 @@ class ProjectTriggerManager(CRUDMixin, RESTManager):
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(required=("description",))
     _update_attrs = RequiredOptional(required=("description",))
+
+    def get(
+        self, id: Union[str, int], lazy: bool = False, **kwargs: Any
+    ) -> ProjectTrigger:
+        return cast(ProjectTrigger, super().get(id=id, lazy=lazy, **kwargs))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,22 @@ ignore_errors = true
 
 [[tool.mypy.overrides]] # Overrides to negate above patterns
 module = [
+    "gitlab.v4.objects.access_requests",
+    "gitlab.v4.objects.applications",
+    "gitlab.v4.objects.broadcast_messages",
+    "gitlab.v4.objects.deployments",
     "gitlab.v4.objects.groups",
+    "gitlab.v4.objects.keys",
     "gitlab.v4.objects.merge_requests",
+    "gitlab.v4.objects.merge_trains",
+    "gitlab.v4.objects.namespaces",
+    "gitlab.v4.objects.pages",
+    "gitlab.v4.objects.personal_access_tokens",
+    "gitlab.v4.objects.project_access_tokens",
     "gitlab.v4.objects.projects",
+    "gitlab.v4.objects.tags",
+    "gitlab.v4.objects.templates",
+    "gitlab.v4.objects.triggers",
     "gitlab.v4.objects.users",
 ]
 ignore_errors = false


### PR DESCRIPTION
Add and/or check type-hints for the following files
    gitlab.v4.objects.access_requests
    gitlab.v4.objects.applications
    gitlab.v4.objects.broadcast_messages
    gitlab.v4.objects.deployments
    gitlab.v4.objects.keys
    gitlab.v4.objects.merge_trains
    gitlab.v4.objects.namespaces
    gitlab.v4.objects.pages
    gitlab.v4.objects.personal_access_tokens
    gitlab.v4.objects.project_access_tokens
    gitlab.v4.objects.tags
    gitlab.v4.objects.templates
    gitlab.v4.objects.triggers

Add a 'get' method with the correct type for Managers derived from
GetMixin.
