### PR TITLE
chore: enable using GitLab EE in functional tests

### DIFF
--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -218,8 +218,9 @@ def test_group_subgroups_projects(gl, user):
     group4.delete()
 
 
-@pytest.mark.skip
-def test_group_wiki(group):
+def test_group_wiki(gitlab_ee, group):
+    if not gitlab_ee:
+        pytest.skip("Requires GitLab EE to run")
     content = "Group Wiki page content"
     wiki = group.wikis.create({"title": "groupwikipage", "content": content})
     assert wiki in group.wikis.list()
@@ -234,8 +235,9 @@ def test_group_wiki(group):
     assert wiki not in group.wikis.list()
 
 
-@pytest.mark.skip(reason="EE feature")
-def test_group_hooks(group):
+def test_group_hooks(gitlab_ee, group):
+    if not gitlab_ee:
+        pytest.skip("Requires GitLab EE to run")
     hook = group.hooks.create({"url": "http://hook.url"})
     assert hook in group.hooks.list()
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -20,6 +20,17 @@ def fixture_dir(test_dir):
 def reset_gitlab(gl: gitlab.Gitlab) -> None:
     """Delete resources (such as projects, groups, users) that shouldn't
     exist."""
+    if is_gitlab_ee(gl):
+        logging.info("GitLab EE detected")
+        # NOTE(jlvillal): By default in GitLab EE it will wait 7 days before
+        # deleting a group. Change it to 0 days.
+        settings = gl.settings.get()
+        logging.info(f"deletion_adjourned_period: {settings.deletion_adjourned_period}")
+        if settings.deletion_adjourned_period != 0:
+            logging.info("Setting deletion_adjourned_period to 0")
+            settings.deletion_adjourned_period = 0
+            settings.save()
+
     for project in gl.projects.list():
         for deploy_token in project.deploytokens.list():
             logging.info(
@@ -178,6 +189,18 @@ def gl(gitlab_config):
     reset_gitlab(instance)
 
     return instance
+
+
+def is_gitlab_ee(gl: gitlab.Gitlab) -> bool:
+    """Determine if we are running with GitLab EE as opposed to GitLab CE"""
+    try:
+        license = gl.get_license()
+    except gitlab.exceptions.GitlabLicenseError:
+        license = None
+    # If we have a license then we assume we are running on GitLab EE
+    if license:
+        return True
+    return False
 
 
 @pytest.fixture(scope="session")

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -25,7 +25,6 @@ def reset_gitlab(gl: gitlab.Gitlab) -> None:
         # NOTE(jlvillal): By default in GitLab EE it will wait 7 days before
         # deleting a group. Change it to 0 days.
         settings = gl.settings.get()
-        logging.info(f"deletion_adjourned_period: {settings.deletion_adjourned_period}")
         if settings.deletion_adjourned_period != 0:
             logging.info("Setting deletion_adjourned_period to 0")
             settings.deletion_adjourned_period = 0
@@ -201,6 +200,11 @@ def is_gitlab_ee(gl: gitlab.Gitlab) -> bool:
     if license:
         return True
     return False
+
+
+@pytest.fixture(scope="session")
+def gitlab_ee(gl) -> bool:
+    return is_gitlab_ee(gl=gl)
 
 
 @pytest.fixture(scope="session")

--- a/tests/functional/fixtures/.env
+++ b/tests/functional/fixtures/.env
@@ -1,2 +1,2 @@
-GITLAB_IMAGE=gitlab/gitlab-ce
-GITLAB_TAG=14.9.2-ce.0
+GITLAB_IMAGE=gitlab/gitlab-ee
+GITLAB_TAG=14.9.2-ee.0

--- a/tests/functional/fixtures/create_license.rb
+++ b/tests/functional/fixtures/create_license.rb
@@ -1,0 +1,51 @@
+# NOTE: As of 2022-06-01 the GitLab Enterprise Edition License has the following
+# section:
+#   Notwithstanding the foregoing, you may copy and modify the Software for development
+#   and testing purposes, without requiring a subscription.
+#
+# https://gitlab.com/gitlab-org/gitlab/-/blob/29503bc97b96af8d4876dc23fc8996e3dab7d211/ee/LICENSE
+#
+# This code is strictly intended for use in the testing framework of python-gitlab
+
+# Code inspired by MIT licensed code at: https://github.com/CONIGUERO/gitlab-license.git
+
+require 'openssl'
+require 'gitlab/license'
+
+# Generate a 2048 bit key pair.
+license_encryption_key = OpenSSL::PKey::RSA.generate(2048)
+
+# Save the private key
+File.open("/.license_encryption_key", "w") { |f| f.write(license_encryption_key.to_pem) }
+# Save the public key
+public_key = license_encryption_key.public_key
+File.open("/.license_encryption_key.pub", "w") { |f| f.write(public_key.to_pem) }
+File.open("/opt/gitlab/embedded/service/gitlab-rails/.license_encryption_key.pub", "w") { |f| f.write(public_key.to_pem) }
+
+Gitlab::License.encryption_key = license_encryption_key
+
+# Build a new license.
+license = Gitlab::License.new
+
+license.licensee = {
+  "Name"    => "python-gitlab-ci",
+  "Company" => "python-gitlab-ci",
+  "Email"   => "python-gitlab-ci@example.com",
+}
+
+# The date the license starts. 
+license.starts_at         = Date.today
+# Want to make sure we get at least 1 day of usage. Do two days after because if CI
+# started at 23:59 we could be expired in one minute if we only did one next_day.
+license.expires_at         = Date.today.next_day.next_day
+
+# Use 'ultimate' plan so that we can test all features in the CI
+license.restrictions = {
+  :plan => "ultimate", 
+  :id   => rand(1000..99999999)
+}
+
+# Export the license, which encrypts and encodes it.
+data = license.export
+
+File.open("/python-gitlab-ci.gitlab-license", 'w') { |file| file.write(data) }

--- a/tests/functional/fixtures/docker-compose.yml
+++ b/tests/functional/fixtures/docker-compose.yml
@@ -31,12 +31,14 @@ services:
         gitlab_exporter['enable'] = false
         grafana['enable'] = false
         letsencrypt['enable'] = false
+        gitlab_rails['initial_license_file'] = '/python-gitlab-ci.gitlab-license'
     entrypoint:
       - /bin/sh
       - -c
-      - chmod 644 /opt/gitlab/embedded/service/gitlab-rails/db/fixtures/production/* && /assets/wrapper
+      - ruby /create_license.rb && chmod 644 /opt/gitlab/embedded/service/gitlab-rails/db/fixtures/production/* && /assets/wrapper
     volumes:
       - ${PWD}/tests/functional/fixtures/set_token.rb:/opt/gitlab/embedded/service/gitlab-rails/db/fixtures/production/003_set_token.rb
+      - ${PWD}/tests/functional/fixtures/create_license.rb:/create_license.rb
     ports:
       - '8080:80'
       - '2222:22'


### PR DESCRIPTION
Enable using GitLab Enterprise Edition (EE) in the functional tests.
This will allow us to add tests for EE only features in the
functional tests.

Closes https://github.com/python-gitlab/python-gitlab/issues/1492