### PR TITLE
chore: remove pytest-console-scripts specific config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -84,13 +84,10 @@ exclude_lines =
   if TYPE_CHECKING:
   if debug:
 
-[pytest]
-script_launch_mode = subprocess
-
 [testenv:cli_func_v4]
 deps = -r{toxinidir}/requirements-docker.txt
 commands =
-  pytest --cov --cov-report xml tests/functional/cli {posargs}
+  pytest --script-launch-mode=subprocess --cov --cov-report xml tests/functional/cli {posargs}
 
 [testenv:py_func_v4]
 deps = -r{toxinidir}/requirements-docker.txt


### PR DESCRIPTION
Remove the pytest-console-scripts specific config from the global
'[pytest]' config section.

Move it to a command line option for the functional tests which use
the Docker container.

Closes #1713