### PR TITLE
Retry additional http transient errors

### DIFF
--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -35,6 +35,8 @@ REDIRECT_MSG = (
     "{source!r} to {target!r}"
 )
 
+RETRYABLE_TRANSIENT_ERROR_CODES = [500, 502, 503, 504] + list(range(520, 531))
+
 
 class Gitlab:
     """Represents a GitLab server connection.
@@ -694,9 +696,9 @@ class Gitlab:
                 )
             except requests.ConnectionError:
                 if retry_transient_errors and (
-                        max_retries == -1 or cur_retries < max_retries
+                    max_retries == -1 or cur_retries < max_retries
                 ):
-                    wait_time = 2 ** cur_retries * 0.1
+                    wait_time = 2**cur_retries * 0.1
                     cur_retries += 1
                     time.sleep(wait_time)
                     continue
@@ -712,7 +714,8 @@ class Gitlab:
                 "retry_transient_errors", self.retry_transient_errors
             )
             if (429 == result.status_code and obey_rate_limit) or (
-                result.status_code in [500, 502, 503, 504] and retry_transient_errors
+                result.status_code in RETRYABLE_TRANSIENT_ERROR_CODES
+                and retry_transient_errors
             ):
                 # Response headers documentation:
                 # https://docs.gitlab.com/ee/user/admin_area/settings/user_and_ip_rate_limits.html#response-headers

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -710,9 +710,6 @@ class Gitlab:
             if 200 <= result.status_code < 300:
                 return result
 
-            retry_transient_errors = kwargs.get(
-                "retry_transient_errors", self.retry_transient_errors
-            )
             if (429 == result.status_code and obey_rate_limit) or (
                 result.status_code in RETRYABLE_TRANSIENT_ERROR_CODES
                 and retry_transient_errors


### PR DESCRIPTION
Based off of https://github.com/python-gitlab/python-gitlab/pull/1648

This adds additional retries for the 52x caused by cloudflare.

This adds tests for the 52x range and the `requests.ConnectionError` exception