### PR TITLE
fix: remove default arguments for mergerequests.merge()

### DIFF
--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -358,8 +358,8 @@ class ProjectMergeRequest(
     def merge(
         self,
         merge_commit_message: Optional[str] = None,
-        should_remove_source_branch: bool = False,
-        merge_when_pipeline_succeeds: bool = False,
+        should_remove_source_branch: Optional[bool] = None,
+        merge_when_pipeline_succeeds: Optional[bool] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Accept the merge request.
@@ -382,8 +382,8 @@ class ProjectMergeRequest(
             data["merge_commit_message"] = merge_commit_message
         if should_remove_source_branch is not None:
             data["should_remove_source_branch"] = should_remove_source_branch
-        if merge_when_pipeline_succeeds:
-            data["merge_when_pipeline_succeeds"] = True
+        if merge_when_pipeline_succeeds is not None:
+            data["merge_when_pipeline_succeeds"] = merge_when_pipeline_succeeds
 
         server_data = self.manager.gitlab.http_put(path, post_data=data, **kwargs)
         if TYPE_CHECKING:

--- a/tests/functional/api/test_merge_requests.py
+++ b/tests/functional/api/test_merge_requests.py
@@ -170,7 +170,9 @@ def test_merge_request_large_commit_message(
     merge_commit_message = "large_message\r\n" * 1_000
     assert len(merge_commit_message) > 10_000
 
-    mr.merge(merge_commit_message=merge_commit_message)
+    mr.merge(
+        merge_commit_message=merge_commit_message, should_remove_source_branch=False
+    )
 
     result = wait_for_sidekiq(timeout=60)
     assert result is True, "sidekiq process should have terminated but did not"


### PR DESCRIPTION
The arguments `should_remove_source_branch` and
`merge_when_pipeline_succeeds` are optional arguments. We should not
be setting any default value for them.

https://docs.gitlab.com/ee/api/merge_requests.html#accept-mr

Closes: #1750