### PR TITLE
feat(objects): add a complete artifacts manager

### DIFF
--- a/docs/gl_objects/pipelines_and_jobs.rst
+++ b/docs/gl_objects/pipelines_and_jobs.rst
@@ -245,9 +245,14 @@ Get the artifacts of a job::
     build_or_job.artifacts()
 
 Get the artifacts of a job by its name from the latest successful pipeline of
-a branch or tag:
+a branch or tag::
 
-  project.artifacts(ref_name='main', job='build')
+  project.artifacts.download(ref_name='main', job='build')
+
+.. attention::
+
+    An older method ``project.artifacts()`` is deprecated and will be
+    removed in a future version.
 
 .. warning::
 
@@ -275,7 +280,12 @@ Get a single artifact file::
 
 Get a single artifact file by branch and job::
 
-    project.artifact('branch', 'path/to/file', 'job')
+    project.artifacts.raw('branch', 'path/to/file', 'job')
+
+.. attention::
+
+    An older method ``project.artifact()`` is deprecated and will be
+    removed in a future version.
 
 Mark a job artifact as kept when expiration is set::
 

--- a/gitlab/v4/objects/__init__.py
+++ b/gitlab/v4/objects/__init__.py
@@ -18,6 +18,7 @@
 from .access_requests import *
 from .appearance import *
 from .applications import *
+from .artifacts import *
 from .audit_events import *
 from .award_emojis import *
 from .badges import *

--- a/gitlab/v4/objects/artifacts.py
+++ b/gitlab/v4/objects/artifacts.py
@@ -17,6 +17,7 @@ __all__ = ["ProjectArtifact", "ProjectArtifactManager"]
 
 class ProjectArtifact(RESTObject):
     """Dummy object to manage custom actions on artifacts"""
+
     _id_attr = "ref_name"
 
 
@@ -57,6 +58,7 @@ class ProjectArtifactManager(RESTManager):
         **kwargs: Any,
     ) -> Optional[bytes]:
         """Get the job artifacts archive from a specific tag or branch.
+
         Args:
             ref_name: Branch or tag name in repository. HEAD or SHA references
             are not supported.
@@ -69,9 +71,11 @@ class ProjectArtifactManager(RESTManager):
                 data
             chunk_size: Size of each chunk
             **kwargs: Extra options to send to the server (e.g. sudo)
+
         Raises:
             GitlabAuthenticationError: If authentication is not correct
             GitlabGetError: If the artifacts could not be retrieved
+
         Returns:
             The artifacts if `streamed` is False, None otherwise.
         """
@@ -83,7 +87,9 @@ class ProjectArtifactManager(RESTManager):
             assert isinstance(result, requests.Response)
         return utils.response_content(result, streamed, action, chunk_size)
 
-    @cli.register_custom_action("ProjectArtifactManager", ("ref_name", "artifact_path", "job"))
+    @cli.register_custom_action(
+        "ProjectArtifactManager", ("ref_name", "artifact_path", "job")
+    )
     @exc.on_http_error(exc.GitlabGetError)
     def raw(
         self,
@@ -97,6 +103,7 @@ class ProjectArtifactManager(RESTManager):
     ) -> Optional[bytes]:
         """Download a single artifact file from a specific tag or branch from
         within the job's artifacts archive.
+
         Args:
             ref_name: Branch or tag name in repository. HEAD or SHA references
                 are not supported.
@@ -109,9 +116,11 @@ class ProjectArtifactManager(RESTManager):
                 data
             chunk_size: Size of each chunk
             **kwargs: Extra options to send to the server (e.g. sudo)
+
         Raises:
             GitlabAuthenticationError: If authentication is not correct
             GitlabGetError: If the artifacts could not be retrieved
+
         Returns:
             The artifact if `streamed` is False, None otherwise.
         """

