### PR TITLE
chore: add `cz` to default tox environment list and skip_missing_interpreters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Run tests
         env:
           TOXENV: ${{ matrix.python.toxenv }}
-        run: tox
+        run: tox --skip-missing-interpreters false
 
   functional:
     runs-on: ubuntu-20.04

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = py310,py39,py38,py37,pep8,black,twine-check,mypy,isort
+skip_missing_interpreters = True
+envlist = py310,py39,py38,py37,pep8,black,twine-check,mypy,isort,cz
 
 [testenv]
 passenv = GITLAB_IMAGE GITLAB_TAG PY_COLORS NO_COLOR FORCE_COLOR


### PR DESCRIPTION
Add the `cz` (`comittizen`) check by default.

Set skip_missing_interpreters = True so that when a user runs tox and
doesn't have a specific version of Python it doesn't mark it as an
error.
