### PR TITLE
fix(objects): make resource access tokens and repos available in CLI

### DIFF
--- a/gitlab/v4/objects/__init__.py
+++ b/gitlab/v4/objects/__init__.py
@@ -39,6 +39,7 @@ from .export_import import *
 from .features import *
 from .files import *
 from .geo_nodes import *
+from .group_access_tokens import *
 from .groups import *
 from .hooks import *
 from .issues import *
@@ -58,9 +59,11 @@ from .packages import *
 from .pages import *
 from .personal_access_tokens import *
 from .pipelines import *
+from .project_access_tokens import *
 from .projects import *
 from .push_rules import *
 from .releases import *
+from .repositories import *
 from .runners import *
 from .services import *
 from .settings import *

--- a/tests/functional/cli/test_cli_resource_access_tokens.py
+++ b/tests/functional/cli/test_cli_resource_access_tokens.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+def test_list_project_access_tokens(gitlab_cli, project):
+    cmd = ["project-access-token", "list", "--project-id", project.id]
+    ret = gitlab_cli(cmd)
+
+    assert ret.success
+
+
+@pytest.mark.skip(reason="Requires GitLab 14.7")
+def test_list_group_access_tokens(gitlab_cli, group):
+    cmd = ["group-access-token", "list", "--group-id", group.id]
+    ret = gitlab_cli(cmd)
+
+    assert ret.success


### PR DESCRIPTION
This was a bit of an oversight from me a while ago and it's carried over to newer PRs.