### PR TITLE
docs: Update issue example and extend API usage

### DIFF
--- a/docs/api-usage.rst
+++ b/docs/api-usage.rst
@@ -192,6 +192,17 @@ You can print a Gitlab Object. For example:
    # Or explicitly via `pformat()`. This is equivalent to the above.
    print(project.pformat())
 
+You can also extend the object if the parameter isn't explicitly listed. For example,
+if you want to update a field that has been newly introduced to the Gitlab API, setting
+the value on the object is accepted:
+
+.. code-block:: python
+
+   issues = project.issues.list(state='opened')
+   for issue in issues:
+      issue.my_super_awesome_feature_flag = "random_value"
+      issue.save()
+
 
 Base types
 ==========

--- a/docs/gl_objects/issues.rst
+++ b/docs/gl_objects/issues.rst
@@ -133,6 +133,17 @@ Delete an issue (admin or project owner only)::
     # pr
     issue.delete()
 
+
+Assign the issues::
+
+    issue = gl.issues.list()[0]
+    issue.assignee_ids = [25, 10, 31, 12]
+    issue.save()
+
+.. note::
+    The Gitlab API explicitly references that the `assignee_id` field is deprecated,
+    so using a list of user IDs for `assignee_ids` is how to assign an issue to a user(s).
+
 Subscribe / unsubscribe from an issue::
 
     issue.subscribe()


### PR DESCRIPTION
Updates to the documentation to include changes on the Gitlab API for `assignee_ids`, and explicitly reference how to extend an object for attributes not explicitly mentioned.