### PR TITLE
chore: fixtures: after delete() wait to verify deleted

### DIFF
--- a/tests/functional/helpers.py
+++ b/tests/functional/helpers.py
@@ -1,0 +1,39 @@
+import logging
+import time
+
+import pytest
+
+import gitlab.base
+
+SLEEP_INTERVAL = 0.5
+TIMEOUT = 60  # seconds before timeout will occur
+MAX_ITERATIONS = int(TIMEOUT / SLEEP_INTERVAL)
+
+
+def safe_delete(
+    object: gitlab.base.RESTObject,
+    *,
+    hard_delete: bool = False,
+) -> None:
+    """Ensure the object specified can not be retrieved. If object still exists after
+    timeout period, fail the test"""
+    manager = object.manager
+    for index in range(MAX_ITERATIONS):
+        try:
+            object = manager.get(object.get_id())
+        except gitlab.exceptions.GitlabGetError:
+            return
+
+        if index:
+            logging.info(f"Attempt {index+1} to delete {object!r}.")
+        try:
+            if hard_delete:
+                object.delete(hard_delete=True)
+            else:
+                object.delete()
+        except gitlab.exceptions.GitlabDeleteError:
+            logging.info(f"{object!r} already deleted.")
+            pass
+
+        time.sleep(SLEEP_INTERVAL)
+    pytest.fail(f"{object!r} was not deleted")


### PR DESCRIPTION
In our fixtures that create:
  - groups
  - project merge requests
  - projects
  - users

They delete the created objects after use. Now wait to ensure the
objects are deleted before continuing as having unexpected objects
existing can impact some of our tests.