### PR TITLE
feat(client): introduce `iterator=True` and deprecate `as_list=False` in `list()`

### DIFF
--- a/docs/api-usage.rst
+++ b/docs/api-usage.rst
@@ -93,13 +93,13 @@ Examples:
 .. code-block:: python
 
    # list all the projects
-   projects = gl.projects.list(as_list=False)
+   projects = gl.projects.list(iterator=True)
    for project in projects:
        print(project)
 
    # get the group with id == 2
    group = gl.groups.get(2)
-   for project in group.projects.list(as_list=False):
+   for project in group.projects.list(iterator=True):
        print(project)
 
    # create a new user
@@ -109,7 +109,7 @@ Examples:
 
 .. warning::
    Calling ``list()`` without any arguments will by default not return the complete list
-   of items. Use either the ``all=True`` or ``as_list=False`` parameters to get all the
+   of items. Use either the ``all=True`` or ``iterator=True`` parameters to get all the
    items when using listing methods. See the :ref:`pagination` section for more
    information.
 
@@ -156,9 +156,9 @@ conflict with python or python-gitlab when using them as kwargs:
 
 .. code-block:: python
 
-   gl.user_activities.list(from='2019-01-01', as_list=False)  ## invalid
+   gl.user_activities.list(from='2019-01-01', iterator=True)  ## invalid
 
-   gl.user_activities.list(query_parameters={'from': '2019-01-01'}, as_list=False)  # OK
+   gl.user_activities.list(query_parameters={'from': '2019-01-01'}, iterator=True)  # OK
 
 Gitlab Objects
 ==============
@@ -282,13 +282,13 @@ order options. At the time of writing, only ``order_by="id"`` works.
 Reference:
 https://docs.gitlab.com/ce/api/README.html#keyset-based-pagination
 
-``list()`` methods can also return a generator object which will handle the
-next calls to the API when required. This is the recommended way to iterate
-through a large number of items:
+``list()`` methods can also return a generator object, by passing the argument
+``iterator=True``, which will handle the next calls to the API when required. This
+is the recommended way to iterate through a large number of items:
 
 .. code-block:: python
 
-   items = gl.groups.list(as_list=False)
+   items = gl.groups.list(iterator=True)
    for item in items:
        print(item.attributes)
 
@@ -309,6 +309,10 @@ The generator exposes extra listing information as received from the server:
 
    For more information see:
    https://docs.gitlab.com/ee/user/gitlab_com/index.html#pagination-response-headers
+
+.. note::
+   Prior to python-gitlab 3.6.0 the argument ``as_list`` was used instead of
+   ``iterator``.  ``as_list=False`` is the equivalent of ``iterator=True``.
 
 Sudo
 ====

--- a/docs/gl_objects/search.rst
+++ b/docs/gl_objects/search.rst
@@ -63,13 +63,13 @@ The ``search()`` methods implement the pagination support::
 
     # get a generator that will automatically make required API calls for
     # pagination
-    for item in gl.search(gitlab.const.SEARCH_SCOPE_ISSUES, search_str, as_list=False):
+    for item in gl.search(gitlab.const.SEARCH_SCOPE_ISSUES, search_str, iterator=True):
         do_something(item)
 
 The search API doesn't return objects, but dicts. If you need to act on
 objects, you need to create them explicitly::
 
-    for item in gl.search(gitlab.const.SEARCH_SCOPE_ISSUES, search_str, as_list=False):
+    for item in gl.search(gitlab.const.SEARCH_SCOPE_ISSUES, search_str, iterator=True):
         issue_project = gl.projects.get(item['project_id'], lazy=True)
         issue = issue_project.issues.get(item['iid'])
         issue.state = 'closed'

--- a/docs/gl_objects/users.rst
+++ b/docs/gl_objects/users.rst
@@ -413,4 +413,4 @@ Get the users activities::
 
     activities = gl.user_activities.list(
         query_parameters={'from': '2018-07-01'},
-        all=True, as_list=False)
+        all=True, iterator=True)

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -201,12 +201,12 @@ class ListMixin(_RestManagerBase):
             all: If True, return all the items, without pagination
             per_page: Number of items to retrieve per request
             page: ID of the page to return (starts with page 1)
-            as_list: If set to False and no pagination option is
+            iterator: If set to True and no pagination option is
                 defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
-            The list of objects, or a generator if `as_list` is False
+            The list of objects, or a generator if `iterator` is True
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct
@@ -846,8 +846,6 @@ class ParticipantsMixin(_RestObjectBase):
             all: If True, return all the items, without pagination
             per_page: Number of items to retrieve per request
             page: ID of the page to return (starts with page 1)
-            as_list: If set to False and no pagination option is
-                defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:

--- a/gitlab/v4/objects/ldap.py
+++ b/gitlab/v4/objects/ldap.py
@@ -26,12 +26,12 @@ class LDAPGroupManager(RESTManager):
             all: If True, return all the items, without pagination
             per_page: Number of items to retrieve per request
             page: ID of the page to return (starts with page 1)
