### PR TITLE
fix: use url-encoded ID in all paths (alternate method)

### DIFF
--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -209,6 +209,15 @@ class RESTObject(object):
         return getattr(self, self._id_attr)
 
     @property
+    def encoded_id(self) -> Any:
+        """Ensure that the ID is url-encoded so that it can be safely used in a URL
+        path"""
+        obj_id = self.get_id()
+        if isinstance(obj_id, str):
+            obj_id = gitlab.utils.EncodedId(obj_id)
+        return obj_id
+
+    @property
     def attributes(self) -> Dict[str, Any]:
         d = self.__dict__["_updated_attrs"].copy()
         d.update(self.__dict__["_attrs"])

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -99,9 +99,7 @@ class GetMixin(_RestManagerBase):
             GitlabAuthenticationError: If authentication is not correct
             GitlabGetError: If the server cannot perform the request
         """
-        if not isinstance(id, int):
-            id = utils._url_encode(id)
-        path = f"{self.path}/{id}"
+        path = f"{self.path}/{utils.EncodedId(id)}"
         if TYPE_CHECKING:
             assert self._obj_cls is not None
         if lazy is True:
@@ -173,7 +171,7 @@ class RefreshMixin(_RestObjectBase):
             GitlabGetError: If the server cannot perform the request
         """
         if self._id_attr:
-            path = f"{self.manager.path}/{self.id}"
+            path = f"{self.manager.path}/{self.encoded_id}"
         else:
             if TYPE_CHECKING:
                 assert self.manager.path is not None
@@ -391,7 +389,7 @@ class UpdateMixin(_RestManagerBase):
         if id is None:
             path = self.path
         else:
-            path = f"{self.path}/{id}"
+            path = f"{self.path}/{utils.EncodedId(id)}"
 
         self._check_missing_update_attrs(new_data)
         files = {}
@@ -444,7 +442,7 @@ class SetMixin(_RestManagerBase):
         Returns:
             The created/updated attribute
         """
-        path = f"{self.path}/{utils._url_encode(key)}"
+        path = f"{self.path}/{utils.EncodedId(key)}"
         data = {"value": value}
         server_data = self.gitlab.http_put(path, post_data=data, **kwargs)
         if TYPE_CHECKING:
@@ -477,9 +475,7 @@ class DeleteMixin(_RestManagerBase):
         if id is None:
             path = self.path
         else:
-            if not isinstance(id, int):
-                id = utils._url_encode(id)
-            path = f"{self.path}/{id}"
+            path = f"{self.path}/{utils.EncodedId(id)}"
         self.gitlab.http_delete(path, **kwargs)
 
 
@@ -545,7 +541,7 @@ class SaveMixin(_RestObjectBase):
             return
 
         # call the manager
-        obj_id = self.get_id()
+        obj_id = self.encoded_id
         if TYPE_CHECKING:
             assert isinstance(self.manager, UpdateMixin)
         server_data = self.manager.update(obj_id, updated_data, **kwargs)
@@ -575,7 +571,7 @@ class ObjectDeleteMixin(_RestObjectBase):
         """
         if TYPE_CHECKING:
             assert isinstance(self.manager, DeleteMixin)
-        self.manager.delete(self.get_id(), **kwargs)
+        self.manager.delete(self.encoded_id, **kwargs)
 
 
 class UserAgentDetailMixin(_RestObjectBase):
@@ -598,7 +594,7 @@ class UserAgentDetailMixin(_RestObjectBase):
             GitlabAuthenticationError: If authentication is not correct
             GitlabGetError: If the server cannot perform the request
         """
-        path = f"{self.manager.path}/{self.get_id()}/user_agent_detail"
+        path = f"{self.manager.path}/{self.encoded_id}/user_agent_detail"
         result = self.manager.gitlab.http_get(path, **kwargs)
         if TYPE_CHECKING:
             assert not isinstance(result, requests.Response)
@@ -631,7 +627,7 @@ class AccessRequestMixin(_RestObjectBase):
             GitlabUpdateError: If the server fails to perform the request
         """
 
-        path = f"{self.manager.path}/{self.id}/approve"
+        path = f"{self.manager.path}/{self.encoded_id}/approve"
         data = {"access_level": access_level}
         server_data = self.manager.gitlab.http_put(path, post_data=data, **kwargs)
         if TYPE_CHECKING:
@@ -705,7 +701,7 @@ class SubscribableMixin(_RestObjectBase):
             GitlabAuthenticationError: If authentication is not correct
             GitlabSubscribeError: If the subscription cannot be done
         """
-        path = f"{self.manager.path}/{self.get_id()}/subscribe"
+        path = f"{self.manager.path}/{self.encoded_id}/subscribe"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert not isinstance(server_data, requests.Response)
@@ -725,7 +721,7 @@ class SubscribableMixin(_RestObjectBase):
             GitlabAuthenticationError: If authentication is not correct
             GitlabUnsubscribeError: If the unsubscription cannot be done
         """
