### PR TITLE
fix: remove custom `delete` method for labels

### DIFF
--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -104,7 +104,6 @@ def test_groups(gl):
     group2.members.delete(gl.user.id)
 
 
-@pytest.mark.skip(reason="Commented out in legacy test")
 def test_group_labels(group):
     group.labels.create({"name": "foo", "description": "bar", "color": "#112233"})
     label = group.labels.get("foo")
@@ -115,6 +114,12 @@ def test_group_labels(group):
     label = group.labels.get("foo")
     assert label.description == "baz"
     assert len(group.labels.list()) == 1
+
+    label.new_name = "Label:that requires:encoding"
+    label.save()
+    assert label.name == "Label:that requires:encoding"
+    label = group.labels.get("Label:that requires:encoding")
+    assert label.name == "Label:that requires:encoding"
 
     label.delete()
     assert len(group.labels.list()) == 0

--- a/tests/functional/api/test_projects.py
+++ b/tests/functional/api/test_projects.py
@@ -146,9 +146,11 @@ def test_project_labels(project):
     label = project.labels.get("label")
     assert label == labels[0]
 
-    label.new_name = "labelupdated"
+    label.new_name = "Label:that requires:encoding"
     label.save()
-    assert label.name == "labelupdated"
+    assert label.name == "Label:that requires:encoding"
+    label = project.labels.get("Label:that requires:encoding")
+    assert label.name == "Label:that requires:encoding"
 
     label.subscribe()
     assert label.subscribed is True


### PR DESCRIPTION
The usage of deleting was incorrect according to the current API.
Remove custom `delete()` method as not needed.

Add tests to show it works with labels needing to be encoded.

Also enable the test_group_labels() test function. Previously it was
disabled.

Add ability to do a `get()` for group labels.

Closes: #1867