### PR TITLE
Revert "chore(api): temporarily remove topic delete endpoint"

### DIFF
--- a/docs/gl_objects/topics.rst
+++ b/docs/gl_objects/topics.rst
@@ -39,3 +39,10 @@ Update a topic::
 
     # or
     gl.topics.update(topic_id, {"description": "My new topic"})
+
+Delete a topic::
+
+    topic.delete()
+
+    # or
+    gl.topics.delete(topic_id)

--- a/gitlab/v4/objects/topics.py
+++ b/gitlab/v4/objects/topics.py
@@ -2,7 +2,7 @@ from typing import Any, cast, Union
 
 from gitlab import types
 from gitlab.base import RequiredOptional, RESTManager, RESTObject
-from gitlab.mixins import CreateMixin, RetrieveMixin, SaveMixin, UpdateMixin
+from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
 
 __all__ = [
     "Topic",
@@ -10,11 +10,11 @@ __all__ = [
 ]
 
 
-class Topic(SaveMixin, RESTObject):
+class Topic(SaveMixin, ObjectDeleteMixin, RESTObject):
     pass
 
 
-class TopicManager(CreateMixin, RetrieveMixin, UpdateMixin, RESTManager):
+class TopicManager(CRUDMixin, RESTManager):
     _path = "/topics"
     _obj_cls = Topic
     _create_attrs = RequiredOptional(

--- a/tests/functional/api/test_topics.py
+++ b/tests/functional/api/test_topics.py
@@ -16,3 +16,6 @@ def test_topics(gl):
 
     updated_topic = gl.topics.get(topic.id)
     assert updated_topic.description == topic.description
+
+    topic.delete()
+    assert not gl.topics.list()

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -39,6 +39,8 @@ def reset_gitlab(gl):
             )
             deploy_token.delete()
         group.delete()
+    for topic in gl.topics.list():
+        topic.delete()
     for variable in gl.variables.list():
         logging.info(f"Marking for deletion variable: {variable.key!r}")
         variable.delete()

--- a/tests/functional/fixtures/.env
+++ b/tests/functional/fixtures/.env
@@ -1,2 +1,2 @@
 GITLAB_IMAGE=gitlab/gitlab-ce
-GITLAB_TAG=14.6.2-ce.0
+GITLAB_TAG=14.9.2-ce.0

--- a/tests/unit/objects/test_topics.py
+++ b/tests/unit/objects/test_topics.py
@@ -75,6 +75,19 @@ def resp_update_topic():
         yield rsps
 
 
+@pytest.fixture
+def resp_delete_topic(no_content):
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.DELETE,
+            url=topic_url,
+            json=no_content,
+            content_type="application/json",
+            status=204,
+        )
+        yield rsps
+
+
 def test_list_topics(gl, resp_list_topics):
     topics = gl.topics.list()
     assert isinstance(topics, list)
@@ -99,3 +112,8 @@ def test_update_topic(gl, resp_update_topic):
     topic.name = new_name
     topic.save()
     assert topic.name == new_name
+
+
+def test_delete_topic(gl, resp_delete_topic):
+    topic = gl.topics.get(1, lazy=True)
+    topic.delete()


### PR DESCRIPTION
This reverts commit e3035a799a484f8d6c460f57e57d4b59217cd6de.

When I was adding this initially I didn't realize they omitted the delete endpoint. That's handy now as it's been added in 14.9:
https://about.gitlab.com/releases/2022/03/22/gitlab-14-9-released/#api-endpoint-to-delete-project-topics
