### PR TITLE
fix(cli): changed default `allow_abbrev` value to fix arguments collision problem

### DIFF
--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -106,7 +106,9 @@ def cls_to_what(cls: RESTObject) -> str:
 
 def _get_base_parser(add_help: bool = True) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        add_help=add_help, description="GitLab API Command Line Interface"
+        add_help=add_help,
+        description="GitLab API Command Line Interface",
+        allow_abbrev=False,
     )
     parser.add_argument("--version", help="Display the version.", action="store_true")
     parser.add_argument(


### PR DESCRIPTION
    The `--job` argument could be interpreted as `--job-token`

    Example failure:

      $ gitlab \
        --private-token ${GITLAB_API_KEY} -o json \
        project-artifact download \
        --project-id mdm/entities \
        --job ${JOB} \
        --ref-name ${REF} \

      gitlab: error: argument --job-token: not allowed with argument
      --private-token
