### PR TITLE
chore(tests): use method `projects.transfer()`

### DIFF
--- a/tests/functional/api/test_projects.py
+++ b/tests/functional/api/test_projects.py
@@ -333,13 +333,13 @@ def test_project_groups_list(gl, group):
 
 def test_project_transfer(gl, project, group):
     assert project.namespace["path"] != group.full_path
-    project.transfer_project(group.id)
+    project.transfer(group.id)
 
     project = gl.projects.get(project.id)
     assert project.namespace["path"] == group.full_path
 
     gl.auth()
-    project.transfer_project(gl.user.username)
+    project.transfer(gl.user.username)
 
     project = gl.projects.get(project.id)
     assert project.namespace["path"] == gl.user.username


### PR DESCRIPTION
When doing the functional tests use the new function
`projects.transfer` instead of the deprecated function
`projects.transfer_project()`
