### PR TITLE
docs: only use type annotations for documentation

### DIFF
--- a/docs/_templates/breadcrumbs.html
+++ b/docs/_templates/breadcrumbs.html
@@ -15,7 +15,7 @@
     <li>{{ title }}</li>
       <li class="wy-breadcrumbs-aside">
         {% if pagename != "search" %}
-            <a href="https://github.com/python-gitlab/python-gitlab/blob/master/{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-github"> Edit on GitHub</a>
+            <a href="https://github.com/python-gitlab/python-gitlab/blob/main/{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-github"> Edit on GitHub</a>
             | <a href="https://github.com/python-gitlab/python-gitlab/issues/new?title=Documentation+bug&body=%0A%0A------%0AIn+page:+{{ pagename }}{{ suffix }}">Report a bug</a>
         {% endif %}
       </li>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "ext.docstrings",
+    "sphinx_autodoc_typehints",  # must be loaded after napoleon modules
     "sphinxcontrib.autoprogram",
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,9 +42,10 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "ext.docstrings",
-    "sphinx_autodoc_typehints",  # must be loaded after napoleon modules
     "sphinxcontrib.autoprogram",
 ]
+
+autodoc_typehints = "both"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -298,8 +298,7 @@ class RESTManager(object):
         """REST manager constructor.
 
         Args:
-            gl (Gitlab): :class:`~gitlab.Gitlab` connection to use to make
-                         requests.
+            gl: :class:`~gitlab.Gitlab` connection to use to make requests.
             parent: REST object to which the manager is attached.
         """
         self.gitlab = gl

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -39,21 +39,21 @@ class Gitlab(object):
     """Represents a GitLab server connection.
 
     Args:
-        url (str): The URL of the GitLab server (defaults to https://gitlab.com).
-        private_token (str): The user private token
-        oauth_token (str): An oauth token
-        job_token (str): A CI job token
-        ssl_verify (bool|str): Whether SSL certificates should be validated. If
+        url: The URL of the GitLab server (defaults to https://gitlab.com).
+        private_token: The user private token
+        oauth_token: An oauth token
+        job_token: A CI job token
+        ssl_verify: Whether SSL certificates should be validated. If
             the value is a string, it is the path to a CA file used for
             certificate validation.
-        timeout (float): Timeout to use for requests to the GitLab server.
-        http_username (str): Username for HTTP authentication
-        http_password (str): Password for HTTP authentication
-        api_version (str): Gitlab API version to use (support for 4 only)
-        pagination (str): Can be set to 'keyset' to use keyset pagination
-        order_by (str): Set order_by globally
-        user_agent (str): A custom user agent to use for making HTTP requests.
-        retry_transient_errors (bool): Whether to retry after 500, 502, 503, or
+        timeout: Timeout to use for requests to the GitLab server.
+        http_username: Username for HTTP authentication
+        http_password: Password for HTTP authentication
+        api_version: Gitlab API version to use (support for 4 only)
+        pagination: Can be set to 'keyset' to use keyset pagination
+        order_by: Set order_by globally
+        user_agent: A custom user agent to use for making HTTP requests.
+        retry_transient_errors: Whether to retry after 500, 502, 503, or
             504 responses. Defaults to False.
     """
 
@@ -225,11 +225,11 @@ class Gitlab(object):
         """Create a Gitlab connection from configuration files.
 
         Args:
-            gitlab_id (str): ID of the configuration section.
+            gitlab_id: ID of the configuration section.
             config_files list[str]: List of paths to configuration files.
 
         Returns:
-            (gitlab.Gitlab): A Gitlab connection.
+            A Gitlab connection.
 
         Raises:
             gitlab.config.GitlabDataError: If the configuration is not correct.
@@ -269,7 +269,7 @@ class Gitlab(object):
         object.
 
         Returns:
-            tuple (str, str): The server version and server revision.
+            tuple: The server version and server revision.
                               ('unknown', 'unknwown') if the server doesn't
                               perform as expected.
         """
@@ -293,7 +293,7 @@ class Gitlab(object):
         """Validate a gitlab CI configuration.
 
         Args:
-            content (txt): The .gitlab-ci.yml content
+            content: The .gitlab-ci.yml content
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -317,11 +317,9 @@ class Gitlab(object):
         """Render an arbitrary Markdown document.
 
         Args:
-            text (str): The markdown text to render
-            gfm (bool): Render text using GitLab Flavored Markdown. Default is
-                False
-            project (str): Full path of a project used a context when `gfm` is
-                True
+            text: The markdown text to render
+            gfm: Render text using GitLab Flavored Markdown. Default is False
+            project: Full path of a project used a context when `gfm` is True
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -363,7 +361,7 @@ class Gitlab(object):
         """Add a new license.
 
         Args:
-            license (str): The license string
+            license: The license string
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -541,20 +539,19 @@ class Gitlab(object):
         """Make an HTTP request to the Gitlab server.
 
         Args:
