### PR TITLE
fix(cli): allow custom methods in managers

### DIFF
--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -94,6 +94,7 @@ class GitlabCLI(object):
         return self.do_custom()
 
     def do_custom(self) -> Any:
+        class_instance: Union[gitlab.base.RESTManager, gitlab.base.RESTObject]
         in_obj = cli.custom_actions[self.cls_name][self.action][2]
 
         # Get the object (lazy), then act
@@ -106,11 +107,12 @@ class GitlabCLI(object):
                 if TYPE_CHECKING:
                     assert isinstance(self.cls._id_attr, str)
                 data[self.cls._id_attr] = self.args.pop(self.cls._id_attr)
-            obj = self.cls(self.mgr, data)
-            method_name = self.action.replace("-", "_")
-            return getattr(obj, method_name)(**self.args)
+            class_instance = self.cls(self.mgr, data)
         else:
-            return getattr(self.mgr, self.action)(**self.args)
+            class_instance = self.mgr
+
+        method_name = self.action.replace("-", "_")
+        return getattr(class_instance, method_name)(**self.args)
 
     def do_project_export_download(self) -> None:
         try:

--- a/tests/functional/cli/conftest.py
+++ b/tests/functional/cli/conftest.py
@@ -33,3 +33,12 @@ def resp_get_project():
         "content_type": "application/json",
         "status": 200,
     }
+
+
+@pytest.fixture
+def resp_delete_registry_tags_in_bulk():
+    return {
+        "method": responses.DELETE,
+        "url": f"{DEFAULT_URL}/api/v4/projects/1/registry/repositories/1/tags",
+        "status": 202,
+    }

--- a/tests/functional/cli/test_cli_projects.py
+++ b/tests/functional/cli/test_cli_projects.py
@@ -1,0 +1,27 @@
+import pytest
+import responses
+
+
+@pytest.mark.script_launch_mode("inprocess")
+@responses.activate
+def test_project_registry_delete_in_bulk(
+    script_runner, resp_delete_registry_tags_in_bulk
+):
+    responses.add(**resp_delete_registry_tags_in_bulk)
+    cmd = [
+        "gitlab",
+        "project-registry-tag",
+        "delete-in-bulk",
+        "--project-id",
+        "1",
+        "--repository-id",
+        "1",
+        "--name-regex-delete",
+        "^.*dev.*$",
+        # TODO: remove `name` after deleting without ID is possible
+        # See #849 and #1631
+        "--name",
+        ".*",
+    ]
+    ret = ret = script_runner.run(*cmd)
+    assert ret.success


### PR DESCRIPTION
Closes #849 

@JohnVillalovos let me know if you're not available these days and I can re-assign :)

This is still a bit dirty - we need a `DeleteWithoutIdMixin` actually, hence the note in the test. But that's out of scope for this PR I'd say. Also I'm mocking the response in the functional CLI test because of the scaffolding required to get a full docker registry repo up for tests. It still tests the actual CLI not just units though. Maybe one day we add :)