### PR TITLE
chore: exclude `build/` directory from mypy check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ order_by_type = false
 
 [tool.mypy]
 files = "."
+exclude = "build/.*"
 
 # 'strict = true' is equivalent to the following:
 check_untyped_defs = true


### PR DESCRIPTION
The `build/` directory is created by the tox environment
`twine-check`. When the `build/` directory exists `mypy` will have an
error.