### PR TITLE
chore: add Python 3.11 testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,8 @@ jobs:
             toxenv: py39
           - version: "3.10"
             toxenv: py310,smoke
+          - version: '3.11.0-alpha - 3.11' # SemVer's version range syntax
+            toxenv: py311,smoke
         include:
           - os: macos-latest
             python:


### PR DESCRIPTION
Add a unit test for Python 3.11. This will use the latest version of
Python 3.11 that is available from
https://github.com/actions/python-versions/

At this time it is 3.11.0-alpha.2 but will move forward over time
until the final 3.11 release and updates. So 3.11.0, 3.11.1, ... will
be matched.
