### PR TITLE
test(functional): fix GitLab configuration to support pagination

### DIFF
--- a/tests/functional/api/test_gitlab.py
+++ b/tests/functional/api/test_gitlab.py
@@ -81,13 +81,13 @@ def test_template_dockerfile(gl):
 
 
 def test_template_gitignore(gl):
-    assert gl.gitignores.list()
+    assert gl.gitignores.list(all=True)
     gitignore = gl.gitignores.get("Node")
     assert gitignore.content is not None
 
 
 def test_template_gitlabciyml(gl):
-    assert gl.gitlabciymls.list()
+    assert gl.gitlabciymls.list(all=True)
     gitlabciyml = gl.gitlabciymls.get("Nodejs")
     assert gitlabciyml.content is not None
 

--- a/tests/functional/api/test_projects.py
+++ b/tests/functional/api/test_projects.py
@@ -244,7 +244,7 @@ def test_project_protected_branches(project):
 
 
 def test_project_remote_mirrors(project):
-    mirror_url = "http://gitlab.test/root/mirror.git"
+    mirror_url = "https://gitlab.example.com/root/mirror.git"
 
     mirror = project.remote_mirrors.create({"url": mirror_url})
     assert mirror.url == mirror_url

--- a/tests/functional/fixtures/docker-compose.yml
+++ b/tests/functional/fixtures/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       GITLAB_ROOT_PASSWORD: 5iveL!fe
       GITLAB_SHARED_RUNNERS_REGISTRATION_TOKEN: registration-token
       GITLAB_OMNIBUS_CONFIG: |
-        external_url 'http://gitlab.test'
+        external_url 'http://127.0.0.1:8080'
         registry['enable'] = false
         nginx['redirect_http_to_https'] = false
         nginx['listen_port'] = 80


### PR DESCRIPTION
When pagination occurs python-gitlab uses the URL provided by the
GitLab server to use for the next request.

We had previously set the GitLab server configuraiton to say its URL
was `http://gitlab.test` which is not in DNS. Set the hostname
in the URL to `http://127.0.0.1:8080` which is the correct URL for the
GitLab server to be accessed while doing functional tests.

Closes: #1877