### PR TITLE
fix(api): services: add missing `lazy` parameter

### DIFF
--- a/gitlab/v4/objects/services.py
+++ b/gitlab/v4/objects/services.py
@@ -1,3 +1,8 @@
+"""
+GitLab API:
+https://docs.gitlab.com/ee/api/integrations.html
+"""
+
 from typing import Any, cast, Dict, List, Optional, Union
 
 from gitlab import cli
@@ -275,7 +280,10 @@ class ProjectServiceManager(GetMixin, UpdateMixin, DeleteMixin, ListMixin, RESTM
             GitlabAuthenticationError: If authentication is not correct
             GitlabGetError: If the server cannot perform the request
         """
-        obj = cast(ProjectService, super(ProjectServiceManager, self).get(id, **kwargs))
+        obj = cast(
+            ProjectService,
+            super(ProjectServiceManager, self).get(id, lazy=lazy, **kwargs),
+        )
         obj.id = id
         return obj
 

--- a/tests/functional/api/test_services.py
+++ b/tests/functional/api/test_services.py
@@ -1,0 +1,11 @@
+"""
+GitLab API:
+https://docs.gitlab.com/ee/api/integrations.html
+"""
+
+import gitlab
+
+
+def test_services(project):
+    service = project.services.get("jira", lazy=True)
+    assert isinstance(service, gitlab.v4.objects.ProjectService)


### PR DESCRIPTION
Commit 8da0b758c589f608a6ae4eeb74b3f306609ba36d added the `lazy`
parameter to the services `get()` method but missed then using the
`lazy` parameter when it called `super(...).get(...)`

Closes: #1828