### PR TITLE
chore: rename `types.ListAttribute` to `types.CommaSeparatedListAttribute`

### DIFF
--- a/gitlab/types.py
+++ b/gitlab/types.py
@@ -32,7 +32,7 @@ class GitlabAttribute(object):
         return self._value
 
 
-class ListAttribute(GitlabAttribute):
+class CommaSeparatedListAttribute(GitlabAttribute):
     def set_from_cli(self, cli_value: str) -> None:
         if not cli_value.strip():
             self._value = []

--- a/gitlab/v4/objects/deploy_tokens.py
+++ b/gitlab/v4/objects/deploy_tokens.py
@@ -39,7 +39,7 @@ class GroupDeployTokenManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
             "username",
         ),
     )
-    _types = {"scopes": types.ListAttribute}
+    _types = {"scopes": types.CommaSeparatedListAttribute}
 
 
 class ProjectDeployToken(ObjectDeleteMixin, RESTObject):
@@ -60,4 +60,4 @@ class ProjectDeployTokenManager(ListMixin, CreateMixin, DeleteMixin, RESTManager
             "username",
         ),
     )
-    _types = {"scopes": types.ListAttribute}
+    _types = {"scopes": types.CommaSeparatedListAttribute}

--- a/gitlab/v4/objects/epics.py
+++ b/gitlab/v4/objects/epics.py
@@ -42,7 +42,7 @@ class GroupEpicManager(CRUDMixin, RESTManager):
     _update_attrs = RequiredOptional(
         optional=("title", "labels", "description", "start_date", "end_date"),
     )
-    _types = {"labels": types.ListAttribute}
+    _types = {"labels": types.CommaSeparatedListAttribute}
 
     def get(self, id: Union[str, int], lazy: bool = False, **kwargs: Any) -> GroupEpic:
         return cast(GroupEpic, super().get(id=id, lazy=lazy, **kwargs))

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -314,7 +314,10 @@ class GroupManager(CRUDMixin, RESTManager):
             "shared_runners_setting",
         ),
     )
-    _types = {"avatar": types.ImageAttribute, "skip_groups": types.ListAttribute}
+    _types = {
+        "avatar": types.ImageAttribute,
+        "skip_groups": types.CommaSeparatedListAttribute,
+    }
 
     def get(self, id: Union[str, int], lazy: bool = False, **kwargs: Any) -> Group:
         return cast(Group, super().get(id=id, lazy=lazy, **kwargs))
@@ -374,7 +377,7 @@ class GroupSubgroupManager(ListMixin, RESTManager):
         "with_custom_attributes",
         "min_access_level",
     )
-    _types = {"skip_groups": types.ListAttribute}
+    _types = {"skip_groups": types.CommaSeparatedListAttribute}
 
 
 class GroupDescendantGroup(RESTObject):

--- a/gitlab/v4/objects/issues.py
+++ b/gitlab/v4/objects/issues.py
@@ -65,7 +65,10 @@ class IssueManager(RetrieveMixin, RESTManager):
         "updated_after",
         "updated_before",
     )
-    _types = {"iids": types.ListAttribute, "labels": types.ListAttribute}
+    _types = {
+        "iids": types.CommaSeparatedListAttribute,
+        "labels": types.CommaSeparatedListAttribute,
+    }
 
     def get(self, id: Union[str, int], lazy: bool = False, **kwargs: Any) -> Issue:
         return cast(Issue, super().get(id=id, lazy=lazy, **kwargs))
@@ -95,7 +98,10 @@ class GroupIssueManager(ListMixin, RESTManager):
         "updated_after",
         "updated_before",
     )
-    _types = {"iids": types.ListAttribute, "labels": types.ListAttribute}
+    _types = {
+        "iids": types.CommaSeparatedListAttribute,
+        "labels": types.CommaSeparatedListAttribute,
+    }
 
 
 class ProjectIssue(
@@ -233,7 +239,10 @@ class ProjectIssueManager(CRUDMixin, RESTManager):
             "discussion_locked",
         ),
     )
