### PR TITLE
feat: remove support for Python 3.6, require 3.7 or higher

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: 3.6
-            toxenv: py36
           - python-version: 3.7
             toxenv: py37
           - python-version: 3.8

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -2,7 +2,7 @@
 Installation
 ############
 
-``python-gitlab`` is compatible with Python 3.6+.
+``python-gitlab`` is compatible with Python 3.7+.
 
 Use :command:`pip` to install the latest stable version of ``python-gitlab``:
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     package_data={
         "gitlab": ["py.typed"],
     },
-    python_requires=">=3.6.0",
+    python_requires=">=3.7.0",
     entry_points={"console_scripts": ["gitlab = gitlab.cli:main"]},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -44,7 +44,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = py310,py39,py38,py37,py36,pep8,black,twine-check,mypy,isort
+envlist = py310,py39,py38,py37,pep8,black,twine-check,mypy,isort
 
 [testenv]
 passenv = GITLAB_IMAGE GITLAB_TAG


### PR DESCRIPTION
Python 3.6 is End-of-Life (EOL) as of 2021-12 as stated in
https://www.python.org/dev/peps/pep-0494/

By dropping support for Python 3.6 and requiring Python 3.7 or higher
it allows python-gitlab to take advantage of new features in Python
3.7, which are documented at:
https://docs.python.org/3/whatsnew/3.7.html

Some of these new features that may be useful to python-gitlab are:
  * PEP 563, postponed evaluation of type annotations.
  * dataclasses: PEP 557 – Data Classes
  * importlib.resources
  * PEP 562, customization of access to module attributes.
  * PEP 560, core support for typing module and generic types.
  * PEP 565, improved DeprecationWarning handling

BREAKING CHANGE: As of python-gitlab 3.0.0, Python 3.6 is no longer
supported. Python 3.7 or higher is required.