### PR TITLE
chore: add `pprint()` and `pformat()` methods to RESTObject

### DIFF
--- a/docs/api-usage.rst
+++ b/docs/api-usage.rst
@@ -179,6 +179,20 @@ resources. For example:
    project = gl.projects.get(1)
    project.star()
 
+You can print a Gitlab Object. For example:
+
+.. code-block:: python
+
+   project = gl.projects.get(1)
+   print(project)
+
+   # Or in a prettier format.
+   project.pprint()
+
+   # Or explicitly via `pformat()`. This is equivalent to the above.
+   print(project.pformat())
+
+
 Base types
 ==========
 

--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import importlib
+import pprint
 import textwrap
 from types import ModuleType
 from typing import Any, Dict, Iterable, NamedTuple, Optional, Tuple, Type
@@ -146,6 +147,14 @@ class RESTObject(object):
         data = self._attrs.copy()
         data.update(self._updated_attrs)
         return f"{type(self)} => {data}"
+
+    def pformat(self) -> str:
+        data = self._attrs.copy()
+        data.update(self._updated_attrs)
+        return f"{type(self)} => \n{pprint.pformat(data)}"
+
+    def pprint(self) -> None:
+        print(self.pformat())
 
     def __repr__(self) -> str:
         if self._id_attr:

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -201,3 +201,33 @@ class TestRESTObject:
         obj1 = FakeObject(fake_manager, {"attr1": "foo"})
         obj2 = FakeObject(fake_manager, {"attr1": "bar"})
         assert obj1 != obj2
+
+    def test_dunder_str(self, fake_manager):
+        fake_object = FakeObject(fake_manager, {"attr1": "foo"})
+        assert str(fake_object) == (
+            "<class 'tests.unit.test_base.FakeObject'> => {'attr1': 'foo'}"
+        )
+
+    def test_pformat(self, fake_manager):
+        fake_object = FakeObject(
+            fake_manager, {"attr1": "foo" * 10, "ham": "eggs" * 15}
+        )
+        assert fake_object.pformat() == (
+            "<class 'tests.unit.test_base.FakeObject'> => "
+            "\n{'attr1': 'foofoofoofoofoofoofoofoofoofoo',\n"
+            " 'ham': 'eggseggseggseggseggseggseggseggseggseggseggseggseggseggseggs'}"
+        )
+
+    def test_pprint(self, capfd, fake_manager):
+        fake_object = FakeObject(
+            fake_manager, {"attr1": "foo" * 10, "ham": "eggs" * 15}
+        )
+        result = fake_object.pprint()
+        assert result is None
+        stdout, stderr = capfd.readouterr()
+        assert stdout == (
+            "<class 'tests.unit.test_base.FakeObject'> => "
+            "\n{'attr1': 'foofoofoofoofoofoofoofoofoofoo',\n"
+            " 'ham': 'eggseggseggseggseggseggseggseggseggseggseggseggseggseggseggs'}\n"
+        )
+        assert stderr == ""


### PR DESCRIPTION
This is useful in debugging and testing. As can easily print out the
values from an instance in a more human-readable form.