-        path = f"{self.manager.path}/{self.get_id()}/unsubscribe"
+        path = f"{self.manager.path}/{self.encoded_id}/unsubscribe"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert not isinstance(server_data, requests.Response)
@@ -752,7 +748,7 @@ class TodoMixin(_RestObjectBase):
             GitlabAuthenticationError: If authentication is not correct
             GitlabTodoError: If the todo cannot be set
         """
-        path = f"{self.manager.path}/{self.get_id()}/todo"
+        path = f"{self.manager.path}/{self.encoded_id}/todo"
         self.manager.gitlab.http_post(path, **kwargs)
 
 
@@ -781,7 +777,7 @@ class TimeTrackingMixin(_RestObjectBase):
         if "time_stats" in self.attributes:
             return self.attributes["time_stats"]
 
-        path = f"{self.manager.path}/{self.get_id()}/time_stats"
+        path = f"{self.manager.path}/{self.encoded_id}/time_stats"
         result = self.manager.gitlab.http_get(path, **kwargs)
         if TYPE_CHECKING:
             assert not isinstance(result, requests.Response)
@@ -800,7 +796,7 @@ class TimeTrackingMixin(_RestObjectBase):
             GitlabAuthenticationError: If authentication is not correct
             GitlabTimeTrackingError: If the time tracking update cannot be done
         """
-        path = f"{self.manager.path}/{self.get_id()}/time_estimate"
+        path = f"{self.manager.path}/{self.encoded_id}/time_estimate"
         data = {"duration": duration}
         result = self.manager.gitlab.http_post(path, post_data=data, **kwargs)
         if TYPE_CHECKING:
@@ -819,7 +815,7 @@ class TimeTrackingMixin(_RestObjectBase):
             GitlabAuthenticationError: If authentication is not correct
             GitlabTimeTrackingError: If the time tracking update cannot be done
         """
-        path = f"{self.manager.path}/{self.get_id()}/reset_time_estimate"
+        path = f"{self.manager.path}/{self.encoded_id}/reset_time_estimate"
         result = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert not isinstance(result, requests.Response)
@@ -838,7 +834,7 @@ class TimeTrackingMixin(_RestObjectBase):
             GitlabAuthenticationError: If authentication is not correct
             GitlabTimeTrackingError: If the time tracking update cannot be done
         """
-        path = f"{self.manager.path}/{self.get_id()}/add_spent_time"
+        path = f"{self.manager.path}/{self.encoded_id}/add_spent_time"
         data = {"duration": duration}
         result = self.manager.gitlab.http_post(path, post_data=data, **kwargs)
         if TYPE_CHECKING:
@@ -857,7 +853,7 @@ class TimeTrackingMixin(_RestObjectBase):
             GitlabAuthenticationError: If authentication is not correct
             GitlabTimeTrackingError: If the time tracking update cannot be done
         """
-        path = f"{self.manager.path}/{self.get_id()}/reset_spent_time"
+        path = f"{self.manager.path}/{self.encoded_id}/reset_spent_time"
         result = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert not isinstance(result, requests.Response)
@@ -893,7 +889,7 @@ class ParticipantsMixin(_RestObjectBase):
             The list of participants
         """
 
-        path = f"{self.manager.path}/{self.get_id()}/participants"
+        path = f"{self.manager.path}/{self.encoded_id}/participants"
         result = self.manager.gitlab.http_get(path, **kwargs)
         if TYPE_CHECKING:
             assert not isinstance(result, requests.Response)
@@ -967,7 +963,7 @@ class PromoteMixin(_RestObjectBase):
             The updated object data (*not* a RESTObject)
         """
 
-        path = f"{self.manager.path}/{self.id}/promote"
+        path = f"{self.manager.path}/{self.encoded_id}/promote"
         http_method = self._get_update_method()
         result = http_method(path, **kwargs)
         if TYPE_CHECKING:

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -75,7 +75,7 @@ class GitlabCLI(object):
             if key not in self.args:
                 continue
 
-            self.parent_args[key] = gitlab.utils._url_encode(self.args[key])
+            self.parent_args[key] = gitlab.utils.EncodedId(self.args[key])
             # If we don't delete it then it will be added to the URL as a query-string
             del self.args[key]
 

--- a/gitlab/v4/objects/commits.py
+++ b/gitlab/v4/objects/commits.py
@@ -42,7 +42,7 @@ class ProjectCommit(RESTObject):
         Returns:
             The changes done in this commit
         """
-        path = f"{self.manager.path}/{self.get_id()}/diff"
+        path = f"{self.manager.path}/{self.encoded_id}/diff"
         return self.manager.gitlab.http_list(path, **kwargs)
 
     @cli.register_custom_action("ProjectCommit", ("branch",))
