### PR TITLE
refactor(mixins): extract custom type transforms into utils

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -18,7 +18,7 @@
 import json
 import warnings
 
-from gitlab import utils
+from gitlab import types, utils
 
 
 class TestEncodedId:
@@ -95,3 +95,30 @@ class TestWarningsWrapper:
         assert warn_message in str(warning.message)
         assert __file__ in str(warning.message)
         assert warn_source == warning.source
+
+
+def test_transform_types_copies_data_with_empty_files():
+    data = {"attr": "spam"}
+    new_data, files = utils._transform_types(data, {})
+
+    assert new_data is not data
+    assert new_data == data
+    assert files == {}
+
+
+def test_transform_types_with_transform_files_populates_files():
+    custom_types = {"attr": types.FileAttribute}
+    data = {"attr": "spam"}
+    new_data, files = utils._transform_types(data, custom_types)
+
+    assert new_data == {}
+    assert files["attr"] == ("attr", "spam")
+
+
+def test_transform_types_without_transform_files_populates_data_with_empty_files():
+    custom_types = {"attr": types.FileAttribute}
+    data = {"attr": "spam"}
+    new_data, files = utils._transform_types(data, custom_types, transform_files=False)
+
+    assert new_data == {"attr": "spam"}
+    assert files == {}


### PR DESCRIPTION
I'm trying to add support for multipart uploads to the generic package upload (see #2002), but unfortunately the logic for that is currently done directly in the `create()`/`update()` methods (processing the `data`/`files` dict for the `MultipartEncoder`).

This extracts that into a helper and handles `transform_files` so we can also use it for `list()` which doesn't need it. This PR preps the code so the generic package one should be smaller.

In the future I think we can simplify multipart encoding more and get rid of `files` altogether, and just process everything in `data` - but wanted to keep this PR simple.