### PR TITLE
fix: have renovate upgrade black version

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["@commitlint/config-conventional"]
+  "extends": ["@commitlint/config-conventional"],
+  "rules": {
+      "footer-max-line-length": [2, "always", 200]
+  }
 }

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -28,6 +28,12 @@
     {
       "matchPackagePrefixes": ["types-"],
       "groupName": "typing dependencies"
-    }
+    },
+    {
+        "matchPackagePatterns": ["(^|/)black$"],
+        "versioning": "pep440",
+        "ignoreUnstable": false,
+        "groupName": "black"
+     }
   ]
 }


### PR DESCRIPTION
renovate is not upgrading the `black` package. There is an open
issue[1] about this.

Use suggested work-around from:
https://github.com/renovatebot/renovate/issues/7167#issuecomment-904106838
&
https://github.com/scop/bash-completion/blob/e7497f6ee8232065ec11450a52a1f244f345e2c6/renovate.json#L34-L38

1. https://github.com/renovatebot/renovate/issues/7167