### PR TITLE
chore: correct type-hints for http_put/http_post

### DIFF
--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -831,7 +831,7 @@ class Gitlab(object):
         raw: bool = False,
         files: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
-    ) -> Union[Dict[str, Any], requests.Response]:
+    ) -> Dict[str, Any]:
         """Make a POST request to the Gitlab server.
 
         Args:
@@ -870,7 +870,7 @@ class Gitlab(object):
             raise gitlab.exceptions.GitlabParsingError(
                 error_message="Failed to parse the server message"
             ) from e
-        return result
+        return {}
 
     def http_put(
         self,
@@ -880,7 +880,7 @@ class Gitlab(object):
         raw: bool = False,
         files: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
-    ) -> Union[Dict[str, Any], requests.Response]:
+    ) -> Dict[str, Any]:
         """Make a PUT request to the Gitlab server.
 
         Args:

--- a/gitlab/v4/objects/commits.py
+++ b/gitlab/v4/objects/commits.py
@@ -46,7 +46,7 @@ class ProjectCommit(RESTObject):
 
     @cli.register_custom_action("ProjectCommit", ("branch",))
     @exc.on_http_error(exc.GitlabCherryPickError)
-    def cherry_pick(self, branch: str, **kwargs: Any) -> None:
+    def cherry_pick(self, branch: str, **kwargs: Any) -> Dict[str, Any]:
         """Cherry-pick a commit into a branch.
 
         Args:
@@ -59,7 +59,7 @@ class ProjectCommit(RESTObject):
         """
         path = f"{self.manager.path}/{self.get_id()}/cherry_pick"
         post_data = {"branch": branch}
-        self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
+        return self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
 
     @cli.register_custom_action("ProjectCommit", optional=("type",))
     @exc.on_http_error(exc.GitlabGetError)
@@ -103,9 +103,7 @@ class ProjectCommit(RESTObject):
 
     @cli.register_custom_action("ProjectCommit", ("branch",))
     @exc.on_http_error(exc.GitlabRevertError)
-    def revert(
-        self, branch: str, **kwargs: Any
-    ) -> Union[Dict[str, Any], requests.Response]:
+    def revert(self, branch: str, **kwargs: Any) -> Dict[str, Any]:
         """Revert a commit on a given branch.
 
         Args:

--- a/gitlab/v4/objects/deploy_keys.py
+++ b/gitlab/v4/objects/deploy_keys.py
@@ -1,7 +1,5 @@
 from typing import Any, cast, Dict, Union
 
-import requests
-
 from gitlab import cli
 from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
@@ -37,9 +35,7 @@ class ProjectKeyManager(CRUDMixin, RESTManager):
 
     @cli.register_custom_action("ProjectKeyManager", ("key_id",))
     @exc.on_http_error(exc.GitlabProjectDeployKeyError)
-    def enable(
-        self, key_id: int, **kwargs: Any
-    ) -> Union[Dict[str, Any], requests.Response]:
+    def enable(self, key_id: int, **kwargs: Any) -> Dict[str, Any]:
         """Enable a deploy key for a project.
 
         Args:

--- a/gitlab/v4/objects/environments.py
+++ b/gitlab/v4/objects/environments.py
@@ -1,7 +1,5 @@
 from typing import Any, cast, Dict, Union
 
-import requests
-
 from gitlab import cli
 from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
