### PR TITLE
chore: remove duplicate/no-op tests from meta/test_ensure_type_hints

### DIFF
--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -6,4 +6,3 @@ pytest
 types-PyYAML==6.0.1
 types-requests==2.26.0
 types-setuptools==57.4.3
-types-toml==0.10.1


### PR DESCRIPTION
Before we were generating 725 tests for the
meta/test_ensure_type_hints.py tests.  Which isn't a huge concern as
it was fairly fast. But when we had a failure we would usually get two
failures for each problem as the same test was being run multiple
times.

Changed it so that:
  1. Don't add tests that are not for *Manager classes
  2. Use a set so that we don't have duplicate tests.

After doing that our generated test count in
meta/test_ensure_type_hints.py went from 725 to 178 tests.

Additionally removed the parsing of `pyproject.toml` to generate files
to ignore as we have finished adding type-hints to all files in
gitlab/v4/objects/. This also means we no longer use the toml library
so remove installation of `types-toml`.

To determine the test count the following command was run:
  $ tox -e py39 -- -k test_ensure_type_hints