### PR TITLE
fix: members: use new *All objects for *AllManager managers

### DIFF
--- a/gitlab/v4/objects/members.py
+++ b/gitlab/v4/objects/members.py
@@ -17,9 +17,11 @@ __all__ = [
     "GroupBillableMemberMembership",
     "GroupBillableMemberMembershipManager",
     "GroupMember",
+    "GroupMemberAll",
     "GroupMemberManager",
     "GroupMemberAllManager",
     "ProjectMember",
+    "ProjectMemberAll",
     "ProjectMemberManager",
     "ProjectMemberAllManager",
 ]
@@ -70,15 +72,19 @@ class GroupBillableMemberMembershipManager(ListMixin, RESTManager):
     _from_parent_attrs = {"group_id": "group_id", "user_id": "id"}
 
 
+class GroupMemberAll(RESTObject):
+    _short_print_attr = "username"
+
+
 class GroupMemberAllManager(RetrieveMixin, RESTManager):
     _path = "/groups/{group_id}/members/all"
-    _obj_cls = GroupMember
+    _obj_cls = GroupMemberAll
     _from_parent_attrs = {"group_id": "id"}
 
     def get(
         self, id: Union[str, int], lazy: bool = False, **kwargs: Any
-    ) -> GroupMember:
-        return cast(GroupMember, super().get(id=id, lazy=lazy, **kwargs))
+    ) -> GroupMemberAll:
+        return cast(GroupMemberAll, super().get(id=id, lazy=lazy, **kwargs))
 
 
 class ProjectMember(SaveMixin, ObjectDeleteMixin, RESTObject):
@@ -103,12 +109,16 @@ class ProjectMemberManager(CRUDMixin, RESTManager):
         return cast(ProjectMember, super().get(id=id, lazy=lazy, **kwargs))
 
 
+class ProjectMemberAll(RESTObject):
+    _short_print_attr = "username"
+
+
 class ProjectMemberAllManager(RetrieveMixin, RESTManager):
     _path = "/projects/{project_id}/members/all"
-    _obj_cls = ProjectMember
+    _obj_cls = ProjectMemberAll
     _from_parent_attrs = {"project_id": "id"}
 
     def get(
         self, id: Union[str, int], lazy: bool = False, **kwargs: Any
-    ) -> ProjectMember:
-        return cast(ProjectMember, super().get(id=id, lazy=lazy, **kwargs))
+    ) -> ProjectMemberAll:
+        return cast(ProjectMemberAll, super().get(id=id, lazy=lazy, **kwargs))

--- a/tests/functional/cli/test_cli_v4.py
+++ b/tests/functional/cli/test_cli_v4.py
@@ -701,6 +701,31 @@ def test_delete_group_deploy_token(gitlab_cli, group_deploy_token):
     # TODO assert not in list
 
 
+def test_project_member_all(gitlab_cli, project):
+    cmd = [
+        "project-member-all",
+        "list",
+        "--project-id",
+        project.id,
+    ]
+    ret = gitlab_cli(cmd)
+
+    assert ret.success
+
+
+def test_group_member_all(gitlab_cli, group):
+    cmd = [
+        "group-member-all",
+        "list",
+        "--group-id",
+        group.id,
+    ]
+    ret = gitlab_cli(cmd)
+
+    assert ret.success
+
+
+# Deleting the project and group. Add your tests above here.
 def test_delete_project(gitlab_cli, project):
     cmd = ["project", "delete", "--id", project.id]
     ret = gitlab_cli(cmd)
@@ -713,3 +738,6 @@ def test_delete_group(gitlab_cli, group):
     ret = gitlab_cli(cmd)
 
     assert ret.success
+
+
+# Don't add tests below here as the group and project have been deleted


### PR DESCRIPTION
Change it so that:

  GroupMemberAllManager uses GroupMemberAll object
  ProjectMemberAllManager uses ProjectMemberAll object

Create GroupMemberAll and ProjectMemberAll objects that do not support
any Mixin type methods. Previously we were using GroupMember and
ProjectMember which support the `save()` and `delete()` methods but
those methods will not work with objects retrieved using the
`/members/all/` API calls.

`list()` API calls:
  GET /groups/:id/members/all
  GET /projects/:id/members/all

`get()` API calls:
  GET /groups/:id/members/all/:user_id
  GET /projects/:id/members/all/:user_id

Closes: #1825
Closes: #848

[1] https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-and-invited-members
[2] https://docs.gitlab.com/ee/api/members.html#get-a-member-of-a-group-or-project-including-inherited-and-invited-members