### PR TITLE
feat(mixins): allow deleting resources without IDs

### DIFF
--- a/docs/gl_objects/pipelines_and_jobs.rst
+++ b/docs/gl_objects/pipelines_and_jobs.rst
@@ -274,6 +274,10 @@ You can also directly stream the output into a file, and unzip it afterwards::
     subprocess.run(["unzip", "-bo", zipfn])
     os.unlink(zipfn)
 
+Delete all artifacts of a project that can be deleted::
+
+  project.artifacts.delete()
+
 Get a single artifact file::
 
     build_or_job.artifact('path/to/file')

--- a/docs/gl_objects/runners.rst
+++ b/docs/gl_objects/runners.rst
@@ -70,6 +70,10 @@ Remove a runner::
     # or
     runner.delete()
 
+Remove a runner by its authentication token::
+
+    gl.runners.delete(token="runner-auth-token")
+
 Verify a registered runner token::
 
     try:

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -463,7 +463,7 @@ class DeleteMixin(_RestManagerBase):
     gitlab: gitlab.Gitlab
 
     @exc.on_http_error(exc.GitlabDeleteError)
-    def delete(self, id: Union[str, int], **kwargs: Any) -> None:
+    def delete(self, id: Optional[Union[str, int]] = None, **kwargs: Any) -> None:
         """Delete an object on the server.
 
         Args:
@@ -478,6 +478,9 @@ class DeleteMixin(_RestManagerBase):
             path = self.path
         else:
             path = f"{self.path}/{utils.EncodedId(id)}"
+
+        if TYPE_CHECKING:
+            assert path is not None
         self.gitlab.http_delete(path, **kwargs)
 
 

--- a/gitlab/v4/objects/artifacts.py
+++ b/gitlab/v4/objects/artifacts.py
@@ -45,6 +45,23 @@ class ProjectArtifactManager(RESTManager):
             **kwargs,
         )
 
+    @exc.on_http_error(exc.GitlabDeleteError)
+    def delete(self, **kwargs: Any) -> None:
+        """Delete the project's artifacts on the server.
+
+        Args:
+            **kwargs: Extra options to send to the server (e.g. sudo)
+
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabDeleteError: If the server cannot perform the request
+        """
+        path = self._compute_path("/projects/{project_id}/artifacts")
+
+        if TYPE_CHECKING:
+            assert path is not None
+        self.gitlab.http_delete(path, **kwargs)
+
     @cli.register_custom_action(
         "ProjectArtifactManager", ("ref_name", "job"), ("job_token",)
     )

--- a/tests/unit/objects/test_job_artifacts.py
+++ b/tests/unit/objects/test_job_artifacts.py
@@ -24,6 +24,24 @@ def resp_artifacts_by_ref_name(binary_content):
         yield rsps
 
 
+@pytest.fixture
+def resp_project_artifacts_delete(no_content):
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.DELETE,
+            url="http://localhost/api/v4/projects/1/artifacts",
+            json=no_content,
+            content_type="application/json",
+            status=204,
+        )
+        yield rsps
+
+
+def test_project_artifacts_delete(gl, resp_project_artifacts_delete):
+    project = gl.projects.get(1, lazy=True)
+    project.artifacts.delete()
+
+
 def test_project_artifacts_download_by_ref_name(
     gl, binary_content, resp_artifacts_by_ref_name
 ):

--- a/tests/unit/objects/test_runners.py
+++ b/tests/unit/objects/test_runners.py
@@ -174,6 +174,18 @@ def resp_runner_delete():
 
 
 @pytest.fixture
+def resp_runner_delete_by_token():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.DELETE,
+            url="http://localhost/api/v4/runners",
+            status=204,
+            match=[responses.matchers.query_param_matcher({"token": "auth-token"})],
+        )
+        yield rsps
+
+
+@pytest.fixture
 def resp_runner_disable():
     with responses.RequestsMock() as rsps:
         pattern = re.compile(r".*?/projects/1/runners/6")
@@ -242,10 +254,14 @@ def test_get_update_runner(gl: gitlab.Gitlab, resp_runner_detail):
     runner.save()
 
 
-def test_remove_runner(gl: gitlab.Gitlab, resp_runner_delete):
+def test_delete_runner_by_id(gl: gitlab.Gitlab, resp_runner_delete):
     runner = gl.runners.get(6)
     runner.delete()
     gl.runners.delete(6)
+
+
+def test_delete_runner_by_token(gl: gitlab.Gitlab, resp_runner_delete_by_token):
+    gl.runners.delete(token="auth-token")
 
 
 def test_disable_project_runner(gl: gitlab.Gitlab, resp_runner_disable):


### PR DESCRIPTION
Closes https://github.com/python-gitlab/python-gitlab/issues/1631

I started out this PR hoping we would have a generic DeleteMixin for both runners and artifacts, but of course the artifacts endpoint is inconsistent with the other ones. So again I had to add a tiny custom method :sweat_smile: 