### PR TITLE
chore(objects): use `self.encoded_id` where applicable

### DIFF
--- a/gitlab/v4/objects/todos.py
+++ b/gitlab/v4/objects/todos.py
@@ -27,7 +27,7 @@ class Todo(ObjectDeleteMixin, RESTObject):
         Returns:
             A dict with the result
         """
-        path = f"{self.manager.path}/{self.id}/mark_as_done"
+        path = f"{self.manager.path}/{self.encoded_id}/mark_as_done"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(server_data, dict)

--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -179,7 +179,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             Whether the user status has been changed
         """
-        path = f"/users/{self.id}/block"
+        path = f"/users/{self.encoded_id}/block"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if server_data is True:
             self._attrs["state"] = "blocked"
@@ -200,7 +200,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             The new object data (*not* a RESTObject)
         """
-        path = f"/users/{self.id}/follow"
+        path = f"/users/{self.encoded_id}/follow"
         return self.manager.gitlab.http_post(path, **kwargs)
 
     @cli.register_custom_action("User")
@@ -218,7 +218,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             The new object data (*not* a RESTObject)
         """
-        path = f"/users/{self.id}/unfollow"
+        path = f"/users/{self.encoded_id}/unfollow"
         return self.manager.gitlab.http_post(path, **kwargs)
 
     @cli.register_custom_action("User")
@@ -236,7 +236,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             Whether the user status has been changed
         """
-        path = f"/users/{self.id}/unblock"
+        path = f"/users/{self.encoded_id}/unblock"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if server_data is True:
             self._attrs["state"] = "active"
@@ -257,7 +257,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             Whether the user status has been changed
         """
-        path = f"/users/{self.id}/deactivate"
+        path = f"/users/{self.encoded_id}/deactivate"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if server_data:
             self._attrs["state"] = "deactivated"
@@ -278,7 +278,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
         Returns:
             Whether the user status has been changed
         """
-        path = f"/users/{self.id}/activate"
+        path = f"/users/{self.encoded_id}/activate"
         server_data = self.manager.gitlab.http_post(path, **kwargs)
         if server_data:
             self._attrs["state"] = "active"


### PR DESCRIPTION
Updated a few remaining usages of `self.id` to use `self.encoded_id`
as for the most part we shouldn't be using `self.id`

There are now only a few (4 lines of code) remaining uses of
`self.id`, most of which seem that they should stay that way.