-            verb (str): The HTTP method to call ('get', 'post', 'put',
-                        'delete')
-            path (str): Path or full URL to query ('/projects' or
+            verb: The HTTP method to call ('get', 'post', 'put', 'delete')
+            path: Path or full URL to query ('/projects' or
                         'http://whatever/v4/api/projecs')
-            query_data (dict): Data to send as query parameters
-            post_data (dict|bytes): Data to send in the body (will be converted to
+            query_data: Data to send as query parameters
+            post_data: Data to send in the body (will be converted to
                               json by default)
-            raw (bool): If True, do not convert post_data to json
-            streamed (bool): Whether the data should be streamed
-            files (dict): The files to send to the server
-            timeout (float): The timeout, in seconds, for the request
-            obey_rate_limit (bool): Whether to obey 429 Too Many Request
+            raw: If True, do not convert post_data to json
+            streamed: Whether the data should be streamed
+            files: The files to send to the server
+            timeout: The timeout, in seconds, for the request
+            obey_rate_limit: Whether to obey 429 Too Many Request
                                     responses. Defaults to True.
-            max_retries (int): Max retries after 429 or transient errors,
+            max_retries: Max retries after 429 or transient errors,
                                set to -1 to retry forever. Defaults to 10.
             **kwargs: Extra options to send to the server (e.g. sudo)
 
@@ -667,11 +664,11 @@ class Gitlab(object):
         """Make a GET request to the Gitlab server.
 
         Args:
-            path (str): Path or full URL to query ('/projects' or
+            path: Path or full URL to query ('/projects' or
                         'http://whatever/v4/api/projecs')
-            query_data (dict): Data to send as query parameters
-            streamed (bool): Whether the data should be streamed
-            raw (bool): If True do not try to parse the output as json
+            query_data: Data to send as query parameters
+            streamed: Whether the data should be streamed
+            raw: If True do not try to parse the output as json
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
@@ -712,9 +709,9 @@ class Gitlab(object):
         """Make a GET request to the Gitlab server for list-oriented queries.
 
         Args:
-            path (str): Path or full URL to query ('/projects' or
+            path: Path or full URL to query ('/projects' or
                         'http://whatever/v4/api/projects')
-            query_data (dict): Data to send as query parameters
+            query_data: Data to send as query parameters
             **kwargs: Extra options to send to the server (e.g. sudo, page,
                       per_page)
 
@@ -761,13 +758,13 @@ class Gitlab(object):
         """Make a POST request to the Gitlab server.
 
         Args:
-            path (str): Path or full URL to query ('/projects' or
+            path: Path or full URL to query ('/projects' or
                         'http://whatever/v4/api/projecs')
-            query_data (dict): Data to send as query parameters
-            post_data (dict): Data to send in the body (will be converted to
+            query_data: Data to send as query parameters
+            post_data: Data to send in the body (will be converted to
                               json by default)
-            raw (bool): If True, do not convert post_data to json
-            files (dict): The files to send to the server
+            raw: If True, do not convert post_data to json
+            files: The files to send to the server
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
@@ -810,13 +807,13 @@ class Gitlab(object):
         """Make a PUT request to the Gitlab server.
 
         Args:
-            path (str): Path or full URL to query ('/projects' or
+            path: Path or full URL to query ('/projects' or
                         'http://whatever/v4/api/projecs')
-            query_data (dict): Data to send as query parameters
-            post_data (dict|bytes): Data to send in the body (will be converted to
+            query_data: Data to send as query parameters
+            post_data: Data to send in the body (will be converted to
                               json by default)
-            raw (bool): If True, do not convert post_data to json
-            files (dict): The files to send to the server
+            raw: If True, do not convert post_data to json
+            files: The files to send to the server
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
@@ -849,7 +846,7 @@ class Gitlab(object):
         """Make a DELETE request to the Gitlab server.
 
         Args:
-            path (str): Path or full URL to query ('/projects' or
+            path: Path or full URL to query ('/projects' or
                         'http://whatever/v4/api/projecs')
             **kwargs: Extra options to send to the server (e.g. sudo)
 
@@ -868,8 +865,8 @@ class Gitlab(object):
         """Search GitLab resources matching the provided string.'
 
         Args:
-            scope (str): Scope of the search
-            search (str): Search string
+            scope: Scope of the search
+            search: Search string
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -269,9 +269,8 @@ class Gitlab(object):
         object.
 
         Returns:
-            tuple: The server version and server revision.
-                              ('unknown', 'unknwown') if the server doesn't
-                              perform as expected.
+            The server version and server revision.
+                ('unknown', 'unknown') if the server doesn't perform as expected.
         """
         if self._server_version is None:
             try:
@@ -301,8 +300,7 @@ class Gitlab(object):
             GitlabVerifyError: If the validation could not be done
 
         Returns:
-            tuple: (True, []) if the file is valid, (False, errors(list))
-                otherwise
+            (True, []) if the file is valid, (False, errors(list)) otherwise
         """
         post_data = {"content": content}
         data = self.http_post("/ci/lint", post_data=post_data, **kwargs)
@@ -327,7 +325,7 @@ class Gitlab(object):
             GitlabMarkdownError: If the server cannot perform the request
 
         Returns:
-            str: The HTML rendering of the markdown text.
+            The HTML rendering of the markdown text.
         """
         post_data = {"text": text, "gfm": gfm}
         if project is not None:
@@ -349,7 +347,7 @@ class Gitlab(object):
             GitlabGetError: If the server cannot perform the request
 
         Returns:
-            dict: The current license information
+            The current license information
         """
         result = self.http_get("/license", **kwargs)
         if isinstance(result, dict):
@@ -369,7 +367,7 @@ class Gitlab(object):
             GitlabPostError: If the server cannot perform the request
 
         Returns:
-            dict: The new license information
+            The new license information
         """
         data = {"license": license}
         result = self.http_post("/license", post_data=data, **kwargs)
@@ -444,7 +442,7 @@ class Gitlab(object):
         """Return the base URL with the trailing slash stripped.
         If the URL is a Falsy value, return the default URL.
         Returns:
-            str: The base URL
+            The base URL
         """
         if not url:
             return gitlab.const.DEFAULT_URL
@@ -458,7 +456,7 @@ class Gitlab(object):
         it to the stored url.
 
         Returns:
-            str: The full URL
+            The full URL
         """
         if path.startswith("http://") or path.startswith("https://"):
             return path
@@ -716,7 +714,7 @@ class Gitlab(object):
                       per_page)
 
         Returns:
-            list: A list of the objects returned by the server. If `as_list` is
+            A list of the objects returned by the server. If `as_list` is
             False and no pagination-related arguments (`page`, `per_page`,
             `all`) are defined then a GitlabList object (generator) is returned
             instead. This object will make API calls when needed to fetch the
@@ -874,7 +872,7 @@ class Gitlab(object):
             GitlabSearchError: If the server failed to perform the request
 
         Returns:
-            GitlabList: A list of dicts describing the resources found.
+            A list of dicts describing the resources found.
         """
         data = {"scope": scope, "search": search}
         return self.http_list("/search", query_data=data, **kwargs)

--- a/gitlab/exceptions.py
+++ b/gitlab/exceptions.py
@@ -297,8 +297,7 @@ def on_http_error(error: Type[Exception]) -> Callable[[__F], __F]:
     raise specialized exceptions instead.
 
     Args:
-        error(Exception): The exception type to raise -- must inherit from
-            GitlabError
+        The exception type to raise -- must inherit from GitlabError
     """
 
     def wrap(f: __F) -> __F:

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -86,8 +86,8 @@ class GetMixin(_RestManagerBase):
         """Retrieve a single object.
 
         Args:
-            id (int or str): ID of the object to retrieve
-            lazy (bool): If True, don't request the server, but create a
+            id: ID of the object to retrieve
+            lazy: If True, don't request the server, but create a
                          shallow object giving access to the managers. This is
                          useful if you want to avoid useless calls to the API.
             **kwargs: Extra options to send to the server (e.g. sudo)
@@ -199,10 +199,10 @@ class ListMixin(_RestManagerBase):
         """Retrieve a list of objects.
 
         Args:
-            all (bool): If True, return all the items, without pagination
-            per_page (int): Number of items to retrieve per request
-            page (int): ID of the page to return (starts with page 1)
-            as_list (bool): If set to False and no pagination option is
+            all: If True, return all the items, without pagination
+            per_page: Number of items to retrieve per request
+            page: ID of the page to return (starts with page 1)
+            as_list: If set to False and no pagination option is
                 defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
@@ -282,7 +282,7 @@ class CreateMixin(_RestManagerBase):
         """Create a new object.
 
         Args:
-            data (dict): parameters to send to the server to create the
+            data: parameters to send to the server to create the
                          resource
             **kwargs: Extra options to send to the server (e.g. sudo)
 
@@ -433,8 +433,8 @@ class SetMixin(_RestManagerBase):
         """Create or update the object.
 
         Args:
-            key (str): The key of the object to create/update
-            value (str): The value to set for the object
+            key: The key of the object to create/update
+            value: The value to set for the object
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -623,7 +623,7 @@ class AccessRequestMixin(_RestObjectBase):
         """Approve an access request.
 
         Args:
-            access_level (int): The access level for the user
+            access_level: The access level for the user
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -659,12 +659,12 @@ class DownloadMixin(_RestObjectBase):
         """Download the archive of a resource export.
 
         Args:
-            streamed (bool): If True the data will be processed by chunks of
+            streamed: If True the data will be processed by chunks of
                 `chunk_size` and each chunk is passed to `action` for
                 treatment
-            action (callable): Callable responsible of dealing with chunk of
+            action: Callable responsible of dealing with chunk of
                 data
-            chunk_size (int): Size of each chunk
+            chunk_size: Size of each chunk
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -793,7 +793,7 @@ class TimeTrackingMixin(_RestObjectBase):
         """Set an estimated time of work for the object.
 
         Args:
-            duration (str): Duration in human format (e.g. 3h30)
+            duration: Duration in human format (e.g. 3h30)
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -831,7 +831,7 @@ class TimeTrackingMixin(_RestObjectBase):
         """Add time spent working on the object.
 
         Args:
-            duration (str): Duration in human format (e.g. 3h30)
+            duration: Duration in human format (e.g. 3h30)
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -878,10 +878,10 @@ class ParticipantsMixin(_RestObjectBase):
         """List the participants.
 
         Args:
-            all (bool): If True, return all the items, without pagination
-            per_page (int): Number of items to retrieve per request
-            page (int): ID of the page to return (starts with page 1)
-            as_list (bool): If set to False and no pagination option is
+            all: If True, return all the items, without pagination
+            per_page: Number of items to retrieve per request
+            page: ID of the page to return (starts with page 1)
+            as_list: If set to False and no pagination option is
                 defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
@@ -909,8 +909,8 @@ class BadgeRenderMixin(_RestManagerBase):
         """Preview link_url and image_url after interpolation.
 
         Args:
-            link_url (str): URL of the badge link
-            image_url (str): URL of the badge image
+            link_url: URL of the badge link
+            image_url: URL of the badge image
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -93,7 +93,7 @@ class GetMixin(_RestManagerBase):
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
-            object: The generated RESTObject.
+            The generated RESTObject.
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct
@@ -134,7 +134,7 @@ class GetWithoutIdMixin(_RestManagerBase):
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
-            object: The generated RESTObject
+            The generated RESTObject
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct
@@ -207,7 +207,7 @@ class ListMixin(_RestManagerBase):
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
-            list: The list of objects, or a generator if `as_list` is False
+            The list of objects, or a generator if `as_list` is False
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct
@@ -287,7 +287,7 @@ class CreateMixin(_RestManagerBase):
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
-            RESTObject: a new instance of the managed object class built with
+            A new instance of the managed object class built with
                 the data sent by the server
 
         Raises:
@@ -357,7 +357,7 @@ class UpdateMixin(_RestManagerBase):
         """Return the HTTP method to use.
 
         Returns:
-            object: http_put (default) or http_post
+            http_put (default) or http_post
         """
         if self._update_uses_post:
             http_method = self.gitlab.http_post
@@ -380,7 +380,7 @@ class UpdateMixin(_RestManagerBase):
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
-            dict: The new object data (*not* a RESTObject)
+            The new object data (*not* a RESTObject)
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct
@@ -442,7 +442,7 @@ class SetMixin(_RestManagerBase):
             GitlabSetError: If an error occurred
 
         Returns:
-            obj: The created/updated attribute
+            The created/updated attribute
         """
         path = f"{self.path}/{utils.clean_str_id(key)}"
         data = {"value": value}
@@ -672,7 +672,7 @@ class DownloadMixin(_RestObjectBase):
             GitlabGetError: If the server failed to perform the request
 
         Returns:
-            str: The blob content if streamed is False, None otherwise
+            The blob content if streamed is False, None otherwise
         """
         path = f"{self.manager.path}/download"
         result = self.manager.gitlab.http_get(
@@ -890,7 +890,7 @@ class ParticipantsMixin(_RestObjectBase):
             GitlabListError: If the list could not be retrieved
 
         Returns:
-            RESTObjectList: The list of participants
+            The list of participants
         """
 
         path = f"{self.manager.path}/{self.get_id()}/participants"
@@ -918,7 +918,7 @@ class BadgeRenderMixin(_RestManagerBase):
             GitlabRenderError: If the rendering failed
 
         Returns:
-            dict: The rendering properties
+            The rendering properties
         """
         path = f"{self.path}/render"
         data = {"link_url": link_url, "image_url": image_url}
@@ -943,7 +943,7 @@ class PromoteMixin(_RestObjectBase):
         """Return the HTTP method to use.
 
         Returns:
-            object: http_put (default) or http_post
+            http_put (default) or http_post
         """
         if self._update_uses_post:
             http_method = self.manager.gitlab.http_post
@@ -964,7 +964,7 @@ class PromoteMixin(_RestObjectBase):
             GitlabParsingError: If the json data could not be parsed
 
         Returns:
-            dict: The updated object data (*not* a RESTObject)
+            The updated object data (*not* a RESTObject)
         """
 
         path = f"{self.manager.path}/{self.id}/promote"

--- a/gitlab/v4/objects/appearance.py
+++ b/gitlab/v4/objects/appearance.py
@@ -48,7 +48,7 @@ class ApplicationAppearanceManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
-            dict: The new object data (*not* a RESTObject)
+            The new object data (*not* a RESTObject)
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct

--- a/gitlab/v4/objects/clusters.py
+++ b/gitlab/v4/objects/clusters.py
@@ -51,8 +51,8 @@ class GroupClusterManager(CRUDMixin, RESTManager):
             GitlabCreateError: If the server cannot perform the request
 
         Returns:
-            RESTObject: A new instance of the manage object class build with
-                        the data sent by the server
+            A new instance of the manage object class build with
+                the data sent by the server
         """
         path = f"{self.path}/user"
         return cast(GroupCluster, CreateMixin.create(self, data, path=path, **kwargs))
@@ -102,8 +102,8 @@ class ProjectClusterManager(CRUDMixin, RESTManager):
             GitlabCreateError: If the server cannot perform the request
 
         Returns:
-            RESTObject: A new instance of the manage object class build with
-                        the data sent by the server
+            A new instance of the manage object class build with
+                the data sent by the server
         """
         path = f"{self.path}/user"
         return cast(ProjectCluster, CreateMixin.create(self, data, path=path, **kwargs))

--- a/gitlab/v4/objects/clusters.py
+++ b/gitlab/v4/objects/clusters.py
@@ -41,7 +41,7 @@ class GroupClusterManager(CRUDMixin, RESTManager):
         """Create a new object.
 
         Args:
-            data (dict): Parameters to send to the server to create the
+            data: Parameters to send to the server to create the
                          resource
             **kwargs: Extra options to send to the server (e.g. sudo or
                       'ref_name', 'stage', 'name', 'all')
@@ -92,7 +92,7 @@ class ProjectClusterManager(CRUDMixin, RESTManager):
         """Create a new object.
 
         Args:
-            data (dict): Parameters to send to the server to create the
+            data: Parameters to send to the server to create the
                          resource
             **kwargs: Extra options to send to the server (e.g. sudo or
                       'ref_name', 'stage', 'name', 'all')

--- a/gitlab/v4/objects/commits.py
+++ b/gitlab/v4/objects/commits.py
@@ -50,7 +50,7 @@ class ProjectCommit(RESTObject):
         """Cherry-pick a commit into a branch.
 
         Args:
-            branch (str): Name of target branch
+            branch: Name of target branch
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -69,7 +69,7 @@ class ProjectCommit(RESTObject):
         """List the references the commit is pushed to.
 
         Args:
-            type (str): The scope of references ('branch', 'tag' or 'all')
+            type: The scope of references ('branch', 'tag' or 'all')
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -109,7 +109,7 @@ class ProjectCommit(RESTObject):
         """Revert a commit on a given branch.
 
         Args:
-            branch (str): Name of target branch
+            branch: Name of target branch
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -191,7 +191,7 @@ class ProjectCommitStatusManager(ListMixin, CreateMixin, RESTManager):
         """Create a new object.
 
         Args:
-            data (dict): Parameters to send to the server to create the
+            data: Parameters to send to the server to create the
                          resource
             **kwargs: Extra options to send to the server (e.g. sudo or
                       'ref_name', 'stage', 'name', 'all')

--- a/gitlab/v4/objects/commits.py
+++ b/gitlab/v4/objects/commits.py
@@ -39,7 +39,7 @@ class ProjectCommit(RESTObject):
             GitlabGetError: If the diff could not be retrieved
 
         Returns:
-            list: The changes done in this commit
+            The changes done in this commit
         """
         path = f"{self.manager.path}/{self.get_id()}/diff"
         return self.manager.gitlab.http_get(path, **kwargs)
@@ -77,7 +77,7 @@ class ProjectCommit(RESTObject):
             GitlabGetError: If the references could not be retrieved
 
         Returns:
-            list: The references the commit is pushed to.
+            The references the commit is pushed to.
         """
         path = f"{self.manager.path}/{self.get_id()}/refs"
         data = {"type": type}
@@ -96,7 +96,7 @@ class ProjectCommit(RESTObject):
             GitlabGetError: If the references could not be retrieved
 
         Returns:
-            list: The merge requests related to the commit.
+            The merge requests related to the commit.
         """
         path = f"{self.manager.path}/{self.get_id()}/merge_requests"
         return self.manager.gitlab.http_get(path, **kwargs)
@@ -117,7 +117,7 @@ class ProjectCommit(RESTObject):
             GitlabRevertError: If the revert could not be performed
 
         Returns:
-            dict: The new commit data (*not* a RESTObject)
+            The new commit data (*not* a RESTObject)
         """
         path = f"{self.manager.path}/{self.get_id()}/revert"
         post_data = {"branch": branch}
@@ -136,7 +136,7 @@ class ProjectCommit(RESTObject):
             GitlabGetError: If the signature could not be retrieved
 
         Returns:
-            dict: The commit's signature data
+            The commit's signature data
         """
         path = f"{self.manager.path}/{self.get_id()}/signature"
         return self.manager.gitlab.http_get(path, **kwargs)
@@ -201,8 +201,8 @@ class ProjectCommitStatusManager(ListMixin, CreateMixin, RESTManager):
             GitlabCreateError: If the server cannot perform the request
 
         Returns:
-            RESTObject: A new instance of the manage object class build with
-                        the data sent by the server
+            A new instance of the manage object class build with
+                the data sent by the server
         """
         # project_id and commit_id are in the data dict when using the CLI, but
         # they are missing when using only the API

--- a/gitlab/v4/objects/container_registry.py
+++ b/gitlab/v4/objects/container_registry.py
@@ -42,14 +42,14 @@ class ProjectRegistryTagManager(DeleteMixin, RetrieveMixin, RESTManager):
         """Delete Tag in bulk
 
         Args:
-            name_regex_delete (string): The regex of the name to delete. To delete all
-                                        tags specify .*.
-            keep_n (integer):           The amount of latest tags of given name to keep.
-            name_regex_keep (string):   The regex of the name to keep. This value
-                                        overrides any matches from name_regex.
-            older_than (string):        Tags to delete that are older than the given time,
-                                        written in human readable form 1h, 1d, 1month.
-            **kwargs:                   Extra options to send to the server (e.g. sudo)
+            name_regex_delete: The regex of the name to delete. To delete all
+                tags specify .*.
+            keep_n: The amount of latest tags of given name to keep.
+            name_regex_keep: The regex of the name to keep. This value
+                overrides any matches from name_regex.
+            older_than: Tags to delete that are older than the given time,
+                written in human readable form 1h, 1d, 1month.
+            **kwargs: Extra options to send to the server (e.g. sudo)
         Raises:
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server cannot perform the request

--- a/gitlab/v4/objects/deploy_keys.py
+++ b/gitlab/v4/objects/deploy_keys.py
@@ -43,7 +43,7 @@ class ProjectKeyManager(CRUDMixin, RESTManager):
         """Enable a deploy key for a project.
 
         Args:
-            key_id (int): The ID of the key to enable
+            key_id: The ID of the key to enable
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:

--- a/gitlab/v4/objects/epics.py
+++ b/gitlab/v4/objects/epics.py
@@ -92,7 +92,7 @@ class GroupEpicIssueManager(
         """Create a new object.
 
         Args:
-            data (dict): Parameters to send to the server to create the
+            data: Parameters to send to the server to create the
                          resource
             **kwargs: Extra options to send to the server (e.g. sudo)
 

--- a/gitlab/v4/objects/epics.py
+++ b/gitlab/v4/objects/epics.py
@@ -101,8 +101,8 @@ class GroupEpicIssueManager(
             GitlabCreateError: If the server cannot perform the request
 
         Returns:
-            RESTObject: A new instance of the manage object class build with
-                        the data sent by the server
+            A new instance of the manage object class build with
+                the data sent by the server
         """
         if TYPE_CHECKING:
             assert data is not None

--- a/gitlab/v4/objects/features.py
+++ b/gitlab/v4/objects/features.py
@@ -37,12 +37,12 @@ class FeatureManager(ListMixin, DeleteMixin, RESTManager):
         """Create or update the object.
 
         Args:
-            name (str): The value to set for the object
-            value (bool/int): The value to set for the object
-            feature_group (str): A feature group name
-            user (str): A GitLab username
-            group (str): A GitLab group
-            project (str): A GitLab project in form group/project
+            name: The value to set for the object
+            value: The value to set for the object
+            feature_group: A feature group name
+            user: A GitLab username
+            group: A GitLab group
+            project: A GitLab project in form group/project
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:

--- a/gitlab/v4/objects/features.py
+++ b/gitlab/v4/objects/features.py
@@ -50,7 +50,7 @@ class FeatureManager(ListMixin, DeleteMixin, RESTManager):
             GitlabSetError: If an error occurred
 
         Returns:
-            obj: The created/updated attribute
+            The created/updated attribute
         """
         path = f"{self.path}/{name.replace('/', '%2F')}"
         data = {

--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -111,7 +111,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
             GitlabGetError: If the file could not be retrieved
 
         Returns:
-            object: The generated RESTObject
+            The generated RESTObject
         """
         return cast(ProjectFile, GetMixin.get(self, file_path, ref=ref, **kwargs))
 
@@ -132,7 +132,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
-            RESTObject: a new instance of the managed object class built with
+            a new instance of the managed object class built with
                 the data sent by the server
 
         Raises:
@@ -165,7 +165,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
-            dict: The new object data (*not* a RESTObject)
+            The new object data (*not* a RESTObject)
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct
@@ -236,7 +236,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
             GitlabGetError: If the file could not be retrieved
 
         Returns:
-            str: The file content
+            The file content
         """
         file_path = file_path.replace("/", "%2F").replace(".", "%2E")
         path = f"{self.path}/{file_path}/raw"

--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -32,7 +32,7 @@ class ProjectFile(SaveMixin, ObjectDeleteMixin, RESTObject):
         """Returns the decoded content of the file.
 
         Returns:
-            (bytes): the decoded content.
+            The decoded content.
         """
         return base64.b64decode(self.content)
 
@@ -46,8 +46,8 @@ class ProjectFile(SaveMixin, ObjectDeleteMixin, RESTObject):
         The object is updated to match what the server returns.
 
         Args:
-            branch (str): Branch in which the file will be updated
-            commit_message (str): Message to send with the commit
+            branch: Branch in which the file will be updated
+            commit_message: Message to send with the commit
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -68,8 +68,8 @@ class ProjectFile(SaveMixin, ObjectDeleteMixin, RESTObject):
         """Delete the file from the server.
 
         Args:
-            branch (str): Branch from which the file will be removed
-            commit_message (str): Commit message for the deletion
+            branch: Branch from which the file will be removed
+            commit_message: Commit message for the deletion
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -102,8 +102,8 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         """Retrieve a single file.
 
         Args:
-            file_path (str): Path of the file to retrieve
-            ref (str): Name of the branch, tag or commit
+            file_path: Path of the file to retrieve
+            ref: Name of the branch, tag or commit
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -127,7 +127,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         """Create a new object.
 
         Args:
-            data (dict): parameters to send to the server to create the
+            data: parameters to send to the server to create the
                          resource
             **kwargs: Extra options to send to the server (e.g. sudo)
 
@@ -194,9 +194,9 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         """Delete a file on the server.
 
         Args:
-            file_path (str): Path of the file to remove
-            branch (str): Branch from which the file will be removed
-            commit_message (str): Commit message for the deletion
+            file_path: Path of the file to remove
+            branch: Branch from which the file will be removed
+            commit_message: Commit message for the deletion
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -221,14 +221,14 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         """Return the content of a file for a commit.
 
         Args:
-            ref (str): ID of the commit
-            filepath (str): Path of the file to return
-            streamed (bool): If True the data will be processed by chunks of
+            ref: ID of the commit
+            filepath: Path of the file to return
+            streamed: If True the data will be processed by chunks of
                 `chunk_size` and each chunk is passed to `action` for
                 treatment
-            action (callable): Callable responsible of dealing with chunk of
+            action: Callable responsible of dealing with chunk of
                 data
-            chunk_size (int): Size of each chunk
+            chunk_size: Size of each chunk
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -254,8 +254,8 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         """Return the content of a file for a commit.
 
         Args:
-            file_path (str): Path of the file to retrieve
-            ref (str): Name of the branch, tag or commit
+            file_path: Path of the file to retrieve
+            ref: Name of the branch, tag or commit
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -263,7 +263,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
             GitlabListError:  If the server failed to perform the request
 
         Returns:
-            list(blame): a list of commits/lines matching the file
+            A list of commits/lines matching the file
         """
         file_path = file_path.replace("/", "%2F").replace(".", "%2E")
         path = f"{self.path}/{file_path}/blame"

--- a/gitlab/v4/objects/geo_nodes.py
+++ b/gitlab/v4/objects/geo_nodes.py
@@ -49,7 +49,7 @@ class GeoNode(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabGetError: If the server failed to perform the request
 
         Returns:
-            dict: The status of the geo node
+            The status of the geo node
         """
         path = f"/geo_nodes/{self.get_id()}/status"
         result = self.manager.gitlab.http_get(path, **kwargs)
@@ -81,7 +81,7 @@ class GeoNodeManager(RetrieveMixin, UpdateMixin, DeleteMixin, RESTManager):
             GitlabGetError: If the server failed to perform the request
 
         Returns:
-            list: The status of all the geo nodes
+            The status of all the geo nodes
         """
         result = self.gitlab.http_list("/geo_nodes/status", **kwargs)
         if TYPE_CHECKING:
@@ -101,7 +101,7 @@ class GeoNodeManager(RetrieveMixin, UpdateMixin, DeleteMixin, RESTManager):
             GitlabGetError: If the server failed to perform the request
 
         Returns:
-            list: The list of failures
+            The list of failures
         """
         result = self.gitlab.http_list("/geo_nodes/current/failures", **kwargs)
         if TYPE_CHECKING:

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -110,7 +110,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabSearchError: If the server failed to perform the request
 
         Returns:
-            GitlabList: A list of dicts describing the resources found.
+            A list of dicts describing the resources found.
         """
         data = {"scope": scope, "search": search}
         path = f"/groups/{self.get_id()}/search"
@@ -319,7 +319,7 @@ class GroupManager(CRUDMixin, RESTManager):
             GitlabImportError: If the server failed to perform the request
 
         Returns:
-            dict: A representation of the import status.
+            A representation of the import status.
         """
         files = {"file": ("file.tar.gz", file, "application/octet-stream")}
         data = {"path": path, "name": name}

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -83,7 +83,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
         """Transfer a project to this group.
 
         Args:
-            to_project_id (int): ID of the project to transfer
+            to_project_id: ID of the project to transfer
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -101,8 +101,8 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
         """Search the group resources matching the provided string.'
 
         Args:
-            scope (str): Scope of the search
-            search (str): Search string
+            scope: Scope of the search
+            search: Search string
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -124,10 +124,10 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
         """Add an LDAP group link.
 
         Args:
-            cn (str): CN of the LDAP group
-            group_access (int): Minimum access level for members of the LDAP
+            cn: CN of the LDAP group
+            group_access: Minimum access level for members of the LDAP
                 group
-            provider (str): LDAP provider for the LDAP group
+            provider: LDAP provider for the LDAP group
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -146,8 +146,8 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
         """Delete an LDAP group link.
 
         Args:
-            cn (str): CN of the LDAP group
-            provider (str): LDAP provider for the LDAP group
+            cn: CN of the LDAP group
+            provider: LDAP provider for the LDAP group
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -187,8 +187,8 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
         """Share the group with a group.
 
         Args:
-            group_id (int): ID of the group.
-            group_access (int): Access level for the group.
+            group_id: ID of the group.
+            group_access: Access level for the group.
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -215,7 +215,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
         """Delete a shared group link within a group.
 
         Args:
-            group_id (int): ID of the group.
+            group_id: ID of the group.
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -308,9 +308,9 @@ class GroupManager(CRUDMixin, RESTManager):
 
         Args:
             file: Data or file object containing the group
-            path (str): The path for the new group to be imported.
-            name (str): The name for the new group.
-            parent_id (str): ID of a parent group that the group will
+            path: The path for the new group to be imported.
+            name: The name for the new group.
+            parent_id: ID of a parent group that the group will
                 be imported into.
             **kwargs: Extra options to send to the server (e.g. sudo)
 

--- a/gitlab/v4/objects/issues.py
+++ b/gitlab/v4/objects/issues.py
@@ -152,7 +152,7 @@ class ProjectIssue(
             GitlabGetErrot: If the merge requests could not be retrieved
 
         Returns:
-            list: The list of merge requests.
+            The list of merge requests.
         """
         path = f"{self.manager.path}/{self.get_id()}/related_merge_requests"
         result = self.manager.gitlab.http_get(path, **kwargs)
@@ -173,7 +173,7 @@ class ProjectIssue(
             GitlabGetErrot: If the merge requests could not be retrieved
 
         Returns:
-            list: The list of merge requests.
+            The list of merge requests.
         """
         path = f"{self.manager.path}/{self.get_id()}/closed_by"
         result = self.manager.gitlab.http_get(path, **kwargs)
@@ -265,7 +265,7 @@ class ProjectIssueLinkManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
-            RESTObject, RESTObject: The source and target issues
+            The source and target issues
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct

--- a/gitlab/v4/objects/issues.py
+++ b/gitlab/v4/objects/issues.py
@@ -125,7 +125,7 @@ class ProjectIssue(
         """Move the issue to another project.
 
         Args:
-            to_project_id(int): ID of the target project
+            to_project_id: ID of the target project
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -260,7 +260,7 @@ class ProjectIssueLinkManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
         """Create a new object.
 
         Args:
-            data (dict): parameters to send to the server to create the
+            data: parameters to send to the server to create the
                          resource
             **kwargs: Extra options to send to the server (e.g. sudo)
 

--- a/gitlab/v4/objects/jobs.py
+++ b/gitlab/v4/objects/jobs.py
@@ -136,7 +136,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabGetError: If the artifacts could not be retrieved
 
         Returns:
-            bytes: The artifacts if `streamed` is False, None otherwise.
+            The artifacts if `streamed` is False, None otherwise.
         """
         path = f"{self.manager.path}/{self.get_id()}/artifacts"
         result = self.manager.gitlab.http_get(
@@ -173,7 +173,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabGetError: If the artifacts could not be retrieved
 
         Returns:
-            bytes: The artifacts if `streamed` is False, None otherwise.
+            The artifacts if `streamed` is False, None otherwise.
         """
         path = f"{self.manager.path}/{self.get_id()}/artifacts/{path}"
         result = self.manager.gitlab.http_get(
@@ -208,7 +208,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabGetError: If the artifacts could not be retrieved
 
         Returns:
-            str: The trace
+            The trace
         """
         path = f"{self.manager.path}/{self.get_id()}/trace"
         result = self.manager.gitlab.http_get(

--- a/gitlab/v4/objects/jobs.py
+++ b/gitlab/v4/objects/jobs.py
@@ -123,12 +123,12 @@ class ProjectJob(RefreshMixin, RESTObject):
         """Get the job artifacts.
 
         Args:
-            streamed (bool): If True the data will be processed by chunks of
+            streamed: If True the data will be processed by chunks of
                 `chunk_size` and each chunk is passed to `action` for
                 treatment
-            action (callable): Callable responsible of dealing with chunk of
+            action: Callable responsible of dealing with chunk of
                 data
-            chunk_size (int): Size of each chunk
+            chunk_size: Size of each chunk
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -159,13 +159,13 @@ class ProjectJob(RefreshMixin, RESTObject):
         """Get a single artifact file from within the job's artifacts archive.
 
         Args:
-            path (str): Path of the artifact
-            streamed (bool): If True the data will be processed by chunks of
+            path: Path of the artifact
+            streamed: If True the data will be processed by chunks of
                 `chunk_size` and each chunk is passed to `action` for
                 treatment
-            action (callable): Callable responsible of dealing with chunk of
+            action: Callable responsible of dealing with chunk of
                 data
-            chunk_size (int): Size of each chunk
+            chunk_size: Size of each chunk
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -195,12 +195,12 @@ class ProjectJob(RefreshMixin, RESTObject):
         """Get the job trace.
 
         Args:
-            streamed (bool): If True the data will be processed by chunks of
+            streamed: If True the data will be processed by chunks of
                 `chunk_size` and each chunk is passed to `action` for
                 treatment
-            action (callable): Callable responsible of dealing with chunk of
+            action: Callable responsible of dealing with chunk of
                 data
-            chunk_size (int): Size of each chunk
+            chunk_size: Size of each chunk
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:

--- a/gitlab/v4/objects/ldap.py
+++ b/gitlab/v4/objects/ldap.py
@@ -23,10 +23,10 @@ class LDAPGroupManager(RESTManager):
         """Retrieve a list of objects.
 
         Args:
-            all (bool): If True, return all the items, without pagination
-            per_page (int): Number of items to retrieve per request
-            page (int): ID of the page to return (starts with page 1)
-            as_list (bool): If set to False and no pagination option is
+            all: If True, return all the items, without pagination
+            per_page: Number of items to retrieve per request
+            page: ID of the page to return (starts with page 1)
+            as_list: If set to False and no pagination option is
                 defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 

--- a/gitlab/v4/objects/ldap.py
+++ b/gitlab/v4/objects/ldap.py
@@ -31,7 +31,7 @@ class LDAPGroupManager(RESTManager):
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
-            list: The list of objects, or a generator if `as_list` is False
+            The list of objects, or a generator if `as_list` is False
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct

--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -221,8 +221,8 @@ class ProjectMergeRequestApprovalRuleManager(
             GitlabCreateError: If the server cannot perform the request
 
         Returns:
-            RESTObject: A new instance of the manage object class build with
-                        the data sent by the server
+            A new instance of the manage object class build with
+                the data sent by the server
         """
         if TYPE_CHECKING:
             assert data is not None

--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -55,8 +55,8 @@ class ProjectApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
         """Change project-level allowed approvers and approver groups.
 
         Args:
-            approver_ids (list): User IDs that can approve MRs
-            approver_group_ids (list): Group IDs whose members can approve MRs
+            approver_ids: User IDs that can approve MRs
+            approver_group_ids: Group IDs whose members can approve MRs
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct
@@ -117,9 +117,9 @@ class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTMan
         """Change MR-level allowed approvers and approver groups.
 
         Args:
-            approvals_required (integer): The number of required approvals for this rule
-            approver_ids (list of integers): User IDs that can approve MRs
-            approver_group_ids (list): Group IDs whose members can approve MRs
+            approvals_required: The number of required approvals for this rule
+            approver_ids: User IDs that can approve MRs
+            approver_group_ids: Group IDs whose members can approve MRs
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct
@@ -211,7 +211,7 @@ class ProjectMergeRequestApprovalRuleManager(
         """Create a new object.
 
         Args:
-            data (dict): Parameters to send to the server to create the
+            data: Parameters to send to the server to create the
                          resource
             **kwargs: Extra options to send to the server (e.g. sudo or
                       'ref_name', 'stage', 'name', 'all')

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -196,10 +196,10 @@ class ProjectMergeRequest(
         """List issues that will close on merge."
 
         Args:
-            all (bool): If True, return all the items, without pagination
-            per_page (int): Number of items to retrieve per request
-            page (int): ID of the page to return (starts with page 1)
-            as_list (bool): If set to False and no pagination option is
+            all: If True, return all the items, without pagination
+            per_page: Number of items to retrieve per request
+            page: ID of the page to return (starts with page 1)
+            as_list: If set to False and no pagination option is
                 defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
@@ -223,10 +223,10 @@ class ProjectMergeRequest(
         """List the merge request commits.
 
         Args:
-            all (bool): If True, return all the items, without pagination
-            per_page (int): Number of items to retrieve per request
-            page (int): ID of the page to return (starts with page 1)
-            as_list (bool): If set to False and no pagination option is
+            all: If True, return all the items, without pagination
+            per_page: Number of items to retrieve per request
+            page: ID of the page to return (starts with page 1)
+            as_list: If set to False and no pagination option is
                 defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
@@ -269,7 +269,7 @@ class ProjectMergeRequest(
         """Approve the merge request.
 
         Args:
-            sha (str): Head SHA of MR
+            sha: Head SHA of MR
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -365,10 +365,10 @@ class ProjectMergeRequest(
         """Accept the merge request.
 
         Args:
-            merge_commit_message (str): Commit message
-            should_remove_source_branch (bool): If True, removes the source
+            merge_commit_message: Commit message
+            should_remove_source_branch: If True, removes the source
                                                 branch
-            merge_when_pipeline_succeeds (bool): Wait for the build to succeed,
+            merge_when_pipeline_succeeds: Wait for the build to succeed,
                                                  then merge
             **kwargs: Extra options to send to the server (e.g. sudo)
 

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -208,7 +208,7 @@ class ProjectMergeRequest(
             GitlabListError: If the list could not be retrieved
 
         Returns:
-            RESTObjectList: List of issues
+            List of issues
         """
         path = f"{self.manager.path}/{self.get_id()}/closes_issues"
         data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
@@ -235,7 +235,7 @@ class ProjectMergeRequest(
             GitlabListError: If the list could not be retrieved
 
         Returns:
-            RESTObjectList: The list of commits
+            The list of commits
         """
 
         path = f"{self.manager.path}/{self.get_id()}/commits"
@@ -258,7 +258,7 @@ class ProjectMergeRequest(
             GitlabListError: If the list could not be retrieved
 
         Returns:
-            RESTObjectList: List of changes
+            List of changes
         """
         path = f"{self.manager.path}/{self.get_id()}/changes"
         return self.manager.gitlab.http_get(path, **kwargs)

--- a/gitlab/v4/objects/milestones.py
+++ b/gitlab/v4/objects/milestones.py
@@ -30,10 +30,10 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
         """List issues related to this milestone.
 
         Args:
-            all (bool): If True, return all the items, without pagination
-            per_page (int): Number of items to retrieve per request
-            page (int): ID of the page to return (starts with page 1)
-            as_list (bool): If set to False and no pagination option is
+            all: If True, return all the items, without pagination
+            per_page: Number of items to retrieve per request
+            page: ID of the page to return (starts with page 1)
+            as_list: If set to False and no pagination option is
                 defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
@@ -59,10 +59,10 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
         """List the merge requests related to this milestone.
 
         Args:
-            all (bool): If True, return all the items, without pagination
-            per_page (int): Number of items to retrieve per request
-            page (int): ID of the page to return (starts with page 1)
-            as_list (bool): If set to False and no pagination option is
+            all: If True, return all the items, without pagination
+            per_page: Number of items to retrieve per request
+            page: ID of the page to return (starts with page 1)
+            as_list: If set to False and no pagination option is
                 defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
@@ -111,10 +111,10 @@ class ProjectMilestone(PromoteMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
         """List issues related to this milestone.
 
         Args:
-            all (bool): If True, return all the items, without pagination
-            per_page (int): Number of items to retrieve per request
-            page (int): ID of the page to return (starts with page 1)
-            as_list (bool): If set to False and no pagination option is
+            all: If True, return all the items, without pagination
+            per_page: Number of items to retrieve per request
+            page: ID of the page to return (starts with page 1)
+            as_list: If set to False and no pagination option is
                 defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
@@ -140,10 +140,10 @@ class ProjectMilestone(PromoteMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
         """List the merge requests related to this milestone.
 
         Args:
-            all (bool): If True, return all the items, without pagination
-            per_page (int): Number of items to retrieve per request
-            page (int): ID of the page to return (starts with page 1)
-            as_list (bool): If set to False and no pagination option is
+            all: If True, return all the items, without pagination
+            per_page: Number of items to retrieve per request
+            page: ID of the page to return (starts with page 1)
+            as_list: If set to False and no pagination option is
                 defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 

--- a/gitlab/v4/objects/milestones.py
+++ b/gitlab/v4/objects/milestones.py
@@ -42,7 +42,7 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabListError: If the list could not be retrieved
 
         Returns:
-            RESTObjectList: The list of issues
+            The list of issues
         """
 
         path = f"{self.manager.path}/{self.get_id()}/issues"
@@ -71,7 +71,7 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabListError: If the list could not be retrieved
 
         Returns:
-            RESTObjectList: The list of merge requests
+            The list of merge requests
         """
         path = f"{self.manager.path}/{self.get_id()}/merge_requests"
         data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
@@ -123,7 +123,7 @@ class ProjectMilestone(PromoteMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabListError: If the list could not be retrieved
 
         Returns:
-            RESTObjectList: The list of issues
+            The list of issues
         """
 
         path = f"{self.manager.path}/{self.get_id()}/issues"
@@ -152,7 +152,7 @@ class ProjectMilestone(PromoteMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabListError: If the list could not be retrieved
 
         Returns:
-            RESTObjectList: The list of merge requests
+            The list of merge requests
         """
         path = f"{self.manager.path}/{self.get_id()}/merge_requests"
         data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)

--- a/gitlab/v4/objects/packages.py
+++ b/gitlab/v4/objects/packages.py
@@ -65,7 +65,7 @@ class GenericPackageManager(RESTManager):
             GitlabUploadError: If ``filepath`` cannot be read
 
         Returns:
-            GenericPackage: An object storing the metadata of the uploaded package.
+            An object storing the metadata of the uploaded package.
 
         https://docs.gitlab.com/ee/user/packages/generic_packages/
         """
@@ -126,7 +126,7 @@ class GenericPackageManager(RESTManager):
             GitlabGetError: If the server failed to perform the request
 
         Returns:
-            str: The package content if streamed is False, None otherwise
+            The package content if streamed is False, None otherwise
         """
         path = f"{self._computed_path}/{package_name}/{package_version}/{file_name}"
         result = self.gitlab.http_get(path, streamed=streamed, raw=True, **kwargs)

--- a/gitlab/v4/objects/packages.py
+++ b/gitlab/v4/objects/packages.py
@@ -52,12 +52,12 @@ class GenericPackageManager(RESTManager):
         """Upload a file as a generic package.
 
         Args:
-            package_name (str): The package name. Must follow generic package
+            package_name: The package name. Must follow generic package
                                 name regex rules
-            package_version (str): The package version. Must follow semantic
+            package_version: The package version. Must follow semantic
                                 version regex rules
-            file_name (str): The name of the file as uploaded in the registry
-            path (str): The path to a local file to upload
+            file_name: The name of the file as uploaded in the registry
+            path: The path to a local file to upload
 
         Raises:
             GitlabConnectionError: If the server cannot be reached
@@ -110,15 +110,15 @@ class GenericPackageManager(RESTManager):
         """Download a generic package.
 
         Args:
-            package_name (str): The package name.
-            package_version (str): The package version.
-            file_name (str): The name of the file in the registry
-            streamed (bool): If True the data will be processed by chunks of
+            package_name: The package name.
+            package_version: The package version.
+            file_name: The name of the file in the registry
+            streamed: If True the data will be processed by chunks of
                 `chunk_size` and each chunk is passed to `action` for
                 treatment
-            action (callable): Callable responsible of dealing with chunk of
+            action: Callable responsible of dealing with chunk of
                 data
-            chunk_size (int): Size of each chunk
+            chunk_size: Size of each chunk
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:

--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -113,7 +113,7 @@ class ProjectPipelineManager(RetrieveMixin, CreateMixin, DeleteMixin, RESTManage
         """Creates a new object.
 
         Args:
-            data (dict): Parameters to send to the server to create the
+            data: Parameters to send to the server to create the
                          resource
             **kwargs: Extra options to send to the server (e.g. sudo)
 

--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -122,7 +122,7 @@ class ProjectPipelineManager(RetrieveMixin, CreateMixin, DeleteMixin, RESTManage
             GitlabCreateError: If the server cannot perform the request
 
         Returns:
-            RESTObject: A new instance of the managed object class build with
+            A new instance of the managed object class build with
                 the data sent by the server
         """
         if TYPE_CHECKING:

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -190,7 +190,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         """Create a forked from/to relation between existing projects.
 
         Args:
-            forked_from_id (int): The ID of the project that was forked from
+            forked_from_id: The ID of the project that was forked from
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -316,8 +316,8 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         """Share the project with a group.
 
         Args:
-            group_id (int): ID of the group.
-            group_access (int): Access level for the group.
+            group_id: ID of the group.
+            group_access: Access level for the group.
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -338,7 +338,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         """Delete a shared project link within a group.
 
         Args:
-            group_id (int): ID of the group.
+            group_id: ID of the group.
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -363,9 +363,9 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         See https://gitlab.com/help/ci/triggers/README.md#trigger-a-build
 
         Args:
-            ref (str): Commit to build; can be a branch name or a tag
-            token (str): The trigger token
-            variables (dict): Variables passed to the build script
+            ref: Commit to build; can be a branch name or a tag
+            token: The trigger token
+            variables: Variables passed to the build script
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -413,9 +413,9 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             Either ``filedata`` or ``filepath`` *MUST* be specified.
 
         Args:
-            filename (str): The name of the file being uploaded
-            filedata (bytes): The raw data of the file being uploaded
-            filepath (str): The path to a local file to upload (optional)
+            filename: The name of the file being uploaded
+            filedata: The raw data of the file being uploaded
+            filepath: The path to a local file to upload (optional)
 
         Raises:
             GitlabConnectionError: If the server cannot be reached
@@ -462,13 +462,13 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         """Return a snapshot of the repository.
 
         Args:
-            wiki (bool): If True return the wiki repository
-            streamed (bool): If True the data will be processed by chunks of
+            wiki: If True return the wiki repository
+            streamed: If True the data will be processed by chunks of
                 `chunk_size` and each chunk is passed to `action` for
                 treatment.
-            action (callable): Callable responsible of dealing with chunk of
+            action: Callable responsible of dealing with chunk of
                 data
-            chunk_size (int): Size of each chunk
+            chunk_size: Size of each chunk
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -494,8 +494,8 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         """Search the project resources matching the provided string.'
 
         Args:
-            scope (str): Scope of the search
-            search (str): Search string
+            scope: Scope of the search
+            search: Search string
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -530,7 +530,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         """Transfer a project to the given namespace ID
 
         Args:
-            to_namespace (str): ID or path of the namespace to transfer the
+            to_namespace: ID or path of the namespace to transfer the
             project to
             **kwargs: Extra options to send to the server (e.g. sudo)
 
@@ -557,17 +557,17 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         """Get the job artifacts archive from a specific tag or branch.
 
         Args:
-            ref_name (str): Branch or tag name in repository. HEAD or SHA references
+            ref_name: Branch or tag name in repository. HEAD or SHA references
             are not supported.
-            artifact_path (str): Path to a file inside the artifacts archive.
-            job (str): The name of the job.
-            job_token (str): Job token for multi-project pipeline triggers.
-            streamed (bool): If True the data will be processed by chunks of
+            artifact_path: Path to a file inside the artifacts archive.
+            job: The name of the job.
+            job_token: Job token for multi-project pipeline triggers.
+            streamed: If True the data will be processed by chunks of
                 `chunk_size` and each chunk is passed to `action` for
                 treatment
-            action (callable): Callable responsible of dealing with chunk of
+            action: Callable responsible of dealing with chunk of
                 data
-            chunk_size (int): Size of each chunk
+            chunk_size: Size of each chunk
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -600,15 +600,15 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         """Download a single artifact file from a specific tag or branch from within the job’s artifacts archive.
 
         Args:
-            ref_name (str): Branch or tag name in repository. HEAD or SHA references are not supported.
-            artifact_path (str): Path to a file inside the artifacts archive.
-            job (str): The name of the job.
-            streamed (bool): If True the data will be processed by chunks of
+            ref_name: Branch or tag name in repository. HEAD or SHA references are not supported.
+            artifact_path: Path to a file inside the artifacts archive.
+            job: The name of the job.
+            streamed: If True the data will be processed by chunks of
                 `chunk_size` and each chunk is passed to `action` for
                 treatment
-            action (callable): Callable responsible of dealing with chunk of
+            action: Callable responsible of dealing with chunk of
                 data
-            chunk_size (int): Size of each chunk
+            chunk_size: Size of each chunk
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -809,12 +809,12 @@ class ProjectManager(CRUDMixin, RESTManager):
 
         Args:
             file: Data or file object containing the project
-            path (str): Name and path for the new project
-            namespace (str): The ID or path of the namespace that the project
+            path: Name and path for the new project
+            namespace: The ID or path of the namespace that the project
                 will be imported to
-            overwrite (bool): If True overwrite an existing project with the
+            overwrite: If True overwrite an existing project with the
                 same path
-            override_params (dict): Set the specific settings for the project
+            override_params: Set the specific settings for the project
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -861,14 +861,14 @@ class ProjectManager(CRUDMixin, RESTManager):
             A timeout can be specified via kwargs to override this functionality.
 
         Args:
-            bitbucket_server_url (str): Bitbucket Server URL
-            bitbucket_server_username (str): Bitbucket Server Username
-            personal_access_token (str): Bitbucket Server personal access
+            bitbucket_server_url: Bitbucket Server URL
+            bitbucket_server_username: Bitbucket Server Username
+            personal_access_token: Bitbucket Server personal access
                 token/password
-            bitbucket_server_project (str): Bitbucket Project Key
-            bitbucket_server_repo (str): Bitbucket Repository Name
-            new_name (str): New repository name (Optional)
-            target_namespace (str): Namespace to import repository into.
+            bitbucket_server_project: Bitbucket Project Key
+            bitbucket_server_repo: Bitbucket Repository Name
+            new_name: New repository name (Optional)
+            target_namespace: Namespace to import repository into.
                 Supports subgroups like /namespace/subgroup (Optional)
             **kwargs: Extra options to send to the server (e.g. sudo)
 
@@ -949,10 +949,10 @@ class ProjectManager(CRUDMixin, RESTManager):
             A timeout can be specified via kwargs to override this functionality.
 
         Args:
-            personal_access_token (str): GitHub personal access token
-            repo_id (int): Github repository ID
-            target_namespace (str): Namespace to import repo into
-            new_name (str): New repo name (Optional)
+            personal_access_token: GitHub personal access token
+            repo_id: Github repository ID
+            target_namespace: Namespace to import repo into
+            new_name: New repo name (Optional)
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -1031,7 +1031,7 @@ class ProjectForkManager(CreateMixin, ListMixin, RESTManager):
         """Creates a new object.
 
         Args:
-            data (dict): Parameters to send to the server to create the
+            data: Parameters to send to the server to create the
                          resource
             **kwargs: Extra options to send to the server (e.g. sudo)
 

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -426,7 +426,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
                 specified
 
         Returns:
-            dict: A ``dict`` with the keys:
+            A ``dict`` with the keys:
                 * ``alt`` - The alternate text for the upload
                 * ``url`` - The direct url to the uploaded file
                 * ``markdown`` - Markdown for the uploaded file
@@ -476,7 +476,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabGetError: If the content could not be retrieved
 
         Returns:
-            str: The uncompressed tar archive of the repository
+            The uncompressed tar archive of the repository
         """
         path = f"/projects/{self.get_id()}/snapshot"
         result = self.manager.gitlab.http_get(
@@ -503,7 +503,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabSearchError: If the server failed to perform the request
 
         Returns:
-            GitlabList: A list of dicts describing the resources found.
+            A list of dicts describing the resources found.
         """
         data = {"scope": scope, "search": search}
         path = f"/projects/{self.get_id()}/search"
@@ -575,7 +575,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabGetError: If the artifacts could not be retrieved
 
         Returns:
-            str: The artifacts if `streamed` is False, None otherwise.
+            The artifacts if `streamed` is False, None otherwise.
         """
         path = f"/projects/{self.get_id()}/jobs/artifacts/{ref_name}/download"
         result = self.manager.gitlab.http_get(
@@ -616,7 +616,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabGetError: If the artifacts could not be retrieved
 
         Returns:
-            str: The artifacts if `streamed` is False, None otherwise.
+            The artifacts if `streamed` is False, None otherwise.
         """
 
         path = f"/projects/{self.get_id()}/jobs/artifacts/{ref_name}/raw/{artifact_path}?job={job}"
@@ -822,7 +822,7 @@ class ProjectManager(CRUDMixin, RESTManager):
             GitlabListError: If the server failed to perform the request
 
         Returns:
-            dict: A representation of the import status.
+            A representation of the import status.
         """
         files = {"file": ("file.tar.gz", file, "application/octet-stream")}
         data = {"path": path, "overwrite": str(overwrite)}
@@ -877,7 +877,7 @@ class ProjectManager(CRUDMixin, RESTManager):
             GitlabListError: If the server failed to perform the request
 
         Returns:
-            dict: A representation of the import status.
+            A representation of the import status.
 
         Example:
 
@@ -960,7 +960,7 @@ class ProjectManager(CRUDMixin, RESTManager):
             GitlabListError: If the server failed to perform the request
 
         Returns:
-            dict: A representation of the import status.
+            A representation of the import status.
 
         Example:
 
@@ -1040,7 +1040,7 @@ class ProjectForkManager(CreateMixin, ListMixin, RESTManager):
             GitlabCreateError: If the server cannot perform the request
 
         Returns:
-            RESTObject: A new instance of the managed object class build with
+            A new instance of the managed object class build with
                 the data sent by the server
         """
         if TYPE_CHECKING:

--- a/gitlab/v4/objects/repositories.py
+++ b/gitlab/v4/objects/repositories.py
@@ -28,10 +28,10 @@ class RepositoryMixin(_RestObjectBase):
         """Update a project submodule
 
         Args:
-            submodule (str): Full path to the submodule
-            branch (str): Name of the branch to commit into
-            commit_sha (str): Full commit SHA to update the submodule to
-            commit_message (str): Commit message. If no message is provided, a
+            submodule: Full path to the submodule
+            branch: Name of the branch to commit into
+            commit_sha: Full commit SHA to update the submodule to
+            commit_message: Commit message. If no message is provided, a
                 default one will be set (optional)
 
         Raises:
@@ -54,13 +54,13 @@ class RepositoryMixin(_RestObjectBase):
         """Return a list of files in the repository.
 
         Args:
-            path (str): Path of the top folder (/ by default)
-            ref (str): Reference to a commit or branch
-            recursive (bool): Whether to get the tree recursively
-            all (bool): If True, return all the items, without pagination
-            per_page (int): Number of items to retrieve per request
-            page (int): ID of the page to return (starts with page 1)
-            as_list (bool): If set to False and no pagination option is
+            path: Path of the top folder (/ by default)
+            ref: Reference to a commit or branch
+            recursive: Whether to get the tree recursively
+            all: If True, return all the items, without pagination
+            per_page: Number of items to retrieve per request
+            page: ID of the page to return (starts with page 1)
+            as_list: If set to False and no pagination option is
                 defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
@@ -87,7 +87,7 @@ class RepositoryMixin(_RestObjectBase):
         """Return a file by blob SHA.
 
         Args:
-            sha(str): ID of the blob
+            sha: ID of the blob
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -114,13 +114,13 @@ class RepositoryMixin(_RestObjectBase):
         """Return the raw file contents for a blob.
 
         Args:
-            sha(str): ID of the blob
-            streamed (bool): If True the data will be processed by chunks of
+            sha: ID of the blob
+            streamed: If True the data will be processed by chunks of
                 `chunk_size` and each chunk is passed to `action` for
                 treatment
-            action (callable): Callable responsible of dealing with chunk of
+            action: Callable responsible of dealing with chunk of
                 data
-            chunk_size (int): Size of each chunk
+            chunk_size: Size of each chunk
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -146,8 +146,8 @@ class RepositoryMixin(_RestObjectBase):
         """Return a diff between two branches/commits.
 
         Args:
-            from_(str): Source branch/SHA
-            to(str): Destination branch/SHA
+            from_: Source branch/SHA
+            to: Destination branch/SHA
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -169,10 +169,10 @@ class RepositoryMixin(_RestObjectBase):
         """Return a list of contributors for the project.
 
         Args:
-            all (bool): If True, return all the items, without pagination
-            per_page (int): Number of items to retrieve per request
-            page (int): ID of the page to return (starts with page 1)
-            as_list (bool): If set to False and no pagination option is
+            all: If True, return all the items, without pagination
+            per_page: Number of items to retrieve per request
+            page: ID of the page to return (starts with page 1)
+            as_list: If set to False and no pagination option is
                 defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
@@ -199,13 +199,13 @@ class RepositoryMixin(_RestObjectBase):
         """Return a tarball of the repository.
 
         Args:
-            sha (str): ID of the commit (default branch by default)
-            streamed (bool): If True the data will be processed by chunks of
+            sha: ID of the commit (default branch by default)
+            streamed: If True the data will be processed by chunks of
                 `chunk_size` and each chunk is passed to `action` for
                 treatment
-            action (callable): Callable responsible of dealing with chunk of
+            action: Callable responsible of dealing with chunk of
                 data
-            chunk_size (int): Size of each chunk
+            chunk_size: Size of each chunk
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:

--- a/gitlab/v4/objects/repositories.py
+++ b/gitlab/v4/objects/repositories.py
@@ -69,7 +69,7 @@ class RepositoryMixin(_RestObjectBase):
             GitlabGetError: If the server failed to perform the request
 
         Returns:
-            list: The representation of the tree
+            The representation of the tree
         """
         gl_path = f"/projects/{self.get_id()}/repository/tree"
         query_data: Dict[str, Any] = {"recursive": recursive}
@@ -95,7 +95,7 @@ class RepositoryMixin(_RestObjectBase):
             GitlabGetError: If the server failed to perform the request
 
         Returns:
-            dict: The blob content and metadata
+            The blob content and metadata
         """
 
         path = f"/projects/{self.get_id()}/repository/blobs/{sha}"
@@ -128,7 +128,7 @@ class RepositoryMixin(_RestObjectBase):
             GitlabGetError: If the server failed to perform the request
 
         Returns:
-            str: The blob content if streamed is False, None otherwise
+            The blob content if streamed is False, None otherwise
         """
         path = f"/projects/{self.get_id()}/repository/blobs/{sha}/raw"
         result = self.manager.gitlab.http_get(
@@ -155,7 +155,7 @@ class RepositoryMixin(_RestObjectBase):
             GitlabGetError: If the server failed to perform the request
 
         Returns:
-            str: The diff
+            The diff
         """
         path = f"/projects/{self.get_id()}/repository/compare"
         query_data = {"from": from_, "to": to}
@@ -181,7 +181,7 @@ class RepositoryMixin(_RestObjectBase):
             GitlabGetError: If the server failed to perform the request
 
         Returns:
-            list: The contributors
+            The contributors
         """
         path = f"/projects/{self.get_id()}/repository/contributors"
         return self.manager.gitlab.http_list(path, **kwargs)
@@ -213,7 +213,7 @@ class RepositoryMixin(_RestObjectBase):
             GitlabListError: If the server failed to perform the request
 
         Returns:
-            bytes: The binary data of the archive
+            The binary data of the archive
         """
         path = f"/projects/{self.get_id()}/repository/archive"
         query_data = {}

--- a/gitlab/v4/objects/runners.py
+++ b/gitlab/v4/objects/runners.py
@@ -76,12 +76,12 @@ class RunnerManager(CRUDMixin, RESTManager):
         """List all the runners.
 
         Args:
-            scope (str): The scope of runners to show, one of: specific,
+            scope: The scope of runners to show, one of: specific,
                 shared, active, paused, online
-            all (bool): If True, return all the items, without pagination
-            per_page (int): Number of items to retrieve per request
-            page (int): ID of the page to return (starts with page 1)
-            as_list (bool): If set to False and no pagination option is
+            all: If True, return all the items, without pagination
+            per_page: Number of items to retrieve per request
+            page: ID of the page to return (starts with page 1)
+            as_list: If set to False and no pagination option is
                 defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
@@ -90,7 +90,7 @@ class RunnerManager(CRUDMixin, RESTManager):
             GitlabListError: If the server failed to perform the request
 
         Returns:
-            list(Runner): a list of runners matching the scope.
+            A list of runners matching the scope.
         """
         path = "/runners/all"
         query_data = {}
@@ -105,7 +105,7 @@ class RunnerManager(CRUDMixin, RESTManager):
         """Validates authentication credentials for a registered Runner.
 
         Args:
-            token (str): The runner's authentication token
+            token: The runner's authentication token
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:

--- a/gitlab/v4/objects/services.py
+++ b/gitlab/v4/objects/services.py
@@ -268,7 +268,7 @@ class ProjectServiceManager(GetMixin, UpdateMixin, DeleteMixin, ListMixin, RESTM
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
-            object: The generated RESTObject.
+            The generated RESTObject.
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct
@@ -292,7 +292,7 @@ class ProjectServiceManager(GetMixin, UpdateMixin, DeleteMixin, ListMixin, RESTM
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
-            dict: The new object data (*not* a RESTObject)
+            The new object data (*not* a RESTObject)
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct
@@ -308,6 +308,6 @@ class ProjectServiceManager(GetMixin, UpdateMixin, DeleteMixin, ListMixin, RESTM
         """List the services known by python-gitlab.
 
         Returns:
-            list: The list of service code names.
+            The list of service code names.
         """
         return list(self._service_attrs.keys())

--- a/gitlab/v4/objects/services.py
+++ b/gitlab/v4/objects/services.py
@@ -261,8 +261,8 @@ class ProjectServiceManager(GetMixin, UpdateMixin, DeleteMixin, ListMixin, RESTM
         """Retrieve a single object.
 
         Args:
-            id (int or str): ID of the object to retrieve
-            lazy (bool): If True, don't request the server, but create a
+            id: ID of the object to retrieve
+            lazy: If True, don't request the server, but create a
                          shallow object giving access to the managers. This is
                          useful if you want to avoid useless calls to the API.
             **kwargs: Extra options to send to the server (e.g. sudo)
@@ -308,6 +308,6 @@ class ProjectServiceManager(GetMixin, UpdateMixin, DeleteMixin, ListMixin, RESTM
         """List the services known by python-gitlab.
 
         Returns:
-            list (str): The list of service code names.
+            list: The list of service code names.
         """
         return list(self._service_attrs.keys())

--- a/gitlab/v4/objects/settings.py
+++ b/gitlab/v4/objects/settings.py
@@ -103,7 +103,7 @@ class ApplicationSettingsManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
-            dict: The new object data (*not* a RESTObject)
+            The new object data (*not* a RESTObject)
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct

--- a/gitlab/v4/objects/sidekiq.py
+++ b/gitlab/v4/objects/sidekiq.py
@@ -31,7 +31,7 @@ class SidekiqManager(RESTManager):
             GitlabGetError: If the information couldn't be retrieved
 
         Returns:
-            dict: Information about the Sidekiq queues
+            Information about the Sidekiq queues
         """
         return self.gitlab.http_get("/sidekiq/queue_metrics", **kwargs)
 
@@ -50,7 +50,7 @@ class SidekiqManager(RESTManager):
             GitlabGetError: If the information couldn't be retrieved
 
         Returns:
-            dict: Information about the register Sidekiq worker
+            Information about the register Sidekiq worker
         """
         return self.gitlab.http_get("/sidekiq/process_metrics", **kwargs)
 
@@ -67,7 +67,7 @@ class SidekiqManager(RESTManager):
             GitlabGetError: If the information couldn't be retrieved
 
         Returns:
-            dict: Statistics about the Sidekiq jobs performed
+            Statistics about the Sidekiq jobs performed
         """
         return self.gitlab.http_get("/sidekiq/job_stats", **kwargs)
 
@@ -86,6 +86,6 @@ class SidekiqManager(RESTManager):
             GitlabGetError: If the information couldn't be retrieved
 
         Returns:
-            dict: All available Sidekiq metrics and statistics
+            All available Sidekiq metrics and statistics
         """
         return self.gitlab.http_get("/sidekiq/compound_metrics", **kwargs)

--- a/gitlab/v4/objects/snippets.py
+++ b/gitlab/v4/objects/snippets.py
@@ -48,7 +48,7 @@ class Snippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabGetError: If the content could not be retrieved
 
         Returns:
-            str: The snippet content
+            The snippet content
         """
         path = f"/snippets/{self.get_id()}/raw"
         result = self.manager.gitlab.http_get(
@@ -81,7 +81,7 @@ class SnippetManager(CRUDMixin, RESTManager):
             GitlabListError: If the list could not be retrieved
 
         Returns:
-            RESTObjectList: A generator for the snippets list
+            A generator for the snippets list
         """
         return self.list(path="/snippets/public", **kwargs)
 
@@ -122,7 +122,7 @@ class ProjectSnippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObj
             GitlabGetError: If the content could not be retrieved
 
         Returns:
-            str: The snippet content
+            The snippet content
         """
         path = f"{self.manager.path}/{self.get_id()}/raw"
         result = self.manager.gitlab.http_get(

--- a/gitlab/v4/objects/snippets.py
+++ b/gitlab/v4/objects/snippets.py
@@ -35,12 +35,12 @@ class Snippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
         """Return the content of a snippet.
 
         Args:
-            streamed (bool): If True the data will be processed by chunks of
+            streamed: If True the data will be processed by chunks of
                 `chunk_size` and each chunk is passed to `action` for
                 treatment.
-            action (callable): Callable responsible of dealing with chunk of
+            action: Callable responsible of dealing with chunk of
                 data
-            chunk_size (int): Size of each chunk
+            chunk_size: Size of each chunk
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -74,7 +74,7 @@ class SnippetManager(CRUDMixin, RESTManager):
         """List all the public snippets.
 
         Args:
-            all (bool): If True the returned object will be a list
+            all: If True the returned object will be a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -109,12 +109,12 @@ class ProjectSnippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObj
         """Return the content of a snippet.
 
         Args:
-            streamed (bool): If True the data will be processed by chunks of
+            streamed: If True the data will be processed by chunks of
                 `chunk_size` and each chunk is passed to `action` for
                 treatment.
-            action (callable): Callable responsible of dealing with chunk of
+            action: Callable responsible of dealing with chunk of
                 data
-            chunk_size (int): Size of each chunk
+            chunk_size: Size of each chunk
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:

--- a/gitlab/v4/objects/todos.py
+++ b/gitlab/v4/objects/todos.py
@@ -53,6 +53,6 @@ class TodoManager(ListMixin, DeleteMixin, RESTManager):
             GitlabTodoError: If the server failed to perform the request
 
         Returns:
-            int: The number of todos marked done
+            The number of todos marked done
         """
         self.gitlab.http_post("/todos/mark_as_done", **kwargs)

--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -167,7 +167,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabBlockError: If the user could not be blocked
 
         Returns:
-            bool: Whether the user status has been changed
+            Whether the user status has been changed
         """
         path = f"/users/{self.id}/block"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
@@ -188,7 +188,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabFollowError: If the user could not be followed
 
         Returns:
-            dict: The new object data (*not* a RESTObject)
+            The new object data (*not* a RESTObject)
         """
         path = f"/users/{self.id}/follow"
         return self.manager.gitlab.http_post(path, **kwargs)
@@ -206,7 +206,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabUnfollowError: If the user could not be followed
 
         Returns:
-            dict: The new object data (*not* a RESTObject)
+            The new object data (*not* a RESTObject)
         """
         path = f"/users/{self.id}/unfollow"
         return self.manager.gitlab.http_post(path, **kwargs)
@@ -224,7 +224,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabUnblockError: If the user could not be unblocked
 
         Returns:
-            bool: Whether the user status has been changed
+            Whether the user status has been changed
         """
         path = f"/users/{self.id}/unblock"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
@@ -245,7 +245,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabDeactivateError: If the user could not be deactivated
 
         Returns:
-            bool: Whether the user status has been changed
+            Whether the user status has been changed
         """
         path = f"/users/{self.id}/deactivate"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
@@ -266,7 +266,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabActivateError: If the user could not be activated
 
         Returns:
-            bool: Whether the user status has been changed
+            Whether the user status has been changed
         """
         path = f"/users/{self.id}/activate"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
@@ -528,7 +528,7 @@ class UserProjectManager(ListMixin, CreateMixin, RESTManager):
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
-            list: The list of objects, or a generator if `as_list` is False
+            The list of objects, or a generator if `as_list` is False
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct

--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -520,10 +520,10 @@ class UserProjectManager(ListMixin, CreateMixin, RESTManager):
         """Retrieve a list of objects.
 
         Args:
-            all (bool): If True, return all the items, without pagination
-            per_page (int): Number of items to retrieve per request
-            page (int): ID of the page to return (starts with page 1)
-            as_list (bool): If set to False and no pagination option is
+            all: If True, return all the items, without pagination
+            per_page: Number of items to retrieve per request
+            page: ID of the page to return (starts with page 1)
+            as_list: If set to False and no pagination option is
                 defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,3 +4,4 @@ myst-parser
 sphinx==4.3.1
 sphinx_rtd_theme
 sphinxcontrib-autoprogram
+sphinx-autodoc-typehints==1.12.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,4 +4,3 @@ myst-parser
 sphinx==4.3.1
 sphinx_rtd_theme
 sphinxcontrib-autoprogram
-sphinx-autodoc-typehints==1.12.0


### PR DESCRIPTION
We probably still have a lot of incorrect types in the docstrings and this should just take care of it in the future.

| Before | After |
|--------|------|
| ![image](https://user-images.githubusercontent.com/16777978/143305396-c7c0b0fc-f50b-4a22-a8cc-10c3e27ac9b9.png) | ![image](https://user-images.githubusercontent.com/16777978/143305458-b54324ff-d0ef-4a2f-9332-6ab3321c4eed.png) |

Clashes with the internal extension though so needs more work