### PR TITLE
chore: attempt to be more informative for missing attributes

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -16,6 +16,18 @@ I cannot edit the merge request / issue I've just retrieved
     See the :ref:`merge requests example <merge_requests_examples>` and the
     :ref:`issues examples <issues_examples>`.
 
+.. _attribute_error_list:
+
+I get an ``AttributeError`` when accessing attributes of an object retrieved via a ``list()`` call.
+    Fetching a list of objects, doesn’t always include all attributes in the
+    objects. To retrieve an object with all attributes use a ``get()`` call.
+
+    Example with projects::
+
+        for projects in gl.projects.list():
+            # Retrieve project object with all attributes
+            project = gl.projects.get(project.id)
+
 How can I clone the repository of a project?
     python-gitlab doesn't provide an API to clone a project. You have to use a
     git library or call the ``git`` command.

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -240,7 +240,7 @@ class ListMixin(_RestManagerBase):
             assert self._obj_cls is not None
         obj = self.gitlab.http_list(path, **data)
         if isinstance(obj, list):
-            return [self._obj_cls(self, item) for item in obj]
+            return [self._obj_cls(self, item, created_from_list=True) for item in obj]
         else:
             return base.RESTObjectList(self, self._obj_cls, obj)
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -90,6 +90,30 @@ class TestRESTObject:
         with pytest.raises(gitlab.exceptions.GitlabParsingError):
             FakeObject(fake_manager, ["a", "list", "fails"])
 
+    def test_missing_attribute_does_not_raise_custom(self, fake_gitlab, fake_manager):
+        """Ensure a missing attribute does not raise our custom error message
+        if the RESTObject was not created from a list"""
+        obj = FakeObject(manager=fake_manager, attrs={"foo": "bar"})
+        with pytest.raises(AttributeError) as excinfo:
+            obj.missing_attribute
+        exc_str = str(excinfo.value)
+        assert "missing_attribute" in exc_str
+        assert "was created via a list()" not in exc_str
+        assert base._URL_ATTRIBUTE_ERROR not in exc_str
+
+    def test_missing_attribute_from_list_raises_custom(self, fake_gitlab, fake_manager):
+        """Ensure a missing attribute raises our custom error message if the
+        RESTObject was created from a list"""
+        obj = FakeObject(
+            manager=fake_manager, attrs={"foo": "bar"}, created_from_list=True
+        )
+        with pytest.raises(AttributeError) as excinfo:
+            obj.missing_attribute
+        exc_str = str(excinfo.value)
+        assert "missing_attribute" in exc_str
+        assert "was created via a list()" in exc_str
+        assert base._URL_ATTRIBUTE_ERROR in exc_str
+
     def test_picklability(self, fake_manager):
         obj = FakeObject(fake_manager, {"foo": "bar"})
         original_obj_module = obj._module


### PR DESCRIPTION
A commonly reported issue from users on Gitter is that they get an
AttributeError for an attribute that should be present. This is often
caused due to the fact that they used the `list()` method to retrieve
the object and objects retrieved this way often only have a subset of
the full data.

Add more details in the AttributeError message that explains the
situation to users. This will hopefully allow them to resolve the
issue.

Closes #1138