### PR TITLE
chore: add .env as a file that search tools should not ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ venv/
 # Include tracked hidden files and directories in search and diff tools
 !.commitlintrc.json
 !.dockerignore
+!.env
 !.github/
 !.gitignore
 !.gitlab-ci.yml


### PR DESCRIPTION
The `.env` file was not set as a file that should not be ignored by
search tools. We want to have the search tools search any `.env`
files.