### PR TITLE
chore(deps): upgrade mypy pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
           - requests-toolbelt==0.9.1
         files: 'gitlab/'
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
+    rev: v0.930
     hooks:
       - id: mypy
         args: []


### PR DESCRIPTION
Not quite sure why renovate hasn't picked it up after configuring it, will check this later.