### PR TITLE
docs:Small docs fixup for application scopes

### DIFF
--- a/docs/gl_objects/applications.rst
+++ b/docs/gl_objects/applications.rst
@@ -22,7 +22,7 @@ List all OAuth applications::
 
 Create an application::
 
-    gl.applications.create({'name': 'your_app', 'redirect_uri': 'http://application.url', 'scopes': ['api']})
+    gl.applications.create({'name': 'your_app', 'redirect_uri': 'http://application.url', 'scopes': 'read_user openid profile email'})
 
 Delete an applications::
 


### PR DESCRIPTION
Hi all,

I found a small hickup in the docs that took me a few minutes to understand. Looking at [API docs](https://docs.gitlab.com/ee/api/applications.html) and the code I have found out that the way we try to push the application scopes doesn't match the API. I'd like to leave an appropriate example in docs so that people don't get stuck on this