### PR TITLE
feat(api): add `project.transfer()` and deprecate `transfer_project()`

### DIFF
--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Callable, cast, Dict, List, Optional, TYPE_CHECKING, Union
 
 import requests
@@ -526,7 +527,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
 
     @cli.register_custom_action("Project", ("to_namespace",))
     @exc.on_http_error(exc.GitlabTransferProjectError)
-    def transfer_project(self, to_namespace: str, **kwargs: Any) -> None:
+    def transfer(self, to_namespace: str, **kwargs: Any) -> None:
         """Transfer a project to the given namespace ID
 
         Args:
@@ -542,6 +543,15 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         self.manager.gitlab.http_put(
             path, post_data={"namespace": to_namespace}, **kwargs
         )
+
+    @cli.register_custom_action("Project", ("to_namespace",))
+    def transfer_project(self, *args: Any, **kwargs: Any) -> None:
+        warnings.warn(
+            "The project.transfer_project() method is deprecated and will be "
+            "removed in a future version. Use project.transfer() instead.",
+            DeprecationWarning,
+        )
+        return self.transfer(*args, **kwargs)
 
     @cli.register_custom_action("Project", ("ref_name", "job"), ("job_token",))
     @exc.on_http_error(exc.GitlabGetError)

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -527,7 +527,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
 
     @cli.register_custom_action("Project", ("to_namespace",))
     @exc.on_http_error(exc.GitlabTransferProjectError)
-    def transfer(self, to_namespace: str, **kwargs: Any) -> None:
+    def transfer(self, to_namespace: Union[int, str], **kwargs: Any) -> None:
         """Transfer a project to the given namespace ID
 
         Args:

--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -231,3 +231,19 @@ def test_group_hooks(group):
     hook = group.hooks.get(hook.id)
     assert hook.note_events is True
     hook.delete()
+
+
+@pytest.mark.skip(reason="Pending #1807")
+def test_group_transfer(gl, group):
+    transfer_group = gl.groups.create({"name": "transfer-test-group"})
+    assert group.namespace["path"] != group.full_path
+
+    transfer_group.transfer(group.id)
+
+    transferred_group = gl.projects.get(transfer_group.id)
+    assert transferred_group.namespace["path"] == group.full_path
+
+    transfer_group.transfer()
+
+    transferred_group = gl.projects.get(transfer_group.id)
+    assert transferred_group.path == transferred_group.full_path

--- a/tests/functional/api/test_projects.py
+++ b/tests/functional/api/test_projects.py
@@ -329,3 +329,17 @@ def test_project_groups_list(gl, group):
     groups = project.groups.list()
     group_ids = set([x.id for x in groups])
     assert set((group.id, group2.id)) == group_ids
+
+
+def test_project_transfer(gl, project, group):
+    assert project.namespace["path"] != group.full_path
+    project.transfer_project(group.id)
+
+    project = gl.projects.get(project.id)
+    assert project.namespace["path"] == group.full_path
+
+    gl.auth()
+    project.transfer_project(gl.user.username)
+
+    project = gl.projects.get(project.id)
+    assert project.namespace["path"] == gl.user.username


### PR DESCRIPTION
Needed to bring things in line with https://github.com/python-gitlab/python-gitlab/pull/1807.

`transfer_project` was very confusing already as the direction of transfer can differ depending on the endpoint, see other PR for discussion.