### PR TITLE
docs: revert temporary changelog link for v3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,10 +121,7 @@ html_theme = "furo"
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {
-    "announcement": "⚠ python-gitlab 3.0.0 has been released with several "
-    "<a href='changelog.html#breaking'>breaking changes</a>.",
-}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []


### PR DESCRIPTION
Super minor change which allows accessing the changelog from the warning at the top from anywhere in the documentation.

Right now it's e.g. `https://python-gitlab.readthedocs.io/en/stable/api/changelog.html#breaking` instead of `https://python-gitlab.readthedocs.io/en/stable/changelog.html#breaking` when accessing it from the `API reference` page. This should fix that.

I simply tested it with the builtin Python server, not sure if the behavior is the same when deployed:

```bash
tox -e docs
cd build/sphinx/html
python -m http.server
```