### PR TITLE
feat: add support for `projects.groups.list()`

### DIFF
--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -92,6 +92,11 @@ Create a project in a group::
     group_id = gl.groups.list(search='my-group')[0].id
     project = gl.projects.create({'name': 'myrepo', 'namespace_id': group_id})
 
+List a project's groups::
+
+    # Get a list of ancestor/parent groups for a project.
+    groups = project.groups.list()
+
 Update a project::
 
     project.snippets_enabled = 1

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -109,6 +109,24 @@ class GroupProjectManager(ListMixin, RESTManager):
     )
 
 
+class ProjectGroup(RESTObject):
+    pass
+
+
+class ProjectGroupManager(ListMixin, RESTManager):
+    _path = "/projects/{project_id}/groups"
+    _obj_cls = ProjectGroup
+    _from_parent_attrs = {"project_id": "id"}
+    _list_filters = (
+        "search",
+        "skip_groups",
+        "with_shared",
+        "shared_min_access_level",
+        "shared_visible_only",
+    )
+    _types = {"skip_groups": types.ListAttribute}
+
+
 class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTObject):
     _short_print_attr = "path"
 
@@ -132,6 +150,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
     files: ProjectFileManager
     forks: "ProjectForkManager"
     generic_packages: GenericPackageManager
+    groups: ProjectGroupManager
     hooks: ProjectHookManager
     imports: ProjectImportManager
     issues: ProjectIssueManager

--- a/tests/functional/api/test_projects.py
+++ b/tests/functional/api/test_projects.py
@@ -311,3 +311,21 @@ def test_project_wiki(project):
     wiki.save()
     wiki.delete()
     assert len(project.wikis.list()) == 0
+
+
+def test_project_groups_list(gl, group):
+    """Test listing groups of a project"""
+    # Create a subgroup of our top-group, we will place our new project inside
+    # this group.
+    group2 = gl.groups.create(
+        {"name": "group2_proj", "path": "group2_proj", "parent_id": group.id}
+    )
+    data = {
+        "name": "test-project-tpsg",
+        "namespace_id": group2.id,
+    }
+    project = gl.projects.create(data)
+
+    groups = project.groups.list()
+    group_ids = set([x.id for x in groups])
+    assert set((group.id, group2.id)) == group_ids


### PR DESCRIPTION
Add support for `projects.groups.list()` endpoint.

Closes https://github.com/python-gitlab/python-gitlab/issues/1590