### PR TITLE
chore: add get() methods for GetWithoutIdMixin based classes

### DIFF
--- a/gitlab/v4/objects/appearance.py
+++ b/gitlab/v4/objects/appearance.py
@@ -61,4 +61,4 @@ class ApplicationAppearanceManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
     ) -> Optional[ApplicationAppearance]:
-        return cast(ApplicationAppearance, super().get(id=id, **kwargs))
+        return cast(Optional[ApplicationAppearance], super().get(id=id, **kwargs))

--- a/gitlab/v4/objects/export_import.py
+++ b/gitlab/v4/objects/export_import.py
@@ -27,7 +27,7 @@ class GroupExportManager(GetWithoutIdMixin, CreateMixin, RESTManager):
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
     ) -> Optional[GroupExport]:
-        return cast(GroupExport, super().get(id=id, **kwargs))
+        return cast(Optional[GroupExport], super().get(id=id, **kwargs))
 
 
 class GroupImport(RESTObject):
@@ -42,7 +42,7 @@ class GroupImportManager(GetWithoutIdMixin, RESTManager):
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
     ) -> Optional[GroupImport]:
-        return cast(GroupImport, super().get(id=id, **kwargs))
+        return cast(Optional[GroupImport], super().get(id=id, **kwargs))
 
 
 class ProjectExport(DownloadMixin, RefreshMixin, RESTObject):
@@ -58,7 +58,7 @@ class ProjectExportManager(GetWithoutIdMixin, CreateMixin, RESTManager):
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
     ) -> Optional[ProjectExport]:
-        return cast(ProjectExport, super().get(id=id, **kwargs))
+        return cast(Optional[ProjectExport], super().get(id=id, **kwargs))
 
 
 class ProjectImport(RefreshMixin, RESTObject):
@@ -73,4 +73,4 @@ class ProjectImportManager(GetWithoutIdMixin, RESTManager):
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
     ) -> Optional[ProjectImport]:
-        return cast(ProjectImport, super().get(id=id, **kwargs))
+        return cast(Optional[ProjectImport], super().get(id=id, **kwargs))

--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, cast, Dict, List, Optional, TYPE_CHECKING, Union
 
 from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
@@ -44,6 +44,11 @@ class ProjectApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
         ),
     )
     _update_uses_post = True
+
+    def get(
+        self, id: Optional[Union[int, str]] = None, **kwargs: Any
+    ) -> Optional[ProjectApproval]:
+        return cast(Optional[ProjectApproval], super().get(id=id, **kwargs))
 
     @exc.on_http_error(exc.GitlabUpdateError)
     def set_approvers(
@@ -104,6 +109,11 @@ class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTMan
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}
     _update_attrs = RequiredOptional(required=("approvals_required",))
     _update_uses_post = True
+
+    def get(
+        self, id: Optional[Union[int, str]] = None, **kwargs: Any
+    ) -> Optional[ProjectMergeRequestApproval]:
+        return cast(Optional[ProjectMergeRequestApproval], super().get(id=id, **kwargs))
 
     @exc.on_http_error(exc.GitlabUpdateError)
     def set_approvers(
@@ -241,3 +251,10 @@ class ProjectMergeRequestApprovalStateManager(GetWithoutIdMixin, RESTManager):
     _path = "/projects/{project_id}/merge_requests/{mr_iid}/approval_state"
     _obj_cls = ProjectMergeRequestApprovalState
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}
+
+    def get(
+        self, id: Optional[Union[int, str]] = None, **kwargs: Any
+    ) -> Optional[ProjectMergeRequestApprovalState]:
+        return cast(
+            Optional[ProjectMergeRequestApprovalState], super().get(id=id, **kwargs)
+        )

--- a/gitlab/v4/objects/notification_settings.py
+++ b/gitlab/v4/objects/notification_settings.py
@@ -1,3 +1,5 @@
+from typing import Any, cast, Optional, Union
+
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
 from gitlab.mixins import GetWithoutIdMixin, SaveMixin, UpdateMixin
 
@@ -36,6 +38,11 @@ class NotificationSettingsManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
         ),
     )
 
+    def get(
+        self, id: Optional[Union[int, str]] = None, **kwargs: Any
+    ) -> Optional[NotificationSettings]:
+        return cast(Optional[NotificationSettings], super().get(id=id, **kwargs))
+
 
 class GroupNotificationSettings(NotificationSettings):
     pass
@@ -46,6 +53,11 @@ class GroupNotificationSettingsManager(NotificationSettingsManager):
     _obj_cls = GroupNotificationSettings
     _from_parent_attrs = {"group_id": "id"}
 
+    def get(
+        self, id: Optional[Union[int, str]] = None, **kwargs: Any
+    ) -> Optional[GroupNotificationSettings]:
+        return cast(Optional[GroupNotificationSettings], super().get(id=id, **kwargs))
+
 
 class ProjectNotificationSettings(NotificationSettings):
     pass
@@ -55,3 +67,8 @@ class ProjectNotificationSettingsManager(NotificationSettingsManager):
     _path = "/projects/{project_id}/notification_settings"
     _obj_cls = ProjectNotificationSettings
     _from_parent_attrs = {"project_id": "id"}
+
+    def get(
+        self, id: Optional[Union[int, str]] = None, **kwargs: Any
+    ) -> Optional[ProjectNotificationSettings]:
+        return cast(Optional[ProjectNotificationSettings], super().get(id=id, **kwargs))

--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -246,3 +246,8 @@ class ProjectPipelineTestReportManager(GetWithoutIdMixin, RESTManager):
     _path = "/projects/{project_id}/pipelines/{pipeline_id}/test_report"
     _obj_cls = ProjectPipelineTestReport
     _from_parent_attrs = {"project_id": "project_id", "pipeline_id": "id"}
