### PR TITLE
feat: Test report summary

### DIFF
--- a/docs/gl_objects/pipelines_and_jobs.rst
+++ b/docs/gl_objects/pipelines_and_jobs.rst
@@ -369,7 +369,7 @@ Get the test report for a pipeline::
     test_report = pipeline.test_report.get()
 
 Pipeline test report summary
-====================
+============================
 
 Get a pipeline’s test report summary.
 
@@ -380,7 +380,7 @@ Reference
 
   + :class:`gitlab.v4.objects.ProjectPipelineTestReportSummary`
   + :class:`gitlab.v4.objects.ProjectPipelineTestReportSummaryManager`
-  + :attr:`gitlab.v4.objects.ProjectPipeline.test_report)summary`
+  + :attr:`gitlab.v4.objects.ProjectPipeline.test_report_summary`
 
 * GitLab API: https://docs.gitlab.com/ee/api/pipelines.html#get-a-pipelines-test-report-summary
 

--- a/docs/gl_objects/pipelines_and_jobs.rst
+++ b/docs/gl_objects/pipelines_and_jobs.rst
@@ -367,3 +367,27 @@ Examples
 Get the test report for a pipeline::
 
     test_report = pipeline.test_report.get()
+
+Pipeline test report summary
+====================
+
+Get a pipeline’s test report summary.
+
+Reference
+---------
+
+* v4 API
+
+  + :class:`gitlab.v4.objects.ProjectPipelineTestReportSummary`
+  + :class:`gitlab.v4.objects.ProjectPipelineTestReportSummaryManager`
+  + :attr:`gitlab.v4.objects.ProjectPipeline.test_report)summary`
+
+* GitLab API: https://docs.gitlab.com/ee/api/pipelines.html#get-a-pipelines-test-report-summary
+
+Examples
+--------
+
+Get the test report summary for a pipeline::
+
+    test_report_summary = pipeline.test_report_summary.get()
+

--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -35,6 +35,8 @@ __all__ = [
     "ProjectPipelineScheduleManager",
     "ProjectPipelineTestReport",
     "ProjectPipelineTestReportManager",
+    "ProjectPipelineTestReportSummary",
+    "ProjectPipelineTestReportSummaryManager",
 ]
 
 
@@ -52,6 +54,7 @@ class ProjectPipeline(RefreshMixin, ObjectDeleteMixin, RESTObject):
     bridges: "ProjectPipelineBridgeManager"
     jobs: "ProjectPipelineJobManager"
     test_report: "ProjectPipelineTestReportManager"
+    test_report_summary: "ProjectPipelineTestReportSummaryManager"
     variables: "ProjectPipelineVariableManager"
 
     @cli.register_custom_action("ProjectPipeline")
@@ -251,3 +254,20 @@ class ProjectPipelineTestReportManager(GetWithoutIdMixin, RESTManager):
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
     ) -> Optional[ProjectPipelineTestReport]:
         return cast(Optional[ProjectPipelineTestReport], super().get(id=id, **kwargs))
+
+
+class ProjectPipelineTestReportSummary(RESTObject):
+    _id_attr = None
+
+
+class ProjectPipelineTestReportSummaryManager(GetWithoutIdMixin, RESTManager):
+    _path = "/projects/{project_id}/pipelines/{pipeline_id}/test_report_summary"
+    _obj_cls = ProjectPipelineTestReportSummary
+    _from_parent_attrs = {"project_id": "project_id", "pipeline_id": "id"}
+
+    def get(
+        self, id: Optional[Union[int, str]] = None, **kwargs: Any
+    ) -> Optional[ProjectPipelineTestReportSummary]:
+        return cast(
+            Optional[ProjectPipelineTestReportSummary], super().get(id=id, **kwargs)
+        )


### PR DESCRIPTION
Hello !

This adds the support of the test report summary endpoint. See : [here](https://docs.gitlab.com/ee/api/pipelines.html#get-a-pipelines-test-report-summary)