### PR TITLE
docs: enable gitter chat directly in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,8 +98,14 @@ https://github.com/python-gitlab/python-gitlab/issues.
 Gitter Community Chat
 ---------------------
 
-There is a `gitter <https://gitter.im/python-gitlab/Lobby>`_ community chat
-available at https://gitter.im/python-gitlab/Lobby
+We have a `gitter <https://gitter.im/python-gitlab/Lobby>`_ community chat
+available at https://gitter.im/python-gitlab/Lobby, which you can also
+directly access via the Open Chat button below.
+
+If you have a simple question, the community might be able to help already,
+without you opening an issue. If you regularly use python-gitlab, we also
+encourage you to join and participate. You might discover new ideas and
+use cases yourself!
 
 Documentation
 -------------

--- a/docs/_static/js/gitter.js
+++ b/docs/_static/js/gitter.js
@@ -1,0 +1,3 @@
+((window.gitter = {}).chat = {}).options = {
+  room: 'python-gitlab/Lobby'
+};

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,7 +145,15 @@ html_title = f"{project} <small>v{release}</small>"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ["_static"]
+
+html_js_files = [
+    "js/gitter.js",
+    (
+        "https://sidecar.gitter.im/dist/sidecar.v1.js",
+        {"async": "async", "defer": "defer"},
+    ),
+]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
First ever pull request from aboard a plane :sweat_smile: 

When maintainers are away/on holiday I thought it might be good if we just have a community chat more visible and people can sort it out before opening issues. Or just in general to have simple questions resolved before opening issues