### PR TITLE
chore: create return type-hints for `get_id()` & `encoded_id`

### DIFF
--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -19,7 +19,7 @@ import importlib
 import pprint
 import textwrap
 from types import ModuleType
-from typing import Any, Dict, Iterable, NamedTuple, Optional, Tuple, Type
+from typing import Any, Dict, Iterable, NamedTuple, Optional, Tuple, Type, Union
 
 import gitlab
 from gitlab import types as g_types
@@ -211,14 +211,14 @@ class RESTObject(object):
         self.__dict__["_updated_attrs"] = {}
         self.__dict__["_attrs"] = new_attrs
 
-    def get_id(self) -> Any:
+    def get_id(self) -> Optional[Union[int, str]]:
         """Returns the id of the resource."""
         if self._id_attr is None or not hasattr(self, self._id_attr):
             return None
         return getattr(self, self._id_attr)
 
     @property
-    def encoded_id(self) -> Any:
+    def encoded_id(self) -> Optional[Union[int, str]]:
         """Ensure that the ID is url-encoded so that it can be safely used in a URL
         path"""
         obj_id = self.get_id()

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -576,6 +576,7 @@ class ObjectDeleteMixin(_RestObjectBase):
         """
         if TYPE_CHECKING:
             assert isinstance(self.manager, DeleteMixin)
+            assert self.encoded_id is not None
         self.manager.delete(self.encoded_id, **kwargs)
 
 

--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -77,6 +77,8 @@ class ProjectFile(SaveMixin, ObjectDeleteMixin, RESTObject):
             GitlabDeleteError: If the server cannot perform the request
         """
         file_path = self.encoded_id
+        if TYPE_CHECKING:
+            assert isinstance(file_path, str)
         self.manager.delete(file_path, branch, commit_message, **kwargs)
 
 


### PR DESCRIPTION
Create return type-hints for `RESTObject.get_id()` and
`RESTObject.encoded_id`. Previously was saying they return Any. Be
more precise in saying they can return either: None, str, or int.