### PR TITLE
chore: correct test_groups.py test

### DIFF
--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -36,7 +36,11 @@ def test_groups(gl):
 
     filtered_groups = gl.groups.list(skip_groups=[group3.id, group4.id])
     assert group3 not in filtered_groups
+    assert group4 not in filtered_groups
+
+    filtered_groups = gl.groups.list(skip_groups=[group3.id])
     assert group3 not in filtered_groups
+    assert group4 in filtered_groups
 
     group1.members.create(
         {"access_level": gitlab.const.OWNER_ACCESS, "user_id": user.id}


### PR DESCRIPTION
The test was checking twice if the same group3 was not in the returned
list.  Should have been checking for group3 and group4.

Also added a test that only skipped one group and checked that the
group was not in the returned list and a non-skipped group was in the
list.