### PR TITLE
chore: add type-hints to remaining gitlab/v4/objects/*.py files

### DIFF
--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -150,6 +150,10 @@ class RESTObject(object):
         # annotations. If an attribute is annotated as being a *Manager type
         # then we create the manager and assign it to the attribute.
         for attr, annotation in sorted(self.__annotations__.items()):
+            # We ignore creating a manager for the 'manager' attribute as that
+            # is done in the self.__init__() method
+            if attr in ("manager",):
+                continue
             if not isinstance(annotation, (type, str)):
                 continue
             if isinstance(annotation, type):

--- a/gitlab/v4/objects/geo_nodes.py
+++ b/gitlab/v4/objects/geo_nodes.py
@@ -1,3 +1,5 @@
+from typing import Any, cast, Dict, List, TYPE_CHECKING, Union
+
 from gitlab import cli
 from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
@@ -18,7 +20,7 @@ __all__ = [
 class GeoNode(SaveMixin, ObjectDeleteMixin, RESTObject):
     @cli.register_custom_action("GeoNode")
     @exc.on_http_error(exc.GitlabRepairError)
-    def repair(self, **kwargs):
+    def repair(self, **kwargs: Any) -> None:
         """Repair the OAuth authentication of the geo node.
 
         Args:
@@ -30,11 +32,13 @@ class GeoNode(SaveMixin, ObjectDeleteMixin, RESTObject):
         """
         path = f"/geo_nodes/{self.get_id()}/repair"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
+        if TYPE_CHECKING:
+            assert isinstance(server_data, dict)
         self._update_attrs(server_data)
 
     @cli.register_custom_action("GeoNode")
     @exc.on_http_error(exc.GitlabGetError)
-    def status(self, **kwargs):
+    def status(self, **kwargs: Any) -> Dict[str, Any]:
         """Get the status of the geo node.
 
         Args:
@@ -48,7 +52,10 @@ class GeoNode(SaveMixin, ObjectDeleteMixin, RESTObject):
             dict: The status of the geo node
         """
         path = f"/geo_nodes/{self.get_id()}/status"
-        return self.manager.gitlab.http_get(path, **kwargs)
+        result = self.manager.gitlab.http_get(path, **kwargs)
+        if TYPE_CHECKING:
+            assert isinstance(result, dict)
+        return result
 
 
 class GeoNodeManager(RetrieveMixin, UpdateMixin, DeleteMixin, RESTManager):
@@ -58,9 +65,12 @@ class GeoNodeManager(RetrieveMixin, UpdateMixin, DeleteMixin, RESTManager):
         optional=("enabled", "url", "files_max_capacity", "repos_max_capacity"),
     )
 
+    def get(self, id: Union[str, int], lazy: bool = False, **kwargs: Any) -> GeoNode:
+        return cast(GeoNode, super().get(id=id, lazy=lazy, **kwargs))
+
     @cli.register_custom_action("GeoNodeManager")
     @exc.on_http_error(exc.GitlabGetError)
-    def status(self, **kwargs):
+    def status(self, **kwargs: Any) -> List[Dict[str, Any]]:
         """Get the status of all the geo nodes.
 
         Args:
@@ -73,11 +83,14 @@ class GeoNodeManager(RetrieveMixin, UpdateMixin, DeleteMixin, RESTManager):
         Returns:
             list: The status of all the geo nodes
         """
-        return self.gitlab.http_list("/geo_nodes/status", **kwargs)
+        result = self.gitlab.http_list("/geo_nodes/status", **kwargs)
+        if TYPE_CHECKING:
+            assert isinstance(result, list)
+        return result
 
     @cli.register_custom_action("GeoNodeManager")
     @exc.on_http_error(exc.GitlabGetError)
-    def current_failures(self, **kwargs):
+    def current_failures(self, **kwargs: Any) -> List[Dict[str, Any]]:
         """Get the list of failures on the current geo node.
 
         Args:
@@ -90,4 +103,7 @@ class GeoNodeManager(RetrieveMixin, UpdateMixin, DeleteMixin, RESTManager):
         Returns:
             list: The list of failures
         """
-        return self.gitlab.http_list("/geo_nodes/current/failures", **kwargs)
+        result = self.gitlab.http_list("/geo_nodes/current/failures", **kwargs)
+        if TYPE_CHECKING:
+            assert isinstance(result, list)
+        return result

--- a/gitlab/v4/objects/labels.py
+++ b/gitlab/v4/objects/labels.py
@@ -1,3 +1,5 @@
+from typing import Any, cast, Dict, Optional, TYPE_CHECKING, Union
+
 from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import (
@@ -22,10 +24,11 @@ __all__ = [
 
 class GroupLabel(SubscribableMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
     _id_attr = "name"
+    manager: "GroupLabelManager"
 
     # Update without ID, but we need an ID to get from list.
     @exc.on_http_error(exc.GitlabUpdateError)
-    def save(self, **kwargs):
+    def save(self, **kwargs: Any) -> None:
         """Saves the changes made to the object to the server.
 
         The object is updated to match what the server returns.
@@ -56,7 +59,14 @@ class GroupLabelManager(ListMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
     )
 
     # Update without ID.
-    def update(self, name, new_data=None, **kwargs):
+    # NOTE(jlvillal): Signature doesn't match UpdateMixin.update() so ignore
+    # type error
+    def update(  # type: ignore
+        self,
+        name: Optional[str],
+        new_data: Optional[Dict[str, Any]] = None,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
         """Update a Label on the server.
 
         Args:
@@ -70,7 +80,9 @@ class GroupLabelManager(ListMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
 
     # Delete without ID.
     @exc.on_http_error(exc.GitlabDeleteError)
-    def delete(self, name, **kwargs):
+    # NOTE(jlvillal): Signature doesn't match DeleteMixin.delete() so ignore
+    # type error
+    def delete(self, name: str, **kwargs: Any) -> None:  # type: ignore
         """Delete a Label on the server.
 
         Args:
@@ -81,6 +93,8 @@ class GroupLabelManager(ListMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server cannot perform the request
         """
+        if TYPE_CHECKING:
+            assert self.path is not None
         self.gitlab.http_delete(self.path, query_data={"name": name}, **kwargs)
 
 
@@ -88,10 +102,11 @@ class ProjectLabel(
     PromoteMixin, SubscribableMixin, SaveMixin, ObjectDeleteMixin, RESTObject
 ):
     _id_attr = "name"
+    manager: "ProjectLabelManager"
 
     # Update without ID, but we need an ID to get from list.
     @exc.on_http_error(exc.GitlabUpdateError)
-    def save(self, **kwargs):
+    def save(self, **kwargs: Any) -> None:
         """Saves the changes made to the object to the server.
 
         The object is updated to match what the server returns.
@@ -123,8 +138,20 @@ class ProjectLabelManager(
         required=("name",), optional=("new_name", "color", "description", "priority")
     )
 
+    def get(
+        self, id: Union[str, int], lazy: bool = False, **kwargs: Any
+    ) -> ProjectLabel:
+        return cast(ProjectLabel, super().get(id=id, lazy=lazy, **kwargs))
+
     # Update without ID.
-    def update(self, name, new_data=None, **kwargs):
+    # NOTE(jlvillal): Signature doesn't match UpdateMixin.update() so ignore
+    # type error
+    def update(  # type: ignore
+        self,
+        name: Optional[str],
+        new_data: Optional[Dict[str, Any]] = None,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
         """Update a Label on the server.
 
         Args:
@@ -138,7 +165,9 @@ class ProjectLabelManager(
 
     # Delete without ID.
     @exc.on_http_error(exc.GitlabDeleteError)
-    def delete(self, name, **kwargs):
+    # NOTE(jlvillal): Signature doesn't match DeleteMixin.delete() so ignore
+    # type error
+    def delete(self, name: str, **kwargs: Any) -> None:  # type: ignore
         """Delete a Label on the server.
 
         Args:
@@ -149,4 +178,6 @@ class ProjectLabelManager(
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server cannot perform the request
         """
+        if TYPE_CHECKING:
+            assert self.path is not None
         self.gitlab.http_delete(self.path, query_data={"name": name}, **kwargs)

--- a/gitlab/v4/objects/milestones.py
+++ b/gitlab/v4/objects/milestones.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast, TYPE_CHECKING, Union
 
 from gitlab import cli
 from gitlab import exceptions as exc
@@ -26,7 +26,7 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
 
     @cli.register_custom_action("GroupMilestone")
     @exc.on_http_error(exc.GitlabListError)
-    def issues(self, **kwargs):
+    def issues(self, **kwargs: Any) -> RESTObjectList:
         """List issues related to this milestone.
 
         Args:
@@ -47,13 +47,15 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
 
         path = f"{self.manager.path}/{self.get_id()}/issues"
         data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
+        if TYPE_CHECKING:
+            assert isinstance(data_list, RESTObjectList)
         manager = GroupIssueManager(self.manager.gitlab, parent=self.manager._parent)
         # FIXME(gpocentek): the computed manager path is not correct
         return RESTObjectList(manager, GroupIssue, data_list)
 
     @cli.register_custom_action("GroupMilestone")
     @exc.on_http_error(exc.GitlabListError)
-    def merge_requests(self, **kwargs):
+    def merge_requests(self, **kwargs: Any) -> RESTObjectList:
         """List the merge requests related to this milestone.
 
         Args:
@@ -73,6 +75,8 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
         """
         path = f"{self.manager.path}/{self.get_id()}/merge_requests"
         data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
+        if TYPE_CHECKING:
+            assert isinstance(data_list, RESTObjectList)
         manager = GroupIssueManager(self.manager.gitlab, parent=self.manager._parent)
         # FIXME(gpocentek): the computed manager path is not correct
         return RESTObjectList(manager, GroupMergeRequest, data_list)
@@ -91,6 +95,11 @@ class GroupMilestoneManager(CRUDMixin, RESTManager):
     _list_filters = ("iids", "state", "search")
     _types = {"iids": types.ListAttribute}
 
+    def get(
+        self, id: Union[str, int], lazy: bool = False, **kwargs: Any
+    ) -> GroupMilestone:
+        return cast(GroupMilestone, super().get(id=id, lazy=lazy, **kwargs))
+
 
 class ProjectMilestone(PromoteMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
     _short_print_attr = "title"
@@ -98,7 +107,7 @@ class ProjectMilestone(PromoteMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
 
     @cli.register_custom_action("ProjectMilestone")
     @exc.on_http_error(exc.GitlabListError)
-    def issues(self, **kwargs):
+    def issues(self, **kwargs: Any) -> RESTObjectList:
         """List issues related to this milestone.
 
         Args:
@@ -119,6 +128,8 @@ class ProjectMilestone(PromoteMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
 
         path = f"{self.manager.path}/{self.get_id()}/issues"
         data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
+        if TYPE_CHECKING:
+            assert isinstance(data_list, RESTObjectList)
         manager = ProjectIssueManager(self.manager.gitlab, parent=self.manager._parent)
         # FIXME(gpocentek): the computed manager path is not correct
         return RESTObjectList(manager, ProjectIssue, data_list)
@@ -145,6 +156,8 @@ class ProjectMilestone(PromoteMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
         """
         path = f"{self.manager.path}/{self.get_id()}/merge_requests"
         data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
+        if TYPE_CHECKING:
+            assert isinstance(data_list, RESTObjectList)
         manager = ProjectMergeRequestManager(
             self.manager.gitlab, parent=self.manager._parent
         )
@@ -165,3 +178,8 @@ class ProjectMilestoneManager(CRUDMixin, RESTManager):
     )
     _list_filters = ("iids", "state", "search")
     _types = {"iids": types.ListAttribute}
+
+    def get(
+        self, id: Union[str, int], lazy: bool = False, **kwargs: Any
+    ) -> ProjectMilestone:
+        return cast(ProjectMilestone, super().get(id=id, lazy=lazy, **kwargs))

--- a/gitlab/v4/objects/services.py
+++ b/gitlab/v4/objects/services.py
@@ -1,3 +1,5 @@
+from typing import Any, cast, Dict, List, Optional, Union
+
 from gitlab import cli
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
@@ -253,7 +255,9 @@ class ProjectServiceManager(GetMixin, UpdateMixin, DeleteMixin, ListMixin, RESTM
         "youtrack": (("issues_url", "project_url"), ("description", "push_events")),
     }
 
-    def get(self, id, **kwargs):
+    def get(
+        self, id: Union[str, int], lazy: bool = False, **kwargs: Any
+    ) -> ProjectService:
         """Retrieve a single object.
 
         Args:
@@ -270,11 +274,16 @@ class ProjectServiceManager(GetMixin, UpdateMixin, DeleteMixin, ListMixin, RESTM
             GitlabAuthenticationError: If authentication is not correct
             GitlabGetError: If the server cannot perform the request
         """
-        obj = super(ProjectServiceManager, self).get(id, **kwargs)
+        obj = cast(ProjectService, super(ProjectServiceManager, self).get(id, **kwargs))
         obj.id = id
         return obj
 
-    def update(self, id=None, new_data=None, **kwargs):
+    def update(
+        self,
+        id: Optional[Union[str, int]] = None,
+        new_data: Optional[Dict[str, Any]] = None,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
         """Update an object on the server.
 
         Args:
@@ -290,11 +299,12 @@ class ProjectServiceManager(GetMixin, UpdateMixin, DeleteMixin, ListMixin, RESTM
             GitlabUpdateError: If the server cannot perform the request
         """
         new_data = new_data or {}
-        super(ProjectServiceManager, self).update(id, new_data, **kwargs)
+        result = super(ProjectServiceManager, self).update(id, new_data, **kwargs)
         self.id = id
+        return result
 
     @cli.register_custom_action("ProjectServiceManager")
-    def available(self, **kwargs):
+    def available(self, **kwargs: Any) -> List[str]:
         """List the services known by python-gitlab.
 
         Returns:

--- a/gitlab/v4/objects/sidekiq.py
+++ b/gitlab/v4/objects/sidekiq.py
@@ -1,3 +1,7 @@
+from typing import Any, Dict, Union
+
+import requests
+
 from gitlab import cli
 from gitlab import exceptions as exc
 from gitlab.base import RESTManager
@@ -16,7 +20,7 @@ class SidekiqManager(RESTManager):
 
     @cli.register_custom_action("SidekiqManager")
     @exc.on_http_error(exc.GitlabGetError)
-    def queue_metrics(self, **kwargs):
+    def queue_metrics(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Return the registered queues information.
 
         Args:
@@ -33,7 +37,9 @@ class SidekiqManager(RESTManager):
 
     @cli.register_custom_action("SidekiqManager")
     @exc.on_http_error(exc.GitlabGetError)
-    def process_metrics(self, **kwargs):
+    def process_metrics(
+        self, **kwargs: Any
+    ) -> Union[Dict[str, Any], requests.Response]:
         """Return the registered sidekiq workers.
 
         Args:
@@ -50,7 +56,7 @@ class SidekiqManager(RESTManager):
 
     @cli.register_custom_action("SidekiqManager")
     @exc.on_http_error(exc.GitlabGetError)
-    def job_stats(self, **kwargs):
+    def job_stats(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Return statistics about the jobs performed.
 
         Args:
@@ -67,7 +73,9 @@ class SidekiqManager(RESTManager):
 
     @cli.register_custom_action("SidekiqManager")
     @exc.on_http_error(exc.GitlabGetError)
-    def compound_metrics(self, **kwargs):
+    def compound_metrics(
+        self, **kwargs: Any
+    ) -> Union[Dict[str, Any], requests.Response]:
         """Return all available metrics and statistics.
 
         Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ module = [
     "docs.ext.*",
     "gitlab.v4.objects.files",
     "gitlab.v4.objects.labels",
-    "gitlab.v4.objects.sidekiq",
     "tests.functional.*",
     "tests.functional.api.*",
     "tests.meta.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ module = [
     "docs.ext.*",
     "gitlab.v4.objects.files",
     "gitlab.v4.objects.labels",
-    "gitlab.v4.objects.milestones",
     "gitlab.v4.objects.pipelines",
     "gitlab.v4.objects.repositories",
     "gitlab.v4.objects.services",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ module = [
     "docs.ext.*",
     "gitlab.v4.objects.files",
     "gitlab.v4.objects.labels",
-    "gitlab.v4.objects.pipelines",
     "gitlab.v4.objects.repositories",
     "gitlab.v4.objects.services",
     "gitlab.v4.objects.sidekiq",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ module = [
     "docs.*",
     "docs.ext.*",
     "gitlab.v4.objects.files",
-    "gitlab.v4.objects.issues",
     "gitlab.v4.objects.jobs",
     "gitlab.v4.objects.labels",
     "gitlab.v4.objects.milestones",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ files = "."
 module = [
     "docs.*",
     "docs.ext.*",
-    "gitlab.v4.objects.files",
     "tests.functional.*",
     "tests.functional.api.*",
     "tests.meta.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ module = [
     "docs.*",
     "docs.ext.*",
     "gitlab.v4.objects.files",
-    "gitlab.v4.objects.labels",
     "tests.functional.*",
     "tests.functional.api.*",
     "tests.meta.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ module = [
     "docs.*",
     "docs.ext.*",
     "gitlab.v4.objects.files",
-    "gitlab.v4.objects.geo_nodes",
     "gitlab.v4.objects.issues",
     "gitlab.v4.objects.jobs",
     "gitlab.v4.objects.labels",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ module = [
     "docs.ext.*",
     "gitlab.v4.objects.files",
     "gitlab.v4.objects.labels",
-    "gitlab.v4.objects.services",
     "gitlab.v4.objects.sidekiq",
     "tests.functional.*",
     "tests.functional.api.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ module = [
     "docs.*",
     "docs.ext.*",
     "gitlab.v4.objects.files",
-    "gitlab.v4.objects.jobs",
     "gitlab.v4.objects.labels",
     "gitlab.v4.objects.milestones",
     "gitlab.v4.objects.pipelines",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ files = "."
 module = [
     "docs.*",
     "docs.ext.*",
-    "gitlab.v4.objects.epics",
     "gitlab.v4.objects.files",
     "gitlab.v4.objects.geo_nodes",
     "gitlab.v4.objects.issues",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ module = [
     "docs.ext.*",
     "gitlab.v4.objects.files",
     "gitlab.v4.objects.labels",
-    "gitlab.v4.objects.repositories",
     "gitlab.v4.objects.services",
     "gitlab.v4.objects.sidekiq",
     "tests.functional.*",


### PR DESCRIPTION
Fixed a bug in the auto-manager creation code if we added a type-hint for the `manager` attribute.

Add type-hints for the remainder of the code base.

Finally! 😊