### PR TITLE
chore: add logging to `tests/functional/conftest.py`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Run tests
         env:
           TOXENV: ${{ matrix.toxenv }}
-        run: tox
+        run: tox -- --override-ini='log_cli=True'
       - name: Upload codecov coverage
         uses: codecov/codecov-action@v2
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,10 @@ disable = [
 
 [tool.pytest.ini_options]
 xfail_strict = true
+
+# If 'log_cli=True' the following apply
+# NOTE: If set 'log_cli_level' to 'DEBUG' will show a log of all of the HTTP requests
+# made in functional tests.
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s.%(msecs)03d [%(levelname)8s] (%(filename)s:%(funcName)s:L%(lineno)s) %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 envlist = py310,py39,py38,py37,pep8,black,twine-check,mypy,isort
 
 [testenv]
-passenv = GITLAB_IMAGE GITLAB_TAG
+passenv = GITLAB_IMAGE GITLAB_TAG PY_COLORS NO_COLOR FORCE_COLOR
 setenv = VIRTUAL_ENV={envdir}
 whitelist_externals = true
 usedevelop = True


### PR DESCRIPTION
I have found trying to debug issues in the functional tests can be
difficult. Especially when trying to figure out failures in the CI
running on Github.

Add logging to `tests/functional/conftest.py` to have a better
understanding of what is happening during a test run which is useful
when trying to troubleshoot issues in the CI.