### PR TITLE
chore(ci): do not run release workflow in forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   release:
+    if: github.repository == 'python-gitlab/python-gitlab'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
So we don't get scary emails from forks that we've rebased PRs for.