### PR TITLE
docs: update project access token API reference link

### DIFF
--- a/docs/gl_objects/project_access_tokens.rst
+++ b/docs/gl_objects/project_access_tokens.rst
@@ -13,7 +13,7 @@ References
   + :class:`gitlab.v4.objects.ProjectAccessTokenManager`
   + :attr:`gitlab.Gitlab.project_access_tokens`
 
-* GitLab API: https://docs.gitlab.com/ee/api/resource_access_tokens.html
+* GitLab API: https://docs.gitlab.com/ee/api/project_access_tokens.html
 
 Examples
 --------

--- a/tests/unit/objects/test_project_access_tokens.py
+++ b/tests/unit/objects/test_project_access_tokens.py
@@ -1,5 +1,5 @@
 """
-GitLab API: https://docs.gitlab.com/ee/api/resource_access_tokens.html
+GitLab API: https://docs.gitlab.com/ee/api/project_access_tokens.html
 """
 
 import pytest


### PR DESCRIPTION
The project access tokens API reference page was moved, see https://gitlab.com/gitlab-org/gitlab/-/merge_requests/77649.

/cc @max-wittig @nejch 