### PR TITLE
fix(cli): make 'timeout', 'per_page' and 'page' type explicit

### DIFF
--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -181,6 +181,7 @@ def _get_base_parser(add_help: bool = True) -> argparse.ArgumentParser:
             "[env var: GITLAB_TIMEOUT]"
         ),
         required=False,
+        type=int,
         default=os.getenv("GITLAB_TIMEOUT"),
     )
     parser.add_argument(

--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -197,6 +197,7 @@ def _get_base_parser(add_help: bool = True) -> argparse.ArgumentParser:
             "[env var: GITLAB_PER_PAGE]"
         ),
         required=False,
+        type=int,
         default=os.getenv("GITLAB_PER_PAGE"),
     )
     parser.add_argument(

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -218,8 +218,8 @@ def _populate_sub_parser_by_class(
                     f"--{x.replace('_', '-')}", required=False
                 )
 
-            sub_parser_action.add_argument("--page", required=False)
-            sub_parser_action.add_argument("--per-page", required=False)
+            sub_parser_action.add_argument("--page", required=False, type=int)
+            sub_parser_action.add_argument("--per-page", required=False, type=int)
             sub_parser_action.add_argument("--all", required=False, action="store_true")
 
         if action_name == "delete":


### PR DESCRIPTION
This PR is mainly for fixing handling of `--timeout` / `GITLAB_TIMEOUT`.

**Before:**
```
$ docker run -it --rm python-gitlab:latest --timeout=10 project get --id gitlab-org/gitlab
Impossible to get object (Timeout value connect was 10, but it must be an int, float or None.)

$ docker run -it --rm -e GITLAB_TIMEOUT=10 python-gitlab:latest project get --id gitlab-org/gitlab
Impossible to get object (Timeout value connect was 10, but it must be an int, float or None.)
```

**After (with bbb7df526f4375c438be97d8cfa0d9ea9d604e7d):**
```
$ docker run -it --rm python-gitlab:latest --timeout 10 project get --id gitlab-org/gitlab
id: 278964
path: gitlab

$ docker run -it --rm -e GITLAB_TIMEOUT=10 python-gitlab:latest project get --id gitlab-org/gitlab
id: 278964
path: gitlab

$ docker run -it --rm python-gitlab:latest --timeout xxx project get --id gitlab-org/gitlab
usage: gitlab [--version] [-v] [-d] [-c CONFIG_FILE] [-g GITLAB] [-o {json,legacy,yaml}] [-f FIELDS] [--server-url SERVER_URL] [--ssl-verify SSL_VERIFY] [--timeout TIMEOUT] [--api-version API_VERSION] [--per-page PER_PAGE]
              [--pagination PAGINATION] [--order-by ORDER_BY] [--user-agent USER_AGENT] [--private-token PRIVATE_TOKEN | --oauth-token OAUTH_TOKEN | --job-token JOB_TOKEN]
gitlab: error: argument --timeout: invalid int value: 'xxx'

$ docker run -it --rm -e GITLAB_TIMEOUT=xxx python-gitlab:latest project get --id gitlab-org/gitlab
usage: gitlab [--version] [-v] [-d] [-c CONFIG_FILE] [-g GITLAB] [-o {json,legacy,yaml}] [-f FIELDS] [--server-url SERVER_URL] [--ssl-verify SSL_VERIFY] [--timeout TIMEOUT] [--api-version API_VERSION] [--per-page PER_PAGE]
              [--pagination PAGINATION] [--order-by ORDER_BY] [--user-agent USER_AGENT] [--private-token PRIVATE_TOKEN | --oauth-token OAUTH_TOKEN | --job-token JOB_TOKEN]
gitlab: error: argument --timeout: invalid int value: 'xxx'
```

The 2nd commit (d493a5e8685018daa69c92e5942cbe763e5dac62) is less a fix, it's more to make things coherent for these two other `int` arguments. It improves handling of non-int values, I think.

**Before:**
```
$ docker run -it --rm -e GITLAB_PER_PAGE=xxx python-gitlab:latest project list
Impossible to list objects (400: per_page is invalid)

$ docker run -it --rm python-gitlab:latest --per-page xxx project list
Impossible to list objects (400: per_page is invalid)

$ docker run -it --rm python-gitlab:latest --per-page 2 project list --page xxx
Impossible to list objects (400: page is invalid)
```

**After (with d493a5e8685018daa69c92e5942cbe763e5dac62):**
```
$ docker run -it --rm -e GITLAB_PER_PAGE=xxx python-gitlab:latest project list
usage: gitlab [--version] [-v] [-d] [-c CONFIG_FILE] [-g GITLAB] [-o {json,legacy,yaml}] [-f FIELDS] [--server-url SERVER_URL] [--ssl-verify SSL_VERIFY] [--timeout TIMEOUT] [--api-version API_VERSION] [--per-page PER_PAGE]
              [--pagination PAGINATION] [--order-by ORDER_BY] [--user-agent USER_AGENT] [--private-token PRIVATE_TOKEN | --oauth-token OAUTH_TOKEN | --job-token JOB_TOKEN]
gitlab: error: argument --per-page: invalid int value: 'xxx'

$ docker run -it --rm python-gitlab:latest --per-page xxx project list
usage: gitlab [--version] [-v] [-d] [-c CONFIG_FILE] [-g GITLAB] [-o {json,legacy,yaml}] [-f FIELDS] [--server-url SERVER_URL] [--ssl-verify SSL_VERIFY] [--timeout TIMEOUT] [--api-version API_VERSION] [--per-page PER_PAGE]
              [--pagination PAGINATION] [--order-by ORDER_BY] [--user-agent USER_AGENT] [--private-token PRIVATE_TOKEN | --oauth-token OAUTH_TOKEN | --job-token JOB_TOKEN]
gitlab: error: argument --per-page: invalid int value: 'xxx'

$ docker run -it --rm python-gitlab:latest --per-page 2 project list --page xxx
usage: gitlab project list [-h] [--sudo SUDO] [--archived ARCHIVED] [--id-after ID_AFTER] [--id-before ID_BEFORE] [--last-activity-after LAST_ACTIVITY_AFTER] [--last-activity-before LAST_ACTIVITY_BEFORE] [--membership MEMBERSHIP]
                           [--min-access-level MIN_ACCESS_LEVEL] [--order-by ORDER_BY] [--owned OWNED] [--repository-checksum-failed REPOSITORY_CHECKSUM_FAILED] [--repository-storage REPOSITORY_STORAGE]
                           [--search-namespaces SEARCH_NAMESPACES] [--search SEARCH] [--simple SIMPLE] [--sort SORT] [--starred STARRED] [--statistics STATISTICS] [--topic TOPIC] [--visibility VISIBILITY]
                           [--wiki-checksum-failed WIKI_CHECKSUM_FAILED] [--with-custom-attributes WITH_CUSTOM_ATTRIBUTES] [--with-issues-enabled WITH_ISSUES_ENABLED] [--with-merge-requests-enabled WITH_MERGE_REQUESTS_ENABLED]
                           [--with-programming-language WITH_PROGRAMMING_LANGUAGE] [--page PAGE] [--per-page PER_PAGE] [--all]
gitlab project list: error: argument --page: invalid int value: 'xxx'
```

**Note:** all tests/examples above are run after rebuilding a container as documented in the README, so it seems to be with Python 3.10 (on Alpine).