### PR TITLE
chore: add authentication type to GitlabAuthenticationError

### DIFF
--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -96,6 +96,7 @@ class Gitlab(object):
         self.http_password = http_password
         self.oauth_token = oauth_token
         self.job_token = job_token
+        self.auth_type = ""
         self._set_auth_info()
 
         #: Create a session object for requests
@@ -487,21 +488,25 @@ class Gitlab(object):
             self.headers.pop("Authorization", None)
             self.headers["PRIVATE-TOKEN"] = self.private_token
             self.headers.pop("JOB-TOKEN", None)
+            self.auth_type = "private_token"
 
         if self.oauth_token:
             self.headers["Authorization"] = f"Bearer {self.oauth_token}"
             self.headers.pop("PRIVATE-TOKEN", None)
             self.headers.pop("JOB-TOKEN", None)
+            self.auth_type = "oauth_token"
 
         if self.job_token:
             self.headers.pop("Authorization", None)
             self.headers.pop("PRIVATE-TOKEN", None)
             self.headers["JOB-TOKEN"] = self.job_token
+            self.auth_type = "job_token"
 
         if self.http_username:
             self._http_auth = requests.auth.HTTPBasicAuth(
                 self.http_username, self.http_password
             )
+            self.auth_type = "password"
 
     def enable_debug(self) -> None:
         import logging
@@ -722,6 +727,7 @@ class Gitlab(object):
                     response_code=result.status_code,
                     error_message=error_message,
                     response_body=result.content,
+                    auth_type=self.auth_type,
                 )
 
             raise gitlab.exceptions.GitlabHttpError(

--- a/gitlab/exceptions.py
+++ b/gitlab/exceptions.py
@@ -52,7 +52,24 @@ class GitlabError(Exception):
 
 
 class GitlabAuthenticationError(GitlabError):
-    pass
+    def __init__(
+        self,
+        error_message: Union[str, bytes] = "",
+        response_code: Optional[int] = None,
+        response_body: Optional[bytes] = None,
+        auth_type: str = "",
+    ) -> None:
+        super().__init__(
+            error_message=error_message,
+            response_code=response_code,
+            response_body=response_body,
+        )
+        self.auth_type = auth_type
+
+    def __str__(self) -> str:
+        if self.auth_type:
+            return f"{super().__str__()}: authentication_type: {self.auth_type}"
+        return super().__str__()
 
 
 class RedirectError(GitlabError):

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -16,3 +16,27 @@ def test_error_raises_from_http_error():
     with pytest.raises(TestError) as context:
         raise_error_from_http_error()
     assert isinstance(context.value.__cause__, exceptions.GitlabHttpError)
+
+
+def test_gitlabauthenticationerror_with_auth_type():
+    with pytest.raises(exceptions.GitlabAuthenticationError) as context:
+        raise exceptions.GitlabAuthenticationError(
+            error_message="401 Unauthorized",
+            response_code=401,
+            response_body=b"bad user",
+            auth_type="job_token",
+        )
+    assert "authentication_type" in str(context.value)
+    assert "job_token" in str(context.value)
+    assert "401 Unauthorized" in str(context.value)
+
+
+def test_gitlabauthenticationerror_no_auth_type():
+    with pytest.raises(exceptions.GitlabAuthenticationError) as context:
+        raise exceptions.GitlabAuthenticationError(
+            error_message="401 Unauthorized",
+            response_code=401,
+            response_body=b"bad user",
+        )
+    assert "authentication_type" not in str(context.value)
+    assert "401 Unauthorized" in str(context.value)


### PR DESCRIPTION
Add the type of authentication used to the GitlabAuthenticationError
exception. Hopefully this will make it easier to help user's debug
authentication issues they run into.