-            as_list: If set to False and no pagination option is
+            iterator: If set to True and no pagination option is
                 defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
-            The list of objects, or a generator if `as_list` is False
+            The list of objects, or a generator if `iterator` is True
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -199,8 +199,6 @@ class ProjectMergeRequest(
             all: If True, return all the items, without pagination
             per_page: Number of items to retrieve per request
             page: ID of the page to return (starts with page 1)
-            as_list: If set to False and no pagination option is
-                defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -211,7 +209,7 @@ class ProjectMergeRequest(
             List of issues
         """
         path = f"{self.manager.path}/{self.encoded_id}/closes_issues"
-        data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
+        data_list = self.manager.gitlab.http_list(path, iterator=True, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(data_list, gitlab.GitlabList)
         manager = ProjectIssueManager(self.manager.gitlab, parent=self.manager._parent)
@@ -226,8 +224,6 @@ class ProjectMergeRequest(
             all: If True, return all the items, without pagination
             per_page: Number of items to retrieve per request
             page: ID of the page to return (starts with page 1)
-            as_list: If set to False and no pagination option is
-                defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -239,7 +235,7 @@ class ProjectMergeRequest(
         """
 
         path = f"{self.manager.path}/{self.encoded_id}/commits"
-        data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
+        data_list = self.manager.gitlab.http_list(path, iterator=True, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(data_list, gitlab.GitlabList)
         manager = ProjectCommitManager(self.manager.gitlab, parent=self.manager._parent)

--- a/gitlab/v4/objects/milestones.py
+++ b/gitlab/v4/objects/milestones.py
@@ -33,8 +33,6 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
             all: If True, return all the items, without pagination
             per_page: Number of items to retrieve per request
             page: ID of the page to return (starts with page 1)
-            as_list: If set to False and no pagination option is
-                defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -46,7 +44,7 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
         """
 
         path = f"{self.manager.path}/{self.encoded_id}/issues"
-        data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
+        data_list = self.manager.gitlab.http_list(path, iterator=True, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(data_list, RESTObjectList)
         manager = GroupIssueManager(self.manager.gitlab, parent=self.manager._parent)
@@ -62,8 +60,6 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
             all: If True, return all the items, without pagination
             per_page: Number of items to retrieve per request
             page: ID of the page to return (starts with page 1)
-            as_list: If set to False and no pagination option is
-                defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -74,7 +70,7 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
             The list of merge requests
         """
         path = f"{self.manager.path}/{self.encoded_id}/merge_requests"
-        data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
+        data_list = self.manager.gitlab.http_list(path, iterator=True, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(data_list, RESTObjectList)
         manager = GroupIssueManager(self.manager.gitlab, parent=self.manager._parent)
@@ -114,8 +110,6 @@ class ProjectMilestone(PromoteMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
             all: If True, return all the items, without pagination
             per_page: Number of items to retrieve per request
             page: ID of the page to return (starts with page 1)
-            as_list: If set to False and no pagination option is
-                defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -127,7 +121,7 @@ class ProjectMilestone(PromoteMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
         """
 
         path = f"{self.manager.path}/{self.encoded_id}/issues"
-        data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
+        data_list = self.manager.gitlab.http_list(path, iterator=True, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(data_list, RESTObjectList)
         manager = ProjectIssueManager(self.manager.gitlab, parent=self.manager._parent)
@@ -143,8 +137,6 @@ class ProjectMilestone(PromoteMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
             all: If True, return all the items, without pagination
             per_page: Number of items to retrieve per request
             page: ID of the page to return (starts with page 1)
-            as_list: If set to False and no pagination option is
-                defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -155,7 +147,7 @@ class ProjectMilestone(PromoteMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
             The list of merge requests
         """
         path = f"{self.manager.path}/{self.encoded_id}/merge_requests"
-        data_list = self.manager.gitlab.http_list(path, as_list=False, **kwargs)
+        data_list = self.manager.gitlab.http_list(path, iterator=True, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(data_list, RESTObjectList)
         manager = ProjectMergeRequestManager(

--- a/gitlab/v4/objects/repositories.py
+++ b/gitlab/v4/objects/repositories.py
@@ -60,7 +60,7 @@ class RepositoryMixin(_RestObjectBase):
             all: If True, return all the items, without pagination
             per_page: Number of items to retrieve per request
             page: ID of the page to return (starts with page 1)
-            as_list: If set to False and no pagination option is
+            iterator: If set to True and no pagination option is
                 defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
@@ -172,7 +172,7 @@ class RepositoryMixin(_RestObjectBase):
             all: If True, return all the items, without pagination
             per_page: Number of items to retrieve per request
             page: ID of the page to return (starts with page 1)
-            as_list: If set to False and no pagination option is
+            iterator: If set to True and no pagination option is
                 defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 

--- a/gitlab/v4/objects/runners.py
+++ b/gitlab/v4/objects/runners.py
@@ -81,7 +81,7 @@ class RunnerManager(CRUDMixin, RESTManager):
             all: If True, return all the items, without pagination
             per_page: Number of items to retrieve per request
             page: ID of the page to return (starts with page 1)
-            as_list: If set to False and no pagination option is
+            iterator: If set to True and no pagination option is
                 defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 

--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -542,12 +542,12 @@ class UserProjectManager(ListMixin, CreateMixin, RESTManager):
             all: If True, return all the items, without pagination
             per_page: Number of items to retrieve per request
             page: ID of the page to return (starts with page 1)
-            as_list: If set to False and no pagination option is
+            iterator: If set to True and no pagination option is
                 defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Returns:
-            The list of objects, or a generator if `as_list` is False
+            The list of objects, or a generator if `iterator` is True
 
         Raises:
             GitlabAuthenticationError: If authentication is not correct

--- a/tests/functional/api/test_gitlab.py
+++ b/tests/functional/api/test_gitlab.py
@@ -220,9 +220,20 @@ def test_list_all_true_nowarning(gl):
     assert len(items) > 20
 
 
-def test_list_as_list_false_nowarning(gl):
-    """Using `as_list=False` will disable the warning"""
+def test_list_iterator_true_nowarning(gl):
+    """Using `iterator=True` will disable the warning"""
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        items = gl.gitlabciymls.list(iterator=True)
+    assert len(caught_warnings) == 0
+    assert len(list(items)) > 20
+
+
+def test_list_as_list_false_warnings(gl):
+    """Using `as_list=False` will disable the UserWarning but cause a
+    DeprecationWarning"""
     with warnings.catch_warnings(record=True) as caught_warnings:
         items = gl.gitlabciymls.list(as_list=False)
-    assert len(caught_warnings) == 0
+    assert len(caught_warnings) == 1
+    for warning in caught_warnings:
+        assert isinstance(warning.message, DeprecationWarning)
     assert len(list(items)) > 20

--- a/tests/functional/api/test_projects.py
+++ b/tests/functional/api/test_projects.py
@@ -15,7 +15,7 @@ def test_create_project(gl, user):
     sudo_project = gl.projects.create({"name": "sudo_project"}, sudo=user.id)
 
     created = gl.projects.list()
-    created_gen = gl.projects.list(as_list=False)
+    created_gen = gl.projects.list(iterator=True)
     owned = gl.projects.list(owned=True)
 
     assert admin_project in created and sudo_project in created

--- a/tests/unit/mixins/test_mixin_methods.py
+++ b/tests/unit/mixins/test_mixin_methods.py
@@ -107,7 +107,7 @@ def test_list_mixin(gl):
 
     # test RESTObjectList
     mgr = M(gl)
-    obj_list = mgr.list(as_list=False)
+    obj_list = mgr.list(iterator=True)
     assert isinstance(obj_list, base.RESTObjectList)
     for obj in obj_list:
         assert isinstance(obj, FakeObject)
@@ -138,7 +138,7 @@ def test_list_other_url(gl):
     )
 
     mgr = M(gl)
-    obj_list = mgr.list(path="/others", as_list=False)
+    obj_list = mgr.list(path="/others", iterator=True)
     assert isinstance(obj_list, base.RESTObjectList)
     obj = obj_list.next()
     assert obj.id == 42

--- a/tests/unit/test_gitlab.py
+++ b/tests/unit/test_gitlab.py
@@ -87,7 +87,7 @@ def resp_page_2():
 @responses.activate
 def test_gitlab_build_list(gl, resp_page_1, resp_page_2):
     responses.add(**resp_page_1)
-    obj = gl.http_list("/tests", as_list=False)
+    obj = gl.http_list("/tests", iterator=True)
     assert len(obj) == 2
     assert obj._next_url == "http://localhost/api/v4/tests?per_page=1&page=2"
     assert obj.current_page == 1
@@ -122,7 +122,7 @@ def test_gitlab_build_list_missing_headers(gl, resp_page_1, resp_page_2):
     stripped_page_2 = _strip_pagination_headers(resp_page_2)
 
     responses.add(**stripped_page_1)
-    obj = gl.http_list("/tests", as_list=False)
+    obj = gl.http_list("/tests", iterator=True)
     assert len(obj) == 0  # Lazy generator has no knowledge of total items
     assert obj.total_pages is None
     assert obj.total is None
@@ -133,10 +133,10 @@ def test_gitlab_build_list_missing_headers(gl, resp_page_1, resp_page_2):
 
 
 @responses.activate
-def test_gitlab_all_omitted_when_as_list(gl, resp_page_1, resp_page_2):
+def test_gitlab_all_omitted_when_iterator(gl, resp_page_1, resp_page_2):
     responses.add(**resp_page_1)
     responses.add(**resp_page_2)
-    result = gl.http_list("/tests", as_list=False, all=True)
+    result = gl.http_list("/tests", iterator=True, all=True)
     assert isinstance(result, gitlab.GitlabList)
 
 


### PR DESCRIPTION
`as_list=False` is confusing as it doesn't explain what is being
returned. Replace it with `iterator=True` which more clearly explains
to the user that an iterator/generator will be returned.

This maintains backward compatibility with `as_list` but does issue a
DeprecationWarning if `as_list` is set.
