### PR TITLE
fix: broken URL for FAQ about attribute-error-list

### DIFF
--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -36,7 +36,7 @@ __all__ = [
 
 
 _URL_ATTRIBUTE_ERROR = (
-    f"https://python-gitlab.readthedocs.io/en/{gitlab.__version__}/"
+    f"https://python-gitlab.readthedocs.io/en/v{gitlab.__version__}/"
     f"faq.html#attribute-error-list"
 )
 


### PR DESCRIPTION
```
The URL was missing a 'v' before the version number and thus the page
did not exist.

Previously the URL for python-gitlab 3.0.0 was:
https://python-gitlab.readthedocs.io/en/3.0.0/faq.html#attribute-error-list

Which does not exist.

Change it to:
https://python-gitlab.readthedocs.io/en/v3.0.0/faq.html#attribute-error-list
  add the 'v' --------------------------^
```