### PR TITLE
feat: add support for Group Access Tokens API

### DIFF
--- a/docs/api-objects.rst
+++ b/docs/api-objects.rst
@@ -24,6 +24,7 @@ API examples
    gl_objects/features
    gl_objects/geo_nodes
    gl_objects/groups
+   gl_objects/group_access_tokens
    gl_objects/issues
    gl_objects/keys
    gl_objects/boards

--- a/docs/gl_objects/group_access_tokens.rst
+++ b/docs/gl_objects/group_access_tokens.rst
@@ -1,0 +1,34 @@
+#####################
+Group Access Tokens
+#####################
+
+Get a list of group access tokens
+
+References
+----------
+
+* v4 API:
+
+  + :class:`gitlab.v4.objects.GroupAccessToken`
+  + :class:`gitlab.v4.objects.GroupAccessTokenManager`
+  + :attr:`gitlab.Gitlab.group_access_tokens`
+
+* GitLab API: https://docs.gitlab.com/ee/api/group_access_tokens.html
+
+Examples
+--------
+
+List group access tokens::
+
+    access_tokens = gl.groups.get(1, lazy=True).access_tokens.list()
+    print(access_tokens[0].name)
+
+Create group access token::
+
+    access_token = gl.groups.get(1).access_tokens.create({"name": "test", "scopes": ["api"]})
+
+Revoke a group access tokens::
+
+    gl.groups.get(1).access_tokens.delete(42)
+    # or
+    access_token.delete()

--- a/gitlab/v4/objects/group_access_tokens.py
+++ b/gitlab/v4/objects/group_access_tokens.py
@@ -1,0 +1,17 @@
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CreateMixin, DeleteMixin, ListMixin, ObjectDeleteMixin
+
+__all__ = [
+    "GroupAccessToken",
+    "GroupAccessTokenManager",
+]
+
+
+class GroupAccessToken(ObjectDeleteMixin, RESTObject):
+    pass
+
+
+class GroupAccessTokenManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
+    _path = "/groups/{group_id}/access_tokens"
+    _obj_cls = GroupAccessToken
+    _from_parent_attrs = {"group_id": "id"}

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -18,6 +18,7 @@ from .custom_attributes import GroupCustomAttributeManager  # noqa: F401
 from .deploy_tokens import GroupDeployTokenManager  # noqa: F401
 from .epics import GroupEpicManager  # noqa: F401
 from .export_import import GroupExportManager, GroupImportManager  # noqa: F401
+from .group_access_tokens import GroupAccessTokenManager  # noqa: F401
 from .hooks import GroupHookManager  # noqa: F401
 from .issues import GroupIssueManager  # noqa: F401
 from .labels import GroupLabelManager  # noqa: F401
@@ -49,6 +50,7 @@ __all__ = [
 class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
     _short_print_attr = "name"
 
+    access_tokens: GroupAccessTokenManager
     accessrequests: GroupAccessRequestManager
     audit_events: GroupAuditEventManager
     badges: GroupBadgeManager

--- a/tests/unit/objects/test_group_access_tokens.py
+++ b/tests/unit/objects/test_group_access_tokens.py
@@ -1,0 +1,113 @@
+"""
+GitLab API: https://docs.gitlab.com/ee/api/group_access_tokens.html
+"""
+
+import pytest
+import responses
+
+
+@pytest.fixture
+def resp_list_group_access_token():
+    content = [
+        {
+            "user_id": 141,
+            "scopes": ["api"],
+            "name": "token",
+            "expires_at": "2021-01-31",
+            "id": 42,
+            "active": True,
+            "created_at": "2021-01-20T22:11:48.151Z",
+            "revoked": False,
+        }
+    ]
+
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(
+            method=responses.GET,
+            url="http://localhost/api/v4/groups/1/access_tokens",
+            json=content,
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
+@pytest.fixture
+def resp_create_group_access_token():
+    content = {
+        "user_id": 141,
+        "scopes": ["api"],
+        "name": "token",
+        "expires_at": "2021-01-31",
+        "id": 42,
+        "active": True,
+        "created_at": "2021-01-20T22:11:48.151Z",
+        "revoked": False,
+    }
+
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(
+            method=responses.POST,
+            url="http://localhost/api/v4/groups/1/access_tokens",
+            json=content,
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
+@pytest.fixture
+def resp_revoke_group_access_token():
+    content = [
+        {
+            "user_id": 141,
+            "scopes": ["api"],
+            "name": "token",
+            "expires_at": "2021-01-31",
+            "id": 42,
+            "active": True,
+            "created_at": "2021-01-20T22:11:48.151Z",
+            "revoked": False,
+        }
+    ]
+
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(
+            method=responses.DELETE,
+            url="http://localhost/api/v4/groups/1/access_tokens/42",
+            json=content,
+            content_type="application/json",
+            status=204,
+        )
+        rsps.add(
+            method=responses.GET,
+            url="http://localhost/api/v4/groups/1/access_tokens",
+            json=content,
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
+def test_list_group_access_tokens(gl, resp_list_group_access_token):
+    access_tokens = gl.groups.get(1, lazy=True).access_tokens.list()
+    assert len(access_tokens) == 1
+    assert access_tokens[0].revoked is False
+    assert access_tokens[0].name == "token"
+
+
+def test_create_group_access_token(gl, resp_create_group_access_token):
+    access_tokens = gl.groups.get(1, lazy=True).access_tokens.create(
+        {"name": "test", "scopes": ["api"]}
+    )
+    assert access_tokens.revoked is False
+    assert access_tokens.user_id == 141
+    assert access_tokens.expires_at == "2021-01-31"
+
+
+def test_revoke_group_access_token(
+    gl, resp_list_group_access_token, resp_revoke_group_access_token
+):
+    gl.groups.get(1, lazy=True).access_tokens.delete(42)
+    access_token = gl.groups.get(1, lazy=True).access_tokens.list()[0]
+    access_token.delete()


### PR DESCRIPTION
This MR adds support for the newly created Group Access Tokens API, see https://docs.gitlab.com/ee/api/group_access_tokens.html.

/cc @max-wittig @nejch