### PR TITLE
Add ChunkedEncodingError to list of retryable exceptions

### DIFF
--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -694,7 +694,7 @@ class Gitlab:
                     stream=streamed,
                     **opts,
                 )
-            except requests.ConnectionError:
+            except (requests.ConnectionError, requests.exceptions.ChunkedEncodingError):
                 if retry_transient_errors and (
                     max_retries == -1 or cur_retries < max_retries
                 ):

--- a/tests/unit/test_gitlab_http_methods.py
+++ b/tests/unit/test_gitlab_http_methods.py
@@ -99,7 +99,16 @@ def test_http_request_with_retry_on_method_for_transient_failures(gl):
 
 
 @responses.activate
-def test_http_request_with_retry_on_method_for_transient_network_failures(gl):
+@pytest.mark.parametrize(
+    "exception",
+    [
+        requests.ConnectionError("Connection aborted."),
+        requests.exceptions.ChunkedEncodingError("Connection broken."),
+    ],
+)
+def test_http_request_with_retry_on_method_for_transient_network_failures(
+    gl, exception
+):
     call_count = 0
     calls_before_success = 3
 
@@ -114,7 +123,7 @@ def test_http_request_with_retry_on_method_for_transient_network_failures(gl):
 
         if call_count >= calls_before_success:
             return (status_code, headers, body)
-        raise requests.ConnectionError("Connection aborted.")
+        raise exception
 
     responses.add_callback(
         method=responses.GET,


### PR DESCRIPTION
We've been seeing ChunkedEncodingErrors recently as well, I've added them to the list of retryable exceptions.
```
...
  File redacted.py
    return typing.cast(GitlabProject, project_manager.get(project_id))
  File "/usr/local/lib/python3.10/site-packages/gitlab/v4/objects/projects.py", line 816, in get
    return cast(Project, super().get(id=id, lazy=lazy, **kwargs))
  File "/usr/local/lib/python3.10/site-packages/gitlab/exceptions.py", line 311, in wrapped_f
    return f(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/gitlab/mixins.py", line 111, in get
    server_data = self.gitlab.http_get(path, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/gitlab/client.py", line 761, in http_get
    result = self.http_request(
  File "/usr/local/lib/python3.10/site-packages/gitlab/client.py", line 680, in http_request
    result = self.session.request(
  File "/usr/local/lib/python3.10/site-packages/requests/sessions.py", line 529, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.10/site-packages/requests/sessions.py", line 687, in send
    r.content
  File "/usr/local/lib/python3.10/site-packages/requests/models.py", line 838, in content
    self._content = b''.join(self.iter_content(CONTENT_CHUNK_SIZE)) or b''
  File "/usr/local/lib/python3.10/site-packages/requests/models.py", line 763, in generate
    raise ChunkedEncodingError(e)
requests.exceptions.ChunkedEncodingError: ("Connection broken: InvalidChunkLength(got length b'', 0 bytes read)", InvalidChunkLength(got length b'', 0 bytes read))
```