### PR TITLE
chore(renovate): set schedule to reduce noise

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,7 +1,8 @@
 {
   "extends": [
     "config:base",
-    ":enablePreCommit"
+    ":enablePreCommit",
+    "schedule:weekly"
   ],
   "pip_requirements": {
     "fileMatch": ["^requirements(-[\\w]*)?\\.txt$"]


### PR DESCRIPTION
We have mostly dev- and typing dependencies getting updated by renovate, and I don't see that much value in getting 3 updates per day for `types-requests` etc. Maybe this will also help people who follow the repo, as they won't be spammed with frequent pushes and PRs.