### PR TITLE
chore(dist): add docs *.md files to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include COPYING AUTHORS CHANGELOG.md requirements*.txt
 include tox.ini
 recursive-include tests *
-recursive-include docs *j2 *.py *.rst api/*.rst Makefile make.bat
+recursive-include docs *j2 *.md *.py *.rst api/*.rst Makefile make.bat


### PR DESCRIPTION
build_sphinx to fail due to setup.cfg warning-is-error
