### PR TITLE
Fix `--job` argument interpreted as `--job-token`

### DIFF
--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -106,7 +106,7 @@ def cls_to_what(cls: RESTObject) -> str:
 
 def _get_base_parser(add_help: bool = True) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        add_help=add_help, description="GitLab API Command Line Interface"
+        add_help=add_help, description="GitLab API Command Line Interface", allow_abbrev=False
     )
     parser.add_argument("--version", help="Display the version.", action="store_true")
     parser.add_argument(


### PR DESCRIPTION
## Description of the problem, including code/CLI snippet

`--job` argument interpreted as `--job-token` arugment and conflicts with `  --private-token`

Executing:

```
gitlab \
  --private-token ${GITLAB_API_KEY} -o json \
  project-artifact download \
  --project-id mdm/entities \
  --job ${JOB} \
  --ref-name ${REF} \
```

## Expected Behavior

Artifact downloaded

## Actual Behavior

`gitlab: error: argument --job-token: not allowed with argument --private-token`

## Specifications

  - python-gitlab version: 3.2.0
  - API version you are using (v3/v4): doesn't meter
  - Gitlab server version (or gitlab.com): doesn't meter

## PS

Looks like it happens because of default `argparse.ArgumentParser`s `allow_abbrev` behaviour - both `--job` and `--job-token` starts with `--job` chars. 

Could be fixed [here](https://github.com/python-gitlab/python-gitlab/blob/8e241e483bb8b316a831f5831e6db733dd04a08f/gitlab/cli.py#L108) with:

```diff
    parser = argparse.ArgumentParser(
        add_help=add_help, description="GitLab API Command Line Interface",
+       allow_abbrev=False
    )
```