### PR TITLE
chore: check setup.py with mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ module = [
     "gitlab.v4.objects.repositories",
     "gitlab.v4.objects.services",
     "gitlab.v4.objects.sidekiq",
-    "setup",
     "tests.functional.*",
     "tests.functional.api.*",
     "tests.meta.*",


### PR DESCRIPTION
Prior commit 06184daafd5010ba40bb39a0768540b7e98bd171 fixed the
type-hints for setup.py. But missed removing 'setup' from the exclude
list in pyproject.toml for mypy checks.

Remove 'setup' from the exclude list in pyproject.toml from mypy checks.