-    _types = {"iids": types.ListAttribute, "labels": types.ListAttribute}
+    _types = {
+        "iids": types.CommaSeparatedListAttribute,
+        "labels": types.CommaSeparatedListAttribute,
+    }
 
     def get(
         self, id: Union[str, int], lazy: bool = False, **kwargs: Any

--- a/gitlab/v4/objects/members.py
+++ b/gitlab/v4/objects/members.py
@@ -41,7 +41,7 @@ class GroupMemberManager(CRUDMixin, RESTManager):
     _update_attrs = RequiredOptional(
         required=("access_level",), optional=("expires_at",)
     )
-    _types = {"user_ids": types.ListAttribute}
+    _types = {"user_ids": types.CommaSeparatedListAttribute}
 
     def get(
         self, id: Union[str, int], lazy: bool = False, **kwargs: Any
@@ -101,7 +101,7 @@ class ProjectMemberManager(CRUDMixin, RESTManager):
     _update_attrs = RequiredOptional(
         required=("access_level",), optional=("expires_at",)
     )
-    _types = {"user_ids": types.ListAttribute}
+    _types = {"user_ids": types.CommaSeparatedListAttribute}
 
     def get(
         self, id: Union[str, int], lazy: bool = False, **kwargs: Any

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -95,10 +95,10 @@ class MergeRequestManager(ListMixin, RESTManager):
         "deployed_after",
     )
     _types = {
-        "approver_ids": types.ListAttribute,
-        "approved_by_ids": types.ListAttribute,
-        "in": types.ListAttribute,
-        "labels": types.ListAttribute,
+        "approver_ids": types.CommaSeparatedListAttribute,
+        "approved_by_ids": types.CommaSeparatedListAttribute,
+        "in": types.CommaSeparatedListAttribute,
+        "labels": types.CommaSeparatedListAttribute,
     }
 
 
@@ -133,9 +133,9 @@ class GroupMergeRequestManager(ListMixin, RESTManager):
         "wip",
     )
     _types = {
-        "approver_ids": types.ListAttribute,
-        "approved_by_ids": types.ListAttribute,
-        "labels": types.ListAttribute,
+        "approver_ids": types.CommaSeparatedListAttribute,
+        "approved_by_ids": types.CommaSeparatedListAttribute,
+        "labels": types.CommaSeparatedListAttribute,
     }
 
 
@@ -455,10 +455,10 @@ class ProjectMergeRequestManager(CRUDMixin, RESTManager):
         "wip",
     )
     _types = {
-        "approver_ids": types.ListAttribute,
-        "approved_by_ids": types.ListAttribute,
-        "iids": types.ListAttribute,
-        "labels": types.ListAttribute,
+        "approver_ids": types.CommaSeparatedListAttribute,
+        "approved_by_ids": types.CommaSeparatedListAttribute,
+        "iids": types.CommaSeparatedListAttribute,
+        "labels": types.CommaSeparatedListAttribute,
     }
 
     def get(

--- a/gitlab/v4/objects/milestones.py
+++ b/gitlab/v4/objects/milestones.py
@@ -93,7 +93,7 @@ class GroupMilestoneManager(CRUDMixin, RESTManager):
         optional=("title", "description", "due_date", "start_date", "state_event"),
     )
     _list_filters = ("iids", "state", "search")
-    _types = {"iids": types.ListAttribute}
+    _types = {"iids": types.CommaSeparatedListAttribute}
 
     def get(
         self, id: Union[str, int], lazy: bool = False, **kwargs: Any
@@ -177,7 +177,7 @@ class ProjectMilestoneManager(CRUDMixin, RESTManager):
         optional=("title", "description", "due_date", "start_date", "state_event"),
     )
     _list_filters = ("iids", "state", "search")
-    _types = {"iids": types.ListAttribute}
+    _types = {"iids": types.CommaSeparatedListAttribute}
 
     def get(
         self, id: Union[str, int], lazy: bool = False, **kwargs: Any

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -125,7 +125,7 @@ class ProjectGroupManager(ListMixin, RESTManager):
         "shared_min_access_level",
         "shared_visible_only",
     )
-    _types = {"skip_groups": types.ListAttribute}
+    _types = {"skip_groups": types.CommaSeparatedListAttribute}
 
 
 class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTObject):
@@ -807,7 +807,10 @@ class ProjectManager(CRUDMixin, RESTManager):
         "with_merge_requests_enabled",
         "with_programming_language",
     )
-    _types = {"avatar": types.ImageAttribute, "topic": types.ListAttribute}
+    _types = {
+        "avatar": types.ImageAttribute,
+        "topic": types.CommaSeparatedListAttribute,
+    }
 
     def get(self, id: Union[str, int], lazy: bool = False, **kwargs: Any) -> Project:
         return cast(Project, super().get(id=id, lazy=lazy, **kwargs))

--- a/gitlab/v4/objects/runners.py
+++ b/gitlab/v4/objects/runners.py
@@ -68,7 +68,7 @@ class RunnerManager(CRUDMixin, RESTManager):
         ),
     )
     _list_filters = ("scope", "tag_list")
-    _types = {"tag_list": types.ListAttribute}
+    _types = {"tag_list": types.CommaSeparatedListAttribute}
 
     @cli.register_custom_action("RunnerManager", tuple(), ("scope",))
     @exc.on_http_error(exc.GitlabListError)