@@ -23,7 +21,7 @@ __all__ = [
 class ProjectEnvironment(SaveMixin, ObjectDeleteMixin, RESTObject):
     @cli.register_custom_action("ProjectEnvironment")
     @exc.on_http_error(exc.GitlabStopError)
-    def stop(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
+    def stop(self, **kwargs: Any) -> Dict[str, Any]:
         """Stop the environment.
 
         Args:

--- a/gitlab/v4/objects/epics.py
+++ b/gitlab/v4/objects/epics.py
@@ -109,8 +109,6 @@ class GroupEpicIssueManager(
         CreateMixin._check_missing_create_attrs(self, data)
         path = f"{self.path}/{data.pop('issue_id')}"
         server_data = self.gitlab.http_post(path, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(server_data, dict)
         # The epic_issue_id attribute doesn't exist when creating the resource,
         # but is used everywhere elese. Let's create it to be consistent client
         # side

--- a/gitlab/v4/objects/features.py
+++ b/gitlab/v4/objects/features.py
@@ -2,7 +2,7 @@
 GitLab API:
 https://docs.gitlab.com/ee/api/features.html
 """
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, Union
 
 from gitlab import exceptions as exc
 from gitlab import utils
@@ -62,6 +62,4 @@ class FeatureManager(ListMixin, DeleteMixin, RESTManager):
         }
         data = utils.remove_none_from_dict(data)
         server_data = self.gitlab.http_post(path, post_data=data, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(server_data, dict)
         return self._obj_cls(self, server_data)

--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -147,8 +147,6 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         file_path = new_data.pop("file_path").replace("/", "%2F")
         path = f"{self.path}/{file_path}"
         server_data = self.gitlab.http_post(path, post_data=new_data, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(server_data, dict)
         return self._obj_cls(self, server_data)
 
     @exc.on_http_error(exc.GitlabUpdateError)
@@ -178,8 +176,6 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         path = f"{self.path}/{file_path}"
         self._check_missing_update_attrs(data)
         result = self.gitlab.http_put(path, post_data=data, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(result, dict)
         return result
 
     @cli.register_custom_action(

--- a/gitlab/v4/objects/geo_nodes.py
+++ b/gitlab/v4/objects/geo_nodes.py
@@ -32,8 +32,6 @@ class GeoNode(SaveMixin, ObjectDeleteMixin, RESTObject):
         """
         path = f"/geo_nodes/{self.get_id()}/repair"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(server_data, dict)
         self._update_attrs(server_data)
 
     @cli.register_custom_action("GeoNode")

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -1,6 +1,4 @@
-from typing import Any, BinaryIO, cast, Dict, List, Optional, Type, TYPE_CHECKING, Union
-
-import requests
+from typing import Any, BinaryIO, cast, Dict, List, Optional, Type, Union
 
 import gitlab
 from gitlab import cli
@@ -205,8 +203,6 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
             "expires_at": expires_at,
         }
         server_data = self.manager.gitlab.http_post(path, post_data=data, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(server_data, dict)
         self._update_attrs(server_data)
 
     @cli.register_custom_action("Group", ("group_id",))
@@ -303,7 +299,7 @@ class GroupManager(CRUDMixin, RESTManager):
         name: str,
         parent_id: Optional[str] = None,
         **kwargs: Any,
-    ) -> Union[Dict[str, Any], requests.Response]:
+    ) -> Dict[str, Any]:
         """Import a group from an archive file.
 
         Args:

--- a/gitlab/v4/objects/issues.py
+++ b/gitlab/v4/objects/issues.py
@@ -135,8 +135,6 @@ class ProjectIssue(
         path = f"{self.manager.path}/{self.get_id()}/move"
         data = {"to_project_id": to_project_id}
         server_data = self.manager.gitlab.http_post(path, post_data=data, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(server_data, dict)
         self._update_attrs(server_data)
 
     @cli.register_custom_action("ProjectIssue")
@@ -276,7 +274,6 @@ class ProjectIssueLinkManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
             assert self.path is not None
         server_data = self.gitlab.http_post(self.path, post_data=data, **kwargs)
         if TYPE_CHECKING:
-            assert isinstance(server_data, dict)
             assert self._parent is not None
         source_issue = ProjectIssue(self._parent.manager, server_data["source_issue"])
         target_issue = ProjectIssue(self._parent.manager, server_data["target_issue"])

--- a/gitlab/v4/objects/jobs.py
+++ b/gitlab/v4/objects/jobs.py
@@ -29,8 +29,6 @@ class ProjectJob(RefreshMixin, RESTObject):
         """
         path = f"{self.manager.path}/{self.get_id()}/cancel"
         result = self.manager.gitlab.http_post(path)
-        if TYPE_CHECKING:
-            assert isinstance(result, dict)
         return result
 
     @cli.register_custom_action("ProjectJob")
@@ -47,13 +45,11 @@ class ProjectJob(RefreshMixin, RESTObject):
         """
         path = f"{self.manager.path}/{self.get_id()}/retry"
         result = self.manager.gitlab.http_post(path)
-        if TYPE_CHECKING:
-            assert isinstance(result, dict)
         return result
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabJobPlayError)
-    def play(self, **kwargs: Any) -> None:
+    def play(self, **kwargs: Any) -> Dict[str, Any]:
         """Trigger a job explicitly.
 
         Args:
@@ -64,11 +60,11 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabJobPlayError: If the job could not be triggered
         """
         path = f"{self.manager.path}/{self.get_id()}/play"
-        self.manager.gitlab.http_post(path)
+        return self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabJobEraseError)
-    def erase(self, **kwargs: Any) -> None:
+    def erase(self, **kwargs: Any) -> Dict[str, Any]:
         """Erase the job (remove job artifacts and trace).
 
         Args:
@@ -79,11 +75,11 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabJobEraseError: If the job could not be erased
         """
         path = f"{self.manager.path}/{self.get_id()}/erase"
-        self.manager.gitlab.http_post(path)
+        return self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabCreateError)
-    def keep_artifacts(self, **kwargs: Any) -> None:
+    def keep_artifacts(self, **kwargs: Any) -> Dict[str, Any]:
         """Prevent artifacts from being deleted when expiration is set.
 
         Args:
@@ -94,7 +90,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabCreateError: If the request could not be performed
         """
         path = f"{self.manager.path}/{self.get_id()}/artifacts/keep"
-        self.manager.gitlab.http_post(path)
+        return self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabCreateError)

--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -78,8 +78,6 @@ class ProjectApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
         path = f"/projects/{self._parent.get_id()}/approvers"
         data = {"approver_ids": approver_ids, "approver_group_ids": approver_group_ids}
         result = self.gitlab.http_put(path, post_data=data, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(result, dict)
         return result
 
 

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -185,8 +185,6 @@ class ProjectMergeRequest(
             f"{self.manager.path}/{self.get_id()}/cancel_merge_when_pipeline_succeeds"
         )
         server_data = self.manager.gitlab.http_put(path, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(server_data, dict)
         self._update_attrs(server_data)
         return ProjectMergeRequest(self.manager, server_data)
 
@@ -287,8 +285,6 @@ class ProjectMergeRequest(
             data["sha"] = sha
 
         server_data = self.manager.gitlab.http_post(path, post_data=data, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(server_data, dict)
         self._update_attrs(server_data)
         return server_data
 
@@ -310,13 +306,11 @@ class ProjectMergeRequest(
         data: Dict[str, Any] = {}
 
         server_data = self.manager.gitlab.http_post(path, post_data=data, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(server_data, dict)
         self._update_attrs(server_data)
 
     @cli.register_custom_action("ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabMRRebaseError)
-    def rebase(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
+    def rebase(self, **kwargs: Any) -> Dict[str, Any]:
         """Attempt to rebase the source branch onto the target branch
 
         Args:
@@ -386,8 +380,6 @@ class ProjectMergeRequest(
             data["merge_when_pipeline_succeeds"] = True
 
         server_data = self.manager.gitlab.http_put(path, post_data=data, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(server_data, dict)
         self._update_attrs(server_data)
         return server_data
 

--- a/gitlab/v4/objects/packages.py
+++ b/gitlab/v4/objects/packages.py
@@ -78,8 +78,6 @@ class GenericPackageManager(RESTManager):
 
         url = f"{self._computed_path}/{package_name}/{package_version}/{file_name}"
         server_data = self.gitlab.http_put(url, post_data=file_data, raw=True, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(server_data, dict)
 
         return self._obj_cls(
             self,

--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -1,7 +1,5 @@
 from typing import Any, cast, Dict, Optional, TYPE_CHECKING, Union
 
-import requests
-
 from gitlab import cli
 from gitlab import exceptions as exc
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
@@ -56,7 +54,7 @@ class ProjectPipeline(RefreshMixin, ObjectDeleteMixin, RESTObject):
 
     @cli.register_custom_action("ProjectPipeline")
     @exc.on_http_error(exc.GitlabPipelineCancelError)
-    def cancel(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
+    def cancel(self, **kwargs: Any) -> Dict[str, Any]:
         """Cancel the job.
 
         Args:
@@ -71,7 +69,7 @@ class ProjectPipeline(RefreshMixin, ObjectDeleteMixin, RESTObject):
 
     @cli.register_custom_action("ProjectPipeline")
     @exc.on_http_error(exc.GitlabPipelineRetryError)
-    def retry(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
+    def retry(self, **kwargs: Any) -> Dict[str, Any]:
         """Retry the job.
 
         Args:
@@ -196,8 +194,6 @@ class ProjectPipelineSchedule(SaveMixin, ObjectDeleteMixin, RESTObject):
         """
         path = f"{self.manager.path}/{self.get_id()}/take_ownership"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(server_data, dict)
         self._update_attrs(server_data)
 
     @cli.register_custom_action("ProjectPipelineSchedule")
@@ -215,8 +211,6 @@ class ProjectPipelineSchedule(SaveMixin, ObjectDeleteMixin, RESTObject):
         """
         path = f"{self.manager.path}/{self.get_id()}/play"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(server_data, dict)
         self._update_attrs(server_data)
         return server_data
 

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -244,8 +244,6 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         """
         path = f"/projects/{self.get_id()}/star"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(server_data, dict)
         self._update_attrs(server_data)
 
     @cli.register_custom_action("Project")
@@ -262,8 +260,6 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         """
         path = f"/projects/{self.get_id()}/unstar"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(server_data, dict)
         self._update_attrs(server_data)
 
     @cli.register_custom_action("Project")
@@ -280,8 +276,6 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         """
         path = f"/projects/{self.get_id()}/archive"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(server_data, dict)
         self._update_attrs(server_data)
 
     @cli.register_custom_action("Project")
@@ -298,8 +292,6 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         """
         path = f"/projects/{self.get_id()}/unarchive"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(server_data, dict)
         self._update_attrs(server_data)
 
     @cli.register_custom_action(
@@ -376,8 +368,6 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         path = f"/projects/{self.get_id()}/trigger/pipeline"
         post_data = {"ref": ref, "token": token, "variables": variables}
         attrs = self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(attrs, dict)
         return ProjectPipeline(self.pipelines, attrs)
 
     @cli.register_custom_action("Project")
@@ -444,9 +434,6 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         url = f"/projects/{self.id}/uploads"
         file_info = {"file": (filename, filedata)}
         data = self.manager.gitlab.http_post(url, files=file_info)
-
-        if TYPE_CHECKING:
-            assert isinstance(data, dict)
         return {"alt": data["alt"], "url": data["url"], "markdown": data["markdown"]}
 
     @cli.register_custom_action("Project", optional=("wiki",))
@@ -526,7 +513,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
 
     @cli.register_custom_action("Project", ("to_namespace",))
     @exc.on_http_error(exc.GitlabTransferProjectError)
-    def transfer_project(self, to_namespace: str, **kwargs: Any) -> None:
+    def transfer_project(self, to_namespace: str, **kwargs: Any) -> Dict[str, Any]:
         """Transfer a project to the given namespace ID
 
         Args:
@@ -539,7 +526,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabTransferProjectError: If the project could not be transferred
         """
         path = f"/projects/{self.id}/transfer"
-        self.manager.gitlab.http_put(
+        return self.manager.gitlab.http_put(
             path, post_data={"namespace": to_namespace}, **kwargs
         )
 
@@ -811,7 +798,7 @@ class ProjectManager(CRUDMixin, RESTManager):
         overwrite: bool = False,
         override_params: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
-    ) -> Union[Dict[str, Any], requests.Response]:
+    ) -> Dict[str, Any]:
         """Import a project from an archive file.
 
         Args:
@@ -854,7 +841,7 @@ class ProjectManager(CRUDMixin, RESTManager):
         new_name: Optional[str] = None,
         target_namespace: Optional[str] = None,
         **kwargs: Any,
-    ) -> Union[Dict[str, Any], requests.Response]:
+    ) -> Dict[str, Any]:
         """Import a project from BitBucket Server to Gitlab (schedule the import)
 
         This method will return when an import operation has been safely queued,
@@ -943,7 +930,7 @@ class ProjectManager(CRUDMixin, RESTManager):
         target_namespace: str,
         new_name: Optional[str] = None,
         **kwargs: Any,
-    ) -> Union[Dict[str, Any], requests.Response]:
+    ) -> Dict[str, Any]:
         """Import a project from Github to Gitlab (schedule the import)
 
         This method will return when an import operation has been safely queued,

--- a/gitlab/v4/objects/repositories.py
+++ b/gitlab/v4/objects/repositories.py
@@ -24,7 +24,7 @@ class RepositoryMixin(_RestObjectBase):
     @exc.on_http_error(exc.GitlabUpdateError)
     def update_submodule(
         self, submodule: str, branch: str, commit_sha: str, **kwargs: Any
-    ) -> Union[Dict[str, Any], requests.Response]:
+    ) -> Dict[str, Any]:
         """Update a project submodule
 
         Args:

--- a/gitlab/v4/objects/todos.py
+++ b/gitlab/v4/objects/todos.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, TYPE_CHECKING
+from typing import Any, Dict
 
 from gitlab import cli
 from gitlab import exceptions as exc
@@ -29,8 +29,6 @@ class Todo(ObjectDeleteMixin, RESTObject):
         """
         path = f"{self.manager.path}/{self.id}/mark_as_done"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(server_data, dict)
         self._update_attrs(server_data)
         return server_data
 

--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -5,8 +5,6 @@ https://docs.gitlab.com/ee/api/projects.html#list-projects-starred-by-a-user
 """
 from typing import Any, cast, Dict, List, Optional, Union
 
-import requests
-
 from gitlab import cli
 from gitlab import exceptions as exc
 from gitlab import types
@@ -166,7 +164,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
 
     @cli.register_custom_action("User")
     @exc.on_http_error(exc.GitlabBlockError)
-    def block(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
+    def block(self, **kwargs: Any) -> None:
         """Block the user.
 
         Args:
@@ -180,14 +178,12 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
             Whether the user status has been changed
         """
         path = f"/users/{self.id}/block"
-        server_data = self.manager.gitlab.http_post(path, **kwargs)
-        if server_data is True:
-            self._attrs["state"] = "blocked"
-        return server_data
+        self.manager.gitlab.http_post(path, **kwargs)
+        self._attrs["state"] = "blocked"
 
     @cli.register_custom_action("User")
     @exc.on_http_error(exc.GitlabFollowError)
-    def follow(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
+    def follow(self, **kwargs: Any) -> Dict[str, Any]:
         """Follow the user.
 
         Args:
@@ -205,7 +201,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
 
     @cli.register_custom_action("User")
     @exc.on_http_error(exc.GitlabUnfollowError)
-    def unfollow(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
+    def unfollow(self, **kwargs: Any) -> Dict[str, Any]:
         """Unfollow the user.
 
         Args:
@@ -223,7 +219,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
 
     @cli.register_custom_action("User")
     @exc.on_http_error(exc.GitlabUnblockError)
-    def unblock(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
+    def unblock(self, **kwargs: Any) -> None:
         """Unblock the user.
 
         Args:
@@ -237,14 +233,12 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
             Whether the user status has been changed
         """
         path = f"/users/{self.id}/unblock"
-        server_data = self.manager.gitlab.http_post(path, **kwargs)
-        if server_data is True:
-            self._attrs["state"] = "active"
-        return server_data
+        self.manager.gitlab.http_post(path, **kwargs)
+        self._attrs["state"] = "active"
 
     @cli.register_custom_action("User")
     @exc.on_http_error(exc.GitlabDeactivateError)
-    def deactivate(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
+    def deactivate(self, **kwargs: Any) -> None:
         """Deactivate the user.
 
         Args:
@@ -258,14 +252,12 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
             Whether the user status has been changed
         """
         path = f"/users/{self.id}/deactivate"
-        server_data = self.manager.gitlab.http_post(path, **kwargs)
-        if server_data:
-            self._attrs["state"] = "deactivated"
-        return server_data
+        self.manager.gitlab.http_post(path, **kwargs)
+        self._attrs["state"] = "deactivated"
 
     @cli.register_custom_action("User")
     @exc.on_http_error(exc.GitlabActivateError)
-    def activate(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
+    def activate(self, **kwargs: Any) -> None:
         """Activate the user.
 
         Args:
@@ -279,10 +271,8 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
             Whether the user status has been changed
         """
         path = f"/users/{self.id}/activate"
-        server_data = self.manager.gitlab.http_post(path, **kwargs)
-        if server_data:
-            self._attrs["state"] = "active"
-        return server_data
+        self.manager.gitlab.http_post(path, **kwargs)
+        self._attrs["state"] = "active"
 
 
 class UserManager(CRUDMixin, RESTManager):


### PR DESCRIPTION
http_put/http_post will either return a JSON object or nothing. We
never expect them to return a raw requests.response object.

Update type-hints and code to no longer have a requests.response
object as a possible return value.