+
+    def get(
+        self, id: Optional[Union[int, str]] = None, **kwargs: Any
+    ) -> Optional[ProjectPipelineTestReport]:
+        return cast(Optional[ProjectPipelineTestReport], super().get(id=id, **kwargs))

--- a/gitlab/v4/objects/push_rules.py
+++ b/gitlab/v4/objects/push_rules.py
@@ -54,4 +54,4 @@ class ProjectPushRulesManager(
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
     ) -> Optional[ProjectPushRules]:
-        return cast(ProjectPushRules, super().get(id=id, **kwargs))
+        return cast(Optional[ProjectPushRules], super().get(id=id, **kwargs))

--- a/gitlab/v4/objects/settings.py
+++ b/gitlab/v4/objects/settings.py
@@ -118,4 +118,4 @@ class ApplicationSettingsManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
     ) -> Optional[ApplicationSettings]:
-        return cast(ApplicationSettings, super().get(id=id, **kwargs))
+        return cast(Optional[ApplicationSettings], super().get(id=id, **kwargs))

--- a/gitlab/v4/objects/statistics.py
+++ b/gitlab/v4/objects/statistics.py
@@ -1,3 +1,5 @@
+from typing import Any, cast, Optional, Union
+
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import GetWithoutIdMixin, RefreshMixin
 
@@ -22,6 +24,11 @@ class ProjectAdditionalStatisticsManager(GetWithoutIdMixin, RESTManager):
     _obj_cls = ProjectAdditionalStatistics
     _from_parent_attrs = {"project_id": "id"}
 
+    def get(
+        self, id: Optional[Union[int, str]] = None, **kwargs: Any
+    ) -> Optional[ProjectAdditionalStatistics]:
+        return cast(Optional[ProjectAdditionalStatistics], super().get(id=id, **kwargs))
+
 
 class IssuesStatistics(RefreshMixin, RESTObject):
     _id_attr = None
@@ -30,6 +37,11 @@ class IssuesStatistics(RefreshMixin, RESTObject):
 class IssuesStatisticsManager(GetWithoutIdMixin, RESTManager):
     _path = "/issues_statistics"
     _obj_cls = IssuesStatistics
+
+    def get(
+        self, id: Optional[Union[int, str]] = None, **kwargs: Any
+    ) -> Optional[IssuesStatistics]:
+        return cast(Optional[IssuesStatistics], super().get(id=id, **kwargs))
 
 
 class GroupIssuesStatistics(RefreshMixin, RESTObject):
@@ -41,6 +53,11 @@ class GroupIssuesStatisticsManager(GetWithoutIdMixin, RESTManager):
     _obj_cls = GroupIssuesStatistics
     _from_parent_attrs = {"group_id": "id"}
 
+    def get(
+        self, id: Optional[Union[int, str]] = None, **kwargs: Any
+    ) -> Optional[GroupIssuesStatistics]:
+        return cast(Optional[GroupIssuesStatistics], super().get(id=id, **kwargs))
+
 
 class ProjectIssuesStatistics(RefreshMixin, RESTObject):
     _id_attr = None
@@ -50,3 +67,8 @@ class ProjectIssuesStatisticsManager(GetWithoutIdMixin, RESTManager):
     _path = "/projects/{project_id}/issues_statistics"
     _obj_cls = ProjectIssuesStatistics
     _from_parent_attrs = {"project_id": "id"}
+
+    def get(
+        self, id: Optional[Union[int, str]] = None, **kwargs: Any
+    ) -> Optional[ProjectIssuesStatistics]:
+        return cast(Optional[ProjectIssuesStatistics], super().get(id=id, **kwargs))

--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -3,7 +3,7 @@ GitLab API:
 https://docs.gitlab.com/ee/api/users.html
 https://docs.gitlab.com/ee/api/projects.html#list-projects-starred-by-a-user
 """
-from typing import Any, cast, Dict, List, Union
+from typing import Any, cast, Dict, List, Optional, Union
 
 import requests
 
@@ -120,6 +120,11 @@ class CurrentUserStatusManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
     _obj_cls = CurrentUserStatus
     _update_attrs = RequiredOptional(optional=("emoji", "message"))
 
+    def get(
+        self, id: Optional[Union[int, str]] = None, **kwargs: Any
+    ) -> Optional[CurrentUserStatus]:
+        return cast(Optional[CurrentUserStatus], super().get(id=id, **kwargs))
+
 
 class CurrentUser(RESTObject):
     _id_attr = None
@@ -134,6 +139,11 @@ class CurrentUser(RESTObject):
 class CurrentUserManager(GetWithoutIdMixin, RESTManager):
     _path = "/user"
     _obj_cls = CurrentUser
+
+    def get(
+        self, id: Optional[Union[int, str]] = None, **kwargs: Any
+    ) -> Optional[CurrentUser]:
+        return cast(Optional[CurrentUser], super().get(id=id, **kwargs))
 
 
 class User(SaveMixin, ObjectDeleteMixin, RESTObject):
@@ -389,6 +399,11 @@ class UserStatusManager(GetWithoutIdMixin, RESTManager):
     _path = "/users/{user_id}/status"
     _obj_cls = UserStatus
     _from_parent_attrs = {"user_id": "id"}
+
+    def get(
+        self, id: Optional[Union[int, str]] = None, **kwargs: Any
+    ) -> Optional[UserStatus]:
+        return cast(Optional[UserStatus], super().get(id=id, **kwargs))
 
 
 class UserActivitiesManager(ListMixin, RESTManager):


### PR DESCRIPTION
Add the get() methods for the GetWithoutIdMixin based classes.

Update the tests/meta/test_ensure_type_hints.py tests to check to
ensure that the get methods are defined with the correct return type.