### PR TITLE
chore: correct type-hints for per_page attrbute

### DIFF
--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -302,7 +302,7 @@ class RESTObjectList:
         return self._list.next_page
 
     @property
-    def per_page(self) -> int:
+    def per_page(self) -> Optional[int]:
         """The number of items per page."""
         return self._list.per_page
 

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -1039,11 +1039,9 @@ class GitlabList:
         return int(self._next_page) if self._next_page else None
 
     @property
-    def per_page(self) -> int:
+    def per_page(self) -> Optional[int]:
         """The number of items per page."""
-        if TYPE_CHECKING:
-            assert self._per_page is not None
-        return int(self._per_page)
+        return int(self._per_page) if self._per_page is not None else None
 
     # NOTE(jlvillal): When a query returns more than 10,000 items, GitLab doesn't return
     # the headers 'x-total-pages' and 'x-total'. In those cases we return None.


### PR DESCRIPTION
There are occasions where a GitLab `list()` call does not return the
`x-per-page` header. For example the listing of custom attributes.

Update the type-hints to reflect that.