### PR TITLE
chore: update version in docker-compose.yml

### DIFF
--- a/tests/functional/fixtures/docker-compose.yml
+++ b/tests/functional/fixtures/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 
 networks:
   gitlab-network:


### PR DESCRIPTION
When running with docker-compose on Ubuntu 20.04 I got the error:

  $ docker-compose up
  ERROR: The Compose file './docker-compose.yml' is invalid because:
  networks.gitlab-network value Additional properties are not allowed ('name' was unexpected)

Changing the version in the docker-compose.yml file fro '3' to '3.5'
resolved the issue.