### PR TITLE
chore(ci): pin semantic-release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
     - name: Python Semantic Release
-      uses: relekang/python-semantic-release@master
+      uses: relekang/python-semantic-release@7.28.1
       with:
         github_token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
         pypi_token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Last night's release job failed because `python-semantic-release` parsed a renovate commit as our own version:
https://github.com/relekang/python-semantic-release/issues/442

Rolling back so we can have the release, but I wonder if we should just switch to the JS semantic-release as it only runs in CI and that offers more goodies like PR/issue comments on release to keep people informed when their fix/feature is available. For now let's get this in :)