@@ -58,7 +58,7 @@ class ProjectCommit(RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabCherryPickError: If the cherry-pick could not be performed
         """
-        path = f"{self.manager.path}/{self.get_id()}/cherry_pick"
+        path = f"{self.manager.path}/{self.encoded_id}/cherry_pick"
         post_data = {"branch": branch}
         self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
 
@@ -80,7 +80,7 @@ class ProjectCommit(RESTObject):
         Returns:
             The references the commit is pushed to.
         """
-        path = f"{self.manager.path}/{self.get_id()}/refs"
+        path = f"{self.manager.path}/{self.encoded_id}/refs"
         query_data = {"type": type}
         return self.manager.gitlab.http_list(path, query_data=query_data, **kwargs)
 
@@ -101,7 +101,7 @@ class ProjectCommit(RESTObject):
         Returns:
             The merge requests related to the commit.
         """
-        path = f"{self.manager.path}/{self.get_id()}/merge_requests"
+        path = f"{self.manager.path}/{self.encoded_id}/merge_requests"
         return self.manager.gitlab.http_list(path, **kwargs)
 
     @cli.register_custom_action("ProjectCommit", ("branch",))
@@ -122,7 +122,7 @@ class ProjectCommit(RESTObject):
         Returns:
             The new commit data (*not* a RESTObject)
         """
-        path = f"{self.manager.path}/{self.get_id()}/revert"
+        path = f"{self.manager.path}/{self.encoded_id}/revert"
         post_data = {"branch": branch}
         return self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
 
@@ -141,7 +141,7 @@ class ProjectCommit(RESTObject):
         Returns:
             The commit's signature data
         """
-        path = f"{self.manager.path}/{self.get_id()}/signature"
+        path = f"{self.manager.path}/{self.encoded_id}/signature"
         return self.manager.gitlab.http_get(path, **kwargs)
 
 

--- a/gitlab/v4/objects/environments.py
+++ b/gitlab/v4/objects/environments.py
@@ -36,7 +36,7 @@ class ProjectEnvironment(SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
            A dict of the result.
         """
-        path = f"{self.manager.path}/{self.get_id()}/stop"
+        path = f"{self.manager.path}/{self.encoded_id}/stop"
         return self.manager.gitlab.http_post(path, **kwargs)
 
 

--- a/gitlab/v4/objects/epics.py
+++ b/gitlab/v4/objects/epics.py
@@ -72,7 +72,7 @@ class GroupEpicIssue(ObjectDeleteMixin, SaveMixin, RESTObject):
             return
 
         # call the manager
-        obj_id = self.get_id()
+        obj_id = self.encoded_id
         self.manager.update(obj_id, updated_data, **kwargs)
 
 

--- a/gitlab/v4/objects/features.py
+++ b/gitlab/v4/objects/features.py
@@ -52,8 +52,7 @@ class FeatureManager(ListMixin, DeleteMixin, RESTManager):
         Returns:
             The created/updated attribute
         """
-        name = utils._url_encode(name)
-        path = f"{self.path}/{name}"
+        path = f"{self.path}/{utils.EncodedId(name)}"
         data = {
             "value": value,
             "feature_group": feature_group,

--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -56,7 +56,7 @@ class ProjectFile(SaveMixin, ObjectDeleteMixin, RESTObject):
         """
         self.branch = branch
         self.commit_message = commit_message
-        self.file_path = utils._url_encode(self.file_path)
+        self.file_path = str(utils.EncodedId(self.file_path))
         super(ProjectFile, self).save(**kwargs)
 
     @exc.on_http_error(exc.GitlabDeleteError)
@@ -76,7 +76,7 @@ class ProjectFile(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server cannot perform the request
         """
-        file_path = utils._url_encode(self.get_id())
+        file_path = self.encoded_id
         self.manager.delete(file_path, branch, commit_message, **kwargs)
 
 
@@ -144,7 +144,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
             assert data is not None
         self._check_missing_create_attrs(data)
         new_data = data.copy()
-        file_path = utils._url_encode(new_data.pop("file_path"))
+        file_path = utils.EncodedId(new_data.pop("file_path"))
         path = f"{self.path}/{file_path}"
         server_data = self.gitlab.http_post(path, post_data=new_data, **kwargs)
         if TYPE_CHECKING:
@@ -173,9 +173,9 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         """
         new_data = new_data or {}
         data = new_data.copy()
-        file_path = utils._url_encode(file_path)
-        data["file_path"] = file_path
-        path = f"{self.path}/{file_path}"
+        encoded_file_path = utils.EncodedId(file_path)
+        data["file_path"] = encoded_file_path
+        path = f"{self.path}/{encoded_file_path}"
         self._check_missing_update_attrs(data)
         result = self.gitlab.http_put(path, post_data=data, **kwargs)
         if TYPE_CHECKING:
@@ -203,8 +203,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server cannot perform the request
         """
-        file_path = utils._url_encode(file_path)
-        path = f"{self.path}/{file_path}"
+        path = f"{self.path}/{utils.EncodedId(file_path)}"
         data = {"branch": branch, "commit_message": commit_message}
         self.gitlab.http_delete(path, query_data=data, **kwargs)
 
@@ -239,8 +238,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         Returns:
             The file content
         """
-        file_path = utils._url_encode(file_path)
-        path = f"{self.path}/{file_path}/raw"
+        path = f"{self.path}/{utils.EncodedId(file_path)}/raw"
         query_data = {"ref": ref}
         result = self.gitlab.http_get(
             path, query_data=query_data, streamed=streamed, raw=True, **kwargs
@@ -266,8 +264,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         Returns:
             A list of commits/lines matching the file
         """
-        file_path = utils._url_encode(file_path)
-        path = f"{self.path}/{file_path}/blame"
+        path = f"{self.path}/{utils.EncodedId(file_path)}/blame"
         query_data = {"ref": ref}
         result = self.gitlab.http_list(path, query_data, **kwargs)
         if TYPE_CHECKING:

--- a/gitlab/v4/objects/geo_nodes.py
+++ b/gitlab/v4/objects/geo_nodes.py
@@ -30,7 +30,7 @@ class GeoNode(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabRepairError: If the server failed to perform the request
         """
-        path = f"/geo_nodes/{self.get_id()}/repair"
+        path = f"/geo_nodes/{self.encoded_id}/repair"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(server_data, dict)
@@ -51,7 +51,7 @@ class GeoNode(SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             The status of the geo node
         """
-        path = f"/geo_nodes/{self.get_id()}/status"
+        path = f"/geo_nodes/{self.encoded_id}/status"
         result = self.manager.gitlab.http_get(path, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(result, dict)

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -113,7 +113,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
             A list of dicts describing the resources found.
         """
         data = {"scope": scope, "search": search}
-        path = f"/groups/{self.get_id()}/search"
+        path = f"/groups/{self.encoded_id}/search"
         return self.manager.gitlab.http_list(path, query_data=data, **kwargs)
 
     @cli.register_custom_action("Group", ("cn", "group_access", "provider"))
@@ -134,7 +134,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabCreateError: If the server cannot perform the request
         """
-        path = f"/groups/{self.get_id()}/ldap_group_links"
+        path = f"/groups/{self.encoded_id}/ldap_group_links"
         data = {"cn": cn, "group_access": group_access, "provider": provider}
         self.manager.gitlab.http_post(path, post_data=data, **kwargs)
 
@@ -154,7 +154,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server cannot perform the request
         """
-        path = f"/groups/{self.get_id()}/ldap_group_links"
+        path = f"/groups/{self.encoded_id}/ldap_group_links"
         if provider is not None:
             path += f"/{provider}"
         path += f"/{cn}"
@@ -172,7 +172,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabCreateError: If the server cannot perform the request
         """
-        path = f"/groups/{self.get_id()}/ldap_sync"
+        path = f"/groups/{self.encoded_id}/ldap_sync"
         self.manager.gitlab.http_post(path, **kwargs)
 
     @cli.register_custom_action("Group", ("group_id", "group_access"), ("expires_at",))
@@ -198,7 +198,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             Group
         """
-        path = f"/groups/{self.get_id()}/share"
+        path = f"/groups/{self.encoded_id}/share"
         data = {
             "group_id": group_id,
             "group_access": group_access,
@@ -222,7 +222,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server failed to perform the request
         """
-        path = f"/groups/{self.get_id()}/share/{group_id}"
+        path = f"/groups/{self.encoded_id}/share/{group_id}"
         self.manager.gitlab.http_delete(path, **kwargs)
 
 

--- a/gitlab/v4/objects/issues.py
+++ b/gitlab/v4/objects/issues.py
@@ -132,7 +132,7 @@ class ProjectIssue(
             GitlabAuthenticationError: If authentication is not correct
             GitlabUpdateError: If the issue could not be moved
         """
-        path = f"{self.manager.path}/{self.get_id()}/move"
+        path = f"{self.manager.path}/{self.encoded_id}/move"
         data = {"to_project_id": to_project_id}
         server_data = self.manager.gitlab.http_post(path, post_data=data, **kwargs)
         if TYPE_CHECKING:
@@ -154,7 +154,7 @@ class ProjectIssue(
         Returns:
             The list of merge requests.
         """
-        path = f"{self.manager.path}/{self.get_id()}/related_merge_requests"
+        path = f"{self.manager.path}/{self.encoded_id}/related_merge_requests"
         result = self.manager.gitlab.http_get(path, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(result, dict)
@@ -175,7 +175,7 @@ class ProjectIssue(
         Returns:
             The list of merge requests.
         """
-        path = f"{self.manager.path}/{self.get_id()}/closed_by"
+        path = f"{self.manager.path}/{self.encoded_id}/closed_by"
         result = self.manager.gitlab.http_get(path, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(result, dict)

--- a/gitlab/v4/objects/jobs.py
+++ b/gitlab/v4/objects/jobs.py
@@ -27,7 +27,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabJobCancelError: If the job could not be canceled
         """
-        path = f"{self.manager.path}/{self.get_id()}/cancel"
+        path = f"{self.manager.path}/{self.encoded_id}/cancel"
         result = self.manager.gitlab.http_post(path)
         if TYPE_CHECKING:
             assert isinstance(result, dict)
@@ -45,7 +45,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabJobRetryError: If the job could not be retried
         """
-        path = f"{self.manager.path}/{self.get_id()}/retry"
+        path = f"{self.manager.path}/{self.encoded_id}/retry"
         result = self.manager.gitlab.http_post(path)
         if TYPE_CHECKING:
             assert isinstance(result, dict)
@@ -63,7 +63,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabJobPlayError: If the job could not be triggered
         """
-        path = f"{self.manager.path}/{self.get_id()}/play"
+        path = f"{self.manager.path}/{self.encoded_id}/play"
         self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectJob")
@@ -78,7 +78,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabJobEraseError: If the job could not be erased
         """
-        path = f"{self.manager.path}/{self.get_id()}/erase"
+        path = f"{self.manager.path}/{self.encoded_id}/erase"
         self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectJob")
@@ -93,7 +93,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabCreateError: If the request could not be performed
         """
-        path = f"{self.manager.path}/{self.get_id()}/artifacts/keep"
+        path = f"{self.manager.path}/{self.encoded_id}/artifacts/keep"
         self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectJob")
@@ -108,7 +108,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the request could not be performed
         """
-        path = f"{self.manager.path}/{self.get_id()}/artifacts"
+        path = f"{self.manager.path}/{self.encoded_id}/artifacts"
         self.manager.gitlab.http_delete(path)
 
     @cli.register_custom_action("ProjectJob")
@@ -138,7 +138,7 @@ class ProjectJob(RefreshMixin, RESTObject):
         Returns:
             The artifacts if `streamed` is False, None otherwise.
         """
-        path = f"{self.manager.path}/{self.get_id()}/artifacts"
+        path = f"{self.manager.path}/{self.encoded_id}/artifacts"
         result = self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
@@ -175,7 +175,7 @@ class ProjectJob(RefreshMixin, RESTObject):
         Returns:
             The artifacts if `streamed` is False, None otherwise.
         """
-        path = f"{self.manager.path}/{self.get_id()}/artifacts/{path}"
+        path = f"{self.manager.path}/{self.encoded_id}/artifacts/{path}"
         result = self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
@@ -210,7 +210,7 @@ class ProjectJob(RefreshMixin, RESTObject):
         Returns:
             The trace
         """
-        path = f"{self.manager.path}/{self.get_id()}/trace"
+        path = f"{self.manager.path}/{self.encoded_id}/trace"
         result = self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -182,7 +182,7 @@ class ProjectMergeRequest(
         """
 
         path = (
-            f"{self.manager.path}/{self.get_id()}/cancel_merge_when_pipeline_succeeds"
+            f"{self.manager.path}/{self.encoded_id}/cancel_merge_when_pipeline_succeeds"
         )
         server_data = self.manager.gitlab.http_put(path, **kwargs)
         if TYPE_CHECKING:
@@ -210,7 +210,7 @@ class ProjectMergeRequest(
         Returns:
             List of issues
         """
-        path = f"{self.manager.path}/{self.get_id()}/closes_issues"
+        path = f"{self.manager.path}/{self.encoded_id}/closes_issues"
         data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(data_list, gitlab.GitlabList)
@@ -238,7 +238,7 @@ class ProjectMergeRequest(
             The list of commits
         """
 
-        path = f"{self.manager.path}/{self.get_id()}/commits"
+        path = f"{self.manager.path}/{self.encoded_id}/commits"
         data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(data_list, gitlab.GitlabList)
@@ -260,7 +260,7 @@ class ProjectMergeRequest(
         Returns:
             List of changes
         """
-        path = f"{self.manager.path}/{self.get_id()}/changes"
+        path = f"{self.manager.path}/{self.encoded_id}/changes"
         return self.manager.gitlab.http_get(path, **kwargs)
 
     @cli.register_custom_action("ProjectMergeRequest", tuple(), ("sha",))
@@ -281,7 +281,7 @@ class ProjectMergeRequest(
 
         https://docs.gitlab.com/ee/api/merge_request_approvals.html#approve-merge-request
         """
-        path = f"{self.manager.path}/{self.get_id()}/approve"
+        path = f"{self.manager.path}/{self.encoded_id}/approve"
         data = {}
         if sha:
             data["sha"] = sha
@@ -306,7 +306,7 @@ class ProjectMergeRequest(
 
         https://docs.gitlab.com/ee/api/merge_request_approvals.html#unapprove-merge-request
         """
-        path = f"{self.manager.path}/{self.get_id()}/unapprove"
+        path = f"{self.manager.path}/{self.encoded_id}/unapprove"
         data: Dict[str, Any] = {}
 
         server_data = self.manager.gitlab.http_post(path, post_data=data, **kwargs)
@@ -326,7 +326,7 @@ class ProjectMergeRequest(
             GitlabAuthenticationError: If authentication is not correct
             GitlabMRRebaseError: If rebasing failed
         """
-        path = f"{self.manager.path}/{self.get_id()}/rebase"
+        path = f"{self.manager.path}/{self.encoded_id}/rebase"
         data: Dict[str, Any] = {}
         return self.manager.gitlab.http_put(path, post_data=data, **kwargs)
 
@@ -342,7 +342,7 @@ class ProjectMergeRequest(
         Raises:
             GitlabGetError: If cannot be merged
         """
-        path = f"{self.manager.path}/{self.get_id()}/merge_ref"
+        path = f"{self.manager.path}/{self.encoded_id}/merge_ref"
         return self.manager.gitlab.http_get(path, **kwargs)
 
     @cli.register_custom_action(
@@ -376,7 +376,7 @@ class ProjectMergeRequest(
             GitlabAuthenticationError: If authentication is not correct
             GitlabMRClosedError: If the merge failed
         """
-        path = f"{self.manager.path}/{self.get_id()}/merge"
+        path = f"{self.manager.path}/{self.encoded_id}/merge"
         data: Dict[str, Any] = {}
         if merge_commit_message:
             data["merge_commit_message"] = merge_commit_message

--- a/gitlab/v4/objects/milestones.py
+++ b/gitlab/v4/objects/milestones.py
@@ -45,7 +45,7 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
             The list of issues
         """
 
-        path = f"{self.manager.path}/{self.get_id()}/issues"
+        path = f"{self.manager.path}/{self.encoded_id}/issues"
         data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(data_list, RESTObjectList)
@@ -73,7 +73,7 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             The list of merge requests
         """
-        path = f"{self.manager.path}/{self.get_id()}/merge_requests"
+        path = f"{self.manager.path}/{self.encoded_id}/merge_requests"
         data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(data_list, RESTObjectList)
@@ -126,7 +126,7 @@ class ProjectMilestone(PromoteMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
             The list of issues
         """
 
-        path = f"{self.manager.path}/{self.get_id()}/issues"
+        path = f"{self.manager.path}/{self.encoded_id}/issues"
         data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(data_list, RESTObjectList)
@@ -154,7 +154,7 @@ class ProjectMilestone(PromoteMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             The list of merge requests
         """
-        path = f"{self.manager.path}/{self.get_id()}/merge_requests"
+        path = f"{self.manager.path}/{self.encoded_id}/merge_requests"
         data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(data_list, RESTObjectList)

--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -66,7 +66,7 @@ class ProjectPipeline(RefreshMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabPipelineCancelError: If the request failed
         """
-        path = f"{self.manager.path}/{self.get_id()}/cancel"
+        path = f"{self.manager.path}/{self.encoded_id}/cancel"
         return self.manager.gitlab.http_post(path)
 
     @cli.register_custom_action("ProjectPipeline")
@@ -81,7 +81,7 @@ class ProjectPipeline(RefreshMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabPipelineRetryError: If the request failed
         """
-        path = f"{self.manager.path}/{self.get_id()}/retry"
+        path = f"{self.manager.path}/{self.encoded_id}/retry"
         return self.manager.gitlab.http_post(path)
 
 
@@ -194,7 +194,7 @@ class ProjectPipelineSchedule(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabOwnershipError: If the request failed
         """
-        path = f"{self.manager.path}/{self.get_id()}/take_ownership"
+        path = f"{self.manager.path}/{self.encoded_id}/take_ownership"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(server_data, dict)
@@ -213,7 +213,7 @@ class ProjectPipelineSchedule(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabPipelinePlayError: If the request failed
         """
-        path = f"{self.manager.path}/{self.get_id()}/play"
+        path = f"{self.manager.path}/{self.encoded_id}/play"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(server_data, dict)

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -197,7 +197,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabCreateError: If the relation could not be created
         """
-        path = f"/projects/{self.get_id()}/fork/{forked_from_id}"
+        path = f"/projects/{self.encoded_id}/fork/{forked_from_id}"
         self.manager.gitlab.http_post(path, **kwargs)
 
     @cli.register_custom_action("Project")
@@ -212,7 +212,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server failed to perform the request
         """
-        path = f"/projects/{self.get_id()}/fork"
+        path = f"/projects/{self.encoded_id}/fork"
         self.manager.gitlab.http_delete(path, **kwargs)
 
     @cli.register_custom_action("Project")
@@ -227,7 +227,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabGetError: If the server failed to perform the request
         """
-        path = f"/projects/{self.get_id()}/languages"
+        path = f"/projects/{self.encoded_id}/languages"
         return self.manager.gitlab.http_get(path, **kwargs)
 
     @cli.register_custom_action("Project")
@@ -242,7 +242,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabCreateError: If the server failed to perform the request
         """
-        path = f"/projects/{self.get_id()}/star"
+        path = f"/projects/{self.encoded_id}/star"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(server_data, dict)
@@ -260,7 +260,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server failed to perform the request
         """
-        path = f"/projects/{self.get_id()}/unstar"
+        path = f"/projects/{self.encoded_id}/unstar"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(server_data, dict)
@@ -278,7 +278,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabCreateError: If the server failed to perform the request
         """
-        path = f"/projects/{self.get_id()}/archive"
+        path = f"/projects/{self.encoded_id}/archive"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(server_data, dict)
@@ -296,7 +296,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server failed to perform the request
         """
-        path = f"/projects/{self.get_id()}/unarchive"
+        path = f"/projects/{self.encoded_id}/unarchive"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(server_data, dict)
@@ -324,7 +324,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabCreateError: If the server failed to perform the request
         """
-        path = f"/projects/{self.get_id()}/share"
+        path = f"/projects/{self.encoded_id}/share"
         data = {
             "group_id": group_id,
             "group_access": group_access,
@@ -345,7 +345,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server failed to perform the request
         """
-        path = f"/projects/{self.get_id()}/share/{group_id}"
+        path = f"/projects/{self.encoded_id}/share/{group_id}"
         self.manager.gitlab.http_delete(path, **kwargs)
 
     # variables not supported in CLI
@@ -373,7 +373,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabCreateError: If the server failed to perform the request
         """
         variables = variables or {}
-        path = f"/projects/{self.get_id()}/trigger/pipeline"
+        path = f"/projects/{self.encoded_id}/trigger/pipeline"
         post_data = {"ref": ref, "token": token, "variables": variables}
         attrs = self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
         if TYPE_CHECKING:
@@ -393,7 +393,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabHousekeepingError: If the server failed to perform the
                                      request
         """
-        path = f"/projects/{self.get_id()}/housekeeping"
+        path = f"/projects/{self.encoded_id}/housekeeping"
         self.manager.gitlab.http_post(path, **kwargs)
 
     # see #56 - add file attachment features
@@ -478,7 +478,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         Returns:
             The uncompressed tar archive of the repository
         """
-        path = f"/projects/{self.get_id()}/snapshot"
+        path = f"/projects/{self.encoded_id}/snapshot"
         result = self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
@@ -506,7 +506,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             A list of dicts describing the resources found.
         """
         data = {"scope": scope, "search": search}
-        path = f"/projects/{self.get_id()}/search"
+        path = f"/projects/{self.encoded_id}/search"
         return self.manager.gitlab.http_list(path, query_data=data, **kwargs)
 
     @cli.register_custom_action("Project")
@@ -521,7 +521,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabCreateError: If the server failed to perform the request
         """
-        path = f"/projects/{self.get_id()}/mirror/pull"
+        path = f"/projects/{self.encoded_id}/mirror/pull"
         self.manager.gitlab.http_post(path, **kwargs)
 
     @cli.register_custom_action("Project", ("to_namespace",))
@@ -577,7 +577,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         Returns:
             The artifacts if `streamed` is False, None otherwise.
         """
-        path = f"/projects/{self.get_id()}/jobs/artifacts/{ref_name}/download"
+        path = f"/projects/{self.encoded_id}/jobs/artifacts/{ref_name}/download"
         result = self.manager.gitlab.http_get(
             path, job=job, streamed=streamed, raw=True, **kwargs
         )
@@ -622,7 +622,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         """
 
         path = (
-            f"/projects/{self.get_id()}/jobs/artifacts/{ref_name}/raw/"
+            f"/projects/{self.encoded_id}/jobs/artifacts/{ref_name}/raw/"
             f"{artifact_path}?job={job}"
         )
         result = self.manager.gitlab.http_get(

--- a/gitlab/v4/objects/repositories.py
+++ b/gitlab/v4/objects/repositories.py
@@ -39,8 +39,8 @@ class RepositoryMixin(_RestObjectBase):
             GitlabPutError: If the submodule could not be updated
         """
 
-        submodule = utils._url_encode(submodule)
-        path = f"/projects/{self.get_id()}/repository/submodules/{submodule}"
+        submodule_id = utils.EncodedId(submodule)
+        path = f"/projects/{self.encoded_id}/repository/submodules/{submodule_id}"
         data = {"branch": branch, "commit_sha": commit_sha}
         if "commit_message" in kwargs:
             data["commit_message"] = kwargs["commit_message"]
@@ -71,7 +71,7 @@ class RepositoryMixin(_RestObjectBase):
         Returns:
             The representation of the tree
         """
-        gl_path = f"/projects/{self.get_id()}/repository/tree"
+        gl_path = f"/projects/{self.encoded_id}/repository/tree"
         query_data: Dict[str, Any] = {"recursive": recursive}
         if path:
             query_data["path"] = path
@@ -98,7 +98,7 @@ class RepositoryMixin(_RestObjectBase):
             The blob content and metadata
         """
 
-        path = f"/projects/{self.get_id()}/repository/blobs/{sha}"
+        path = f"/projects/{self.encoded_id}/repository/blobs/{sha}"
         return self.manager.gitlab.http_get(path, **kwargs)
 
     @cli.register_custom_action("Project", ("sha",))
@@ -130,7 +130,7 @@ class RepositoryMixin(_RestObjectBase):
         Returns:
             The blob content if streamed is False, None otherwise
         """
-        path = f"/projects/{self.get_id()}/repository/blobs/{sha}/raw"
+        path = f"/projects/{self.encoded_id}/repository/blobs/{sha}/raw"
         result = self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
@@ -157,7 +157,7 @@ class RepositoryMixin(_RestObjectBase):
         Returns:
             The diff
         """
-        path = f"/projects/{self.get_id()}/repository/compare"
+        path = f"/projects/{self.encoded_id}/repository/compare"
         query_data = {"from": from_, "to": to}
         return self.manager.gitlab.http_get(path, query_data=query_data, **kwargs)
 
@@ -183,7 +183,7 @@ class RepositoryMixin(_RestObjectBase):
         Returns:
             The contributors
         """
-        path = f"/projects/{self.get_id()}/repository/contributors"
+        path = f"/projects/{self.encoded_id}/repository/contributors"
         return self.manager.gitlab.http_list(path, **kwargs)
 
     @cli.register_custom_action("Project", tuple(), ("sha", "format"))
@@ -217,7 +217,7 @@ class RepositoryMixin(_RestObjectBase):
         Returns:
             The binary data of the archive
         """
-        path = f"/projects/{self.get_id()}/repository/archive"
+        path = f"/projects/{self.encoded_id}/repository/archive"
         if format:
             path += "." + format
         query_data = {}
@@ -242,5 +242,5 @@ class RepositoryMixin(_RestObjectBase):
             GitlabAuthenticationError: If authentication is not correct
             GitlabDeleteError: If the server failed to perform the request
         """
-        path = f"/projects/{self.get_id()}/repository/merged_branches"
+        path = f"/projects/{self.encoded_id}/repository/merged_branches"
         self.manager.gitlab.http_delete(path, **kwargs)

--- a/gitlab/v4/objects/snippets.py
+++ b/gitlab/v4/objects/snippets.py
@@ -50,7 +50,7 @@ class Snippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             The snippet content
         """
-        path = f"/snippets/{self.get_id()}/raw"
+        path = f"/snippets/{self.encoded_id}/raw"
         result = self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )
@@ -124,7 +124,7 @@ class ProjectSnippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObj
         Returns:
             The snippet content
         """
-        path = f"{self.manager.path}/{self.get_id()}/raw"
+        path = f"{self.manager.path}/{self.encoded_id}/raw"
         result = self.manager.gitlab.http_get(
             path, streamed=streamed, raw=True, **kwargs
         )

--- a/tests/functional/api/test_wikis.py
+++ b/tests/functional/api/test_wikis.py
@@ -1,0 +1,15 @@
+"""
+GitLab API:
+https://docs.gitlab.com/ee/api/wikis.html
+"""
+
+
+def test_wikis(project):
+
+    page = project.wikis.create({"title": "title/subtitle", "content": "test content"})
+    page.content = "update content"
+    page.title = "subtitle"
+
+    page.save()
+
+    page.delete()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -15,23 +15,59 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import json
+
 from gitlab import utils
 
 
-def test_url_encode():
-    src = "nothing_special"
-    dest = "nothing_special"
-    assert dest == utils._url_encode(src)
+class TestEncodedId:
+    def test_init_str(self):
+        obj = utils.EncodedId("Hello")
+        assert "Hello" == str(obj)
+        assert "Hello" == f"{obj}"
 
-    src = "foo#bar/baz/"
-    dest = "foo%23bar%2Fbaz%2F"
-    assert dest == utils._url_encode(src)
+        obj = utils.EncodedId("this/is a/path")
+        assert "this%2Fis%20a%2Fpath" == str(obj)
+        assert "this%2Fis%20a%2Fpath" == f"{obj}"
 
-    src = "foo%bar/baz/"
-    dest = "foo%25bar%2Fbaz%2F"
-    assert dest == utils._url_encode(src)
+    def test_init_int(self):
+        obj = utils.EncodedId(23)
+        assert "23" == str(obj)
+        assert "23" == f"{obj}"
 
-    # periods/dots should not be modified
-    src = "docs/README.md"
-    dest = "docs%2FREADME.md"
-    assert dest == utils._url_encode(src)
+    def test_init_encodeid_str(self):
+        value = "Goodbye"
+        obj_init = utils.EncodedId(value)
+        obj = utils.EncodedId(obj_init)
+        assert value == str(obj)
+        assert value == f"{obj}"
+        assert value == obj.original_str
+
+        value = "we got/a/path"
+        expected = "we%20got%2Fa%2Fpath"
+        obj_init = utils.EncodedId(value)
+        assert value == obj_init.original_str
+        # Show that no matter how many times we recursively call it we still only
+        # URL-encode it once.
+        obj = utils.EncodedId(
+            utils.EncodedId(utils.EncodedId(utils.EncodedId(utils.EncodedId(obj_init))))
+        )
+        assert expected == str(obj)
+        assert expected == f"{obj}"
+        # We have stored a copy of our original string
+        assert value == obj.original_str
+
+    def test_init_encodeid_int(self):
+        value = 23
+        expected = f"{value}"
+        obj_init = utils.EncodedId(value)
+        obj = utils.EncodedId(obj_init)
+        assert expected == str(obj)
+        assert expected == f"{obj}"
+
+    def test_json_serializable(self):
+        obj = utils.EncodedId("someone")
+        assert '"someone"' == json.dumps(obj)
+
+        obj = utils.EncodedId("we got/a/path")
+        assert '"we%20got%2Fa%2Fpath"' == json.dumps(obj)


### PR DESCRIPTION
An alternative to https://github.com/python-gitlab/python-gitlab/pull/1819

Make sure all usage of the ID in the URL path is encoded. Normally it
isn't an issue as most IDs are integers or strings which don't contain
a slash ('/'). But when the ID is a string with a slash character it
will break things.

Add a test case that shows this fixes wikis issue with subpages which
use the slash character.

Closes: #1079