### PR TITLE
fix: stop encoding '.' to '%2E'

### DIFF
--- a/gitlab/utils.py
+++ b/gitlab/utils.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from typing import Any, Callable, Dict, Optional
-from urllib.parse import quote, urlparse
+from urllib.parse import quote
 
 import requests
 
@@ -58,12 +58,6 @@ def copy_dict(dest: Dict[str, Any], src: Dict[str, Any]) -> None:
 
 def clean_str_id(id: str) -> str:
     return quote(id, safe="")
-
-
-def sanitized_url(url: str) -> str:
-    parsed = urlparse(url)
-    new_path = parsed.path.replace(".", "%2E")
-    return parsed._replace(path=new_path).geturl()
 
 
 def remove_none_from_dict(data: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/unit/objects/test_packages.py
+++ b/tests/unit/objects/test_packages.py
@@ -2,7 +2,6 @@
 GitLab API: https://docs.gitlab.com/ce/api/packages.html
 """
 import re
-from urllib.parse import quote_plus
 
 import pytest
 import responses
@@ -109,10 +108,9 @@ package_version = "v1.0.0"
 file_name = "hello.tar.gz"
 file_content = "package content"
 package_url = "http://localhost/api/v4/projects/1/packages/generic/{}/{}/{}".format(
-    # https://datatracker.ietf.org/doc/html/rfc3986.html#section-2.3 :(
-    quote_plus(package_name).replace(".", "%2E"),
-    quote_plus(package_version).replace(".", "%2E"),
-    quote_plus(file_name).replace(".", "%2E"),
+    package_name,
+    package_version,
+    file_name,
 )
 
 

--- a/tests/unit/objects/test_releases.py
+++ b/tests/unit/objects/test_releases.py
@@ -11,13 +11,12 @@ import responses
 from gitlab.v4.objects import ProjectReleaseLink
 
 tag_name = "v1.0.0"
-encoded_tag_name = "v1%2E0%2E0"
 release_name = "demo-release"
 release_description = "my-rel-desc"
 released_at = "2019-03-15T08:00:00Z"
 link_name = "hello-world"
 link_url = "https://gitlab.example.com/group/hello/-/jobs/688/artifacts/raw/bin/hello-darwin-amd64"
-direct_url = f"https://gitlab.example.com/group/hello/-/releases/{encoded_tag_name}/downloads/hello-world"
+direct_url = f"https://gitlab.example.com/group/hello/-/releases/{tag_name}/downloads/hello-world"
 new_link_type = "package"
 link_content = {
     "id": 2,
@@ -37,14 +36,12 @@ release_content = {
     "released_at": released_at,
 }
 
-release_url = re.compile(
-    rf"http://localhost/api/v4/projects/1/releases/{encoded_tag_name}"
-)
+release_url = re.compile(rf"http://localhost/api/v4/projects/1/releases/{tag_name}")
 links_url = re.compile(
-    rf"http://localhost/api/v4/projects/1/releases/{encoded_tag_name}/assets/links"
+    rf"http://localhost/api/v4/projects/1/releases/{tag_name}/assets/links"
 )
 link_id_url = re.compile(
-    rf"http://localhost/api/v4/projects/1/releases/{encoded_tag_name}/assets/links/1"
+    rf"http://localhost/api/v4/projects/1/releases/{tag_name}/assets/links/1"
 )
 
 

--- a/tests/unit/objects/test_repositories.py
+++ b/tests/unit/objects/test_repositories.py
@@ -29,8 +29,7 @@ def resp_get_repository_file():
         "last_commit_id": "570e7b2abdd848b95f2f578043fc23bd6f6fd24d",
     }
 
-    # requests also encodes `.`
-    encoded_path = quote(file_path, safe="").replace(".", "%2E")
+    encoded_path = quote(file_path, safe="")
 
     with responses.RequestsMock() as rsps:
         rsps.add(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -30,13 +30,3 @@ def test_clean_str_id():
     src = "foo%bar/baz/"
     dest = "foo%25bar%2Fbaz%2F"
     assert dest == utils.clean_str_id(src)
-
-
-def test_sanitized_url():
-    src = "http://localhost/foo/bar"
-    dest = "http://localhost/foo/bar"
-    assert dest == utils.sanitized_url(src)
-
-    src = "http://localhost/foo.bar.baz"
-    dest = "http://localhost/foo%2Ebar%2Ebaz"
-    assert dest == utils.sanitized_url(src)


### PR DESCRIPTION
Forcing the encoding of '.' to '%2E' causes issues. It also goes
against the RFC:
https://datatracker.ietf.org/doc/html/rfc3986.html#section-2.3

From the RFC:
  For consistency, percent-encoded octets in the ranges of ALPHA
  (%41-%5A and %61-%7A), DIGIT (%30-%39), hyphen (%2D), period (%2E),
  underscore (%5F), or tilde (%7E) should not be created by URI
  producers...

Closes #1006
Related #1356
Related #1561

BREAKING CHANGE: stop encoding '.' to '%2E'. This could potentially be
a breaking change for users who have incorrectly configured GitLab
servers which don't handle period '.' characters correctly.