### PR TITLE
chore: generate artifacts for the docs build in the CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,11 @@ jobs:
         env:
           TOXENV: docs
         run: tox
+      - name: Archive generated docs
+        uses: actions/upload-artifact@v2
+        with:
+          name: html-docs
+          path: build/sphinx/html/
 
   twine-check:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
When building the docs store the created documentation as an artifact
so that it can be viewed.

This will create a html-docs.zip file which can be downloaded
containing the contents of the `build/sphinx/html/` directory. It can
be downloaded, extracted, and then viewed. This can be useful in
reviewing changes to the documentation.

See https://github.com/actions/upload-artifact for more information on
how this works.