### PR TITLE
chore: add a stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,40 @@
+# https://github.com/actions/stale
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          any-of-labels: 'need info,Waiting for response'
+          stale-issue-message: >
+            This issue was marked stale because it has been open 60 days with no
+            activity. Please remove the stale label or comment on this issue. Otherwise,
+            it will be closed in 15 days.
+          days-before-issue-stale: 60
+          days-before-issue-close: 15
+          close-issue-message: >
+            This issue was closed because it has been marked stale for 15 days with no
+            activity. If this issue is still valid, please re-open.
+
+          stale-pr-message: >
+            This Pull Request (PR) was marked stale because it has been open 90 days
+            with no activity.  Please remove the stale label or comment on this PR.
+            Otherwise, it will be closed in 15 days.
+          days-before-pr-stale: 90
+          days-before-pr-close: 15
+          close-pr-message: >
+            This PR was closed because it has been marked stale for 15 days with no
+            activity. If this PR is still valid, please re-open.
+


### PR DESCRIPTION
Use the stale action to close issues and pull-requests with no
activity.

Issues: It will mark them as stale after 60 days and then close
them once they have been stale for 15 days.

Pull-Requests: It will mark pull-requests as stale after 90 days and then close
them once they have been stale for 15 days.

https://github.com/actions/stale

Closes: #1649