--- a/gitlab/v4/objects/artifacts.py
+++ b/gitlab/v4/objects/artifacts.py
@@ -1,0 +1,124 @@
+"""
+GitLab API:
+https://docs.gitlab.com/ee/api/job_artifacts.html
+"""
+import warnings
+from typing import Any, Callable, Optional, TYPE_CHECKING
+
+import requests
+
+from gitlab import cli
+from gitlab import exceptions as exc
+from gitlab import utils
+from gitlab.base import RESTManager, RESTObject
+
+__all__ = ["ProjectArtifact", "ProjectArtifactManager"]
+
+
+class ProjectArtifact(RESTObject):
+    """Dummy object to manage custom actions on artifacts"""
+    _id_attr = "ref_name"
+
+
+class ProjectArtifactManager(RESTManager):
+    _obj_cls = ProjectArtifact
+    _path = "/projects/{project_id}/jobs/artifacts"
+    _from_parent_attrs = {"project_id": "id"}
+
+    @cli.register_custom_action(
+        "Project", ("ref_name", "job"), ("job_token",), custom_action="artifacts"
+    )
+    def __call__(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[bytes]:
+        warnings.warn(
+            "The project.artifacts() method is deprecated and will be "
+            "removed in a future version. Use project.artifacts.download() instead.\n",
+            DeprecationWarning,
+        )
+        return self.download(
+            *args,
+            **kwargs,
+        )
+
+    @cli.register_custom_action(
+        "ProjectArtifactManager", ("ref_name", "job"), ("job_token",)
+    )
+    @exc.on_http_error(exc.GitlabGetError)
+    def download(
+        self,
+        ref_name: str,
+        job: str,
+        streamed: bool = False,
+        action: Optional[Callable] = None,
+        chunk_size: int = 1024,
+        **kwargs: Any,
+    ) -> Optional[bytes]:
+        """Get the job artifacts archive from a specific tag or branch.
+        Args:
+            ref_name: Branch or tag name in repository. HEAD or SHA references
+            are not supported.
+            job: The name of the job.
+            job_token: Job token for multi-project pipeline triggers.
+            streamed: If True the data will be processed by chunks of
+                `chunk_size` and each chunk is passed to `action` for
+                treatment
+            action: Callable responsible of dealing with chunk of
+                data
+            chunk_size: Size of each chunk
+            **kwargs: Extra options to send to the server (e.g. sudo)
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabGetError: If the artifacts could not be retrieved
+        Returns:
+            The artifacts if `streamed` is False, None otherwise.
+        """
+        path = f"{self.path}/{ref_name}/download"
+        result = self.gitlab.http_get(
+            path, job=job, streamed=streamed, raw=True, **kwargs
+        )
+        if TYPE_CHECKING:
+            assert isinstance(result, requests.Response)
+        return utils.response_content(result, streamed, action, chunk_size)
+
+    @cli.register_custom_action("ProjectArtifactManager", ("ref_name", "artifact_path", "job"))
+    @exc.on_http_error(exc.GitlabGetError)
+    def raw(
+        self,
+        ref_name: str,
+        artifact_path: str,
+        job: str,
+        streamed: bool = False,
+        action: Optional[Callable] = None,
+        chunk_size: int = 1024,
+        **kwargs: Any,
+    ) -> Optional[bytes]:
+        """Download a single artifact file from a specific tag or branch from
+        within the job's artifacts archive.
+        Args:
+            ref_name: Branch or tag name in repository. HEAD or SHA references
+                are not supported.
+            artifact_path: Path to a file inside the artifacts archive.
+            job: The name of the job.
+            streamed: If True the data will be processed by chunks of
+                `chunk_size` and each chunk is passed to `action` for
+                treatment
+            action: Callable responsible of dealing with chunk of
+                data
+            chunk_size: Size of each chunk
+            **kwargs: Extra options to send to the server (e.g. sudo)
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabGetError: If the artifacts could not be retrieved
+        Returns:
+            The artifact if `streamed` is False, None otherwise.
+        """
+        path = f"{self.path}/{ref_name}/raw/{artifact_path}"
+        result = self.gitlab.http_get(
+            path, streamed=streamed, raw=True, job=job, **kwargs
+        )
+        if TYPE_CHECKING:
+            assert isinstance(result, requests.Response)
+        return utils.response_content(result, streamed, action, chunk_size)

--- a/tests/unit/objects/test_job_artifacts.py
+++ b/tests/unit/objects/test_job_artifacts.py
@@ -24,7 +24,18 @@ def resp_artifacts_by_ref_name(binary_content):
         yield rsps
 
 
-def test_download_artifacts_by_ref_name(gl, binary_content, resp_artifacts_by_ref_name):
+def test_project_artifacts_download_by_ref_name(
+    gl, binary_content, resp_artifacts_by_ref_name
+):
     project = gl.projects.get(1, lazy=True)
-    artifacts = project.artifacts(ref_name=ref_name, job=job)
+    artifacts = project.artifacts.download(ref_name=ref_name, job=job)
+    assert artifacts == binary_content
+
+
+def test_project_artifacts_by_ref_name_warns(
+    gl, binary_content, resp_artifacts_by_ref_name
+):
+    project = gl.projects.get(1, lazy=True)
+    with pytest.warns(DeprecationWarning):
+        artifacts = project.artifacts(ref_name=ref_name, job=job)
     assert artifacts == binary_content


### PR DESCRIPTION
Part 1 of https://github.com/python-gitlab/python-gitlab/pull/1865

All this does is move the custom methods from `ProjectManager` into its own `ProjectArtifactManager` and deprecates the old ones. Along the way I had to fix the paths in the new manager. Also added a dummy object to make CLI custom_actions happy.