### PR TITLE
chore(objects): use `self.encoded_id` where could be a string

### DIFF
--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -92,7 +92,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabAuthenticationError: If authentication is not correct
             GitlabTransferProjectError: If the project could not be transferred
         """
-        path = f"/groups/{self.id}/projects/{project_id}"
+        path = f"/groups/{self.encoded_id}/projects/{project_id}"
         self.manager.gitlab.http_post(path, **kwargs)
 
     @cli.register_custom_action("Group", ("scope", "search"))

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -441,7 +441,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             with open(filepath, "rb") as f:
                 filedata = f.read()
 
-        url = f"/projects/{self.id}/uploads"
+        url = f"/projects/{self.encoded_id}/uploads"
         file_info = {"file": (filename, filedata)}
         data = self.manager.gitlab.http_post(url, files=file_info)
 
@@ -538,7 +538,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             GitlabAuthenticationError: If authentication is not correct
             GitlabTransferProjectError: If the project could not be transferred
         """
-        path = f"/projects/{self.id}/transfer"
+        path = f"/projects/{self.encoded_id}/transfer"
         self.manager.gitlab.http_put(
             path, post_data={"namespace": to_namespace}, **kwargs
         )


### PR DESCRIPTION
Updated a few remaining usages of `self.id` to use `self.encoded_id`
where it could be a string value.