@@ -130,7 +130,7 @@ class GroupRunnerManager(ListMixin, RESTManager):
     _from_parent_attrs = {"group_id": "id"}
     _create_attrs = RequiredOptional(required=("runner_id",))
     _list_filters = ("scope", "tag_list")
-    _types = {"tag_list": types.ListAttribute}
+    _types = {"tag_list": types.CommaSeparatedListAttribute}
 
 
 class ProjectRunner(ObjectDeleteMixin, RESTObject):
@@ -143,4 +143,4 @@ class ProjectRunnerManager(CreateMixin, DeleteMixin, ListMixin, RESTManager):
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(required=("runner_id",))
     _list_filters = ("scope", "tag_list")
-    _types = {"tag_list": types.ListAttribute}
+    _types = {"tag_list": types.CommaSeparatedListAttribute}

--- a/gitlab/v4/objects/settings.py
+++ b/gitlab/v4/objects/settings.py
@@ -80,12 +80,12 @@ class ApplicationSettingsManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
         ),
     )
     _types = {
-        "asset_proxy_allowlist": types.ListAttribute,
-        "disabled_oauth_sign_in_sources": types.ListAttribute,
-        "domain_allowlist": types.ListAttribute,
-        "domain_denylist": types.ListAttribute,
-        "import_sources": types.ListAttribute,
-        "restricted_visibility_levels": types.ListAttribute,
+        "asset_proxy_allowlist": types.CommaSeparatedListAttribute,
+        "disabled_oauth_sign_in_sources": types.CommaSeparatedListAttribute,
+        "domain_allowlist": types.CommaSeparatedListAttribute,
+        "domain_denylist": types.CommaSeparatedListAttribute,
+        "import_sources": types.CommaSeparatedListAttribute,
+        "restricted_visibility_levels": types.CommaSeparatedListAttribute,
     }
 
     @exc.on_http_error(exc.GitlabUpdateError)

--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -369,7 +369,7 @@ class ProjectUserManager(ListMixin, RESTManager):
     _obj_cls = ProjectUser
     _from_parent_attrs = {"project_id": "id"}
     _list_filters = ("search", "skip_users")
-    _types = {"skip_users": types.ListAttribute}
+    _types = {"skip_users": types.CommaSeparatedListAttribute}
 
 
 class UserEmail(ObjectDeleteMixin, RESTObject):

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -30,8 +30,8 @@ def test_gitlab_attribute_get():
     assert o._value is None
 
 
-def test_list_attribute_input():
-    o = types.ListAttribute()
+def test_csv_list_attribute_input():
+    o = types.CommaSeparatedListAttribute()
     o.set_from_cli("foo,bar,baz")
     assert o.get() == ["foo", "bar", "baz"]
 
@@ -39,8 +39,8 @@ def test_list_attribute_input():
     assert o.get() == ["foo"]
 
 
-def test_list_attribute_empty_input():
-    o = types.ListAttribute()
+def test_csv_list_attribute_empty_input():
+    o = types.CommaSeparatedListAttribute()
     o.set_from_cli("")
     assert o.get() == []
 
@@ -48,24 +48,24 @@ def test_list_attribute_empty_input():
     assert o.get() == []
 
 
-def test_list_attribute_get_for_api_from_cli():
-    o = types.ListAttribute()
+def test_csv_list_attribute_get_for_api_from_cli():
+    o = types.CommaSeparatedListAttribute()
     o.set_from_cli("foo,bar,baz")
     assert o.get_for_api() == "foo,bar,baz"
 
 
-def test_list_attribute_get_for_api_from_list():
-    o = types.ListAttribute(["foo", "bar", "baz"])
+def test_csv_list_attribute_get_for_api_from_list():
+    o = types.CommaSeparatedListAttribute(["foo", "bar", "baz"])
     assert o.get_for_api() == "foo,bar,baz"
 
 
-def test_list_attribute_get_for_api_from_int_list():
-    o = types.ListAttribute([1, 9, 7])
+def test_csv_list_attribute_get_for_api_from_int_list():
+    o = types.CommaSeparatedListAttribute([1, 9, 7])
     assert o.get_for_api() == "1,9,7"
 
 
-def test_list_attribute_does_not_split_string():
-    o = types.ListAttribute("foo")
+def test_csv_list_attribute_does_not_split_string():
+    o = types.CommaSeparatedListAttribute("foo")
     assert o.get_for_api() == "foo"
 
 


### PR DESCRIPTION
This name more accurately describes what the type is. Also this is the
first step in a series of steps of our goal to add full support for
the GitLab API data types[1]:
  * array
  * hash
  * array of hashes

[1] https://docs.gitlab.com/ee/api/#encoding-api-parameters-of-array-and-hash-types