### PR TITLE
ci: don't fail CI if unable to upload the code coverage data

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           files: ./coverage.xml
           flags: ${{ matrix.toxenv }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   coverage:
     runs-on: ubuntu-20.04
@@ -101,4 +101,4 @@ jobs:
         with:
           files: ./coverage.xml
           flags: unit
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
If a CI job can't upload coverage results to codecov.com it causes the
CI to fail and code can't be merged.