### PR TITLE
chore(ci): add workflow to lock old issues

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,20 @@
+name: 'Lock Closed Issues'
+
+on:
+  schedule:
+    - cron: '0 0 * * 1 '
+  workflow_dispatch: # For manual cleanup
+
+permissions:
+  issues: write
+
+concurrency:
+  group: lock
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v3
+        with:
+          process-only: 'issues'


### PR DESCRIPTION
See https://github.com/dessant/lock-threads for more info. The terraform repo also uses this action so.. must be ok :eyes: 