### PR TITLE
feat(ux): display project.name_with_namespace on project repr

### DIFF
--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -186,6 +186,16 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
     variables: ProjectVariableManager
     wikis: ProjectWikiManager
 
+    def __repr__(self) -> str:
+        project_repr = super().__repr__()
+
+        if hasattr(self, "name_with_namespace"):
+            return (
+                f'{project_repr[:-1]} name_with_namespace:"{self.name_with_namespace}">'
+            )
+        else:
+            return project_repr
+
     @cli.register_custom_action("Project", ("forked_from_id",))
     @exc.on_http_error(exc.GitlabCreateError)
     def create_fork_relation(self, forked_from_id: int, **kwargs: Any) -> None:


### PR DESCRIPTION
This change the repr from:

```
$ gitlab.projects.get(id=some_id)
<Project id:some_id>
```

To:

```
$ gitlab.projects.get(id=some_id)
<Project id:some_id name_with_namespace:"group_name / project_name">
```

This is especially useful when working on random projects or listing of
projects since users generally don't remember projects ids.

----

On a side note I've encountered this error when trying to do a commit:

```
An unexpected error has occurred: CalledProcessError: command: ('/home/psycojoker/.cache/pre-commit/repox1_osb0o/node_env-default/bin/node', '/home/psycojoker/.cache/pre-commit/repox1_osb0o/node_env-default/bin/npm', 'install', '--dev', '--prod', '--ignore-prepublish', '--no-progress', '--no-save')
return code: 1
expected return code: 0
stdout: (none)
stderr:
    /home/psycojoker/.cache/pre-commit/repox1_osb0o/node_env-default/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /home/psycojoker/.cache/pre-commit/repox1_osb0o/node_env-default/bin/node)
    
Check the log at /home/psycojoker/.cache/pre-commit/pre-commit.log
```

I have to admit that, while I totally understand the importance of linters and good commit messages, having a hard dependency on a specific version of nodejs and glibc just do to a commit on a full python feels a bit ... intense? :sweat_smile: 

Anyway, thanks a lot for this project :heart: 