### PR TITLE
docs(project): remove redundant encoding parameter

### DIFF
--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -372,7 +372,6 @@ Create a new file::
                               'content': file_content,
                               'author_email': 'test@example.com',
                               'author_name': 'yourname',
-                              'encoding': 'text',
                               'commit_message': 'Create testfile'})
 
 Update a file. The entire content must be uploaded, as plain text or as base64


### PR DESCRIPTION
This closes #1751 

Removing encoding parameter as - default is text which means you don't have to specify that parameter itself when you are creating a text file.