### PR TITLE
Document that branch listing defaults to only returning 20 by default.

### DIFF
--- a/docs/gl_objects/branches.rst
+++ b/docs/gl_objects/branches.rst
@@ -15,10 +15,15 @@ References
 
 Examples
 --------
+Branch listing uses the base ListMixin class which provides pagination.
 
-Get the list of branches for a repository::
+Get a list of branches for a repository (Limited to 20 branches in a pagination response)::
 
     branches = project.branches.list()
+    
+Get a list of ALL branches for a repository::
+
+    branches = project.branches.list(all=True)    
 
 Get a single repository branch::
 


### PR DESCRIPTION
The documentation does not mention that by default only 20 branches are returned in a response. You must pass in `all=True` if you want to receive all branches for a repo.