### PR TITLE
chore: correct ModuleNotFoundError() arguments

### DIFF
--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -301,7 +301,7 @@ def main() -> None:
         sys.exit(e)
     # We only support v4 API at this time
     if config.api_version not in ("4",):  # dead code # pragma: no cover
-        raise ModuleNotFoundError(name=f"gitlab.v{config.api_version}.cli")
+        raise ModuleNotFoundError(f"gitlab.v{config.api_version}.cli")
 
     # Now we build the entire set of subcommands and do the complete parsing
     parser = _get_parser()

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -116,7 +116,7 @@ class Gitlab:
 
         # We only support v4 API at this time
         if self._api_version not in ("4",):
-            raise ModuleNotFoundError(name=f"gitlab.v{self._api_version}.objects")
+            raise ModuleNotFoundError(f"gitlab.v{self._api_version}.objects")
         # NOTE: We must delay import of gitlab.v4.objects until now or
         # otherwise it will cause circular import errors
         import gitlab.v4.objects
@@ -209,7 +209,7 @@ class Gitlab:
         # We only support v4 API at this time
         if self._api_version not in ("4",):
             raise ModuleNotFoundError(
-                name=f"gitlab.v{self._api_version}.objects"
+                f"gitlab.v{self._api_version}.objects"
             )  # pragma: no cover, dead code currently
         # NOTE: We must delay import of gitlab.v4.objects until now or
         # otherwise it will cause circular import errors

--- a/tests/unit/test_gitlab.py
+++ b/tests/unit/test_gitlab.py
@@ -91,7 +91,7 @@ def test_gitlab_init_with_valid_api_version():
 
 
 def test_gitlab_init_with_invalid_api_version():
-    with pytest.raises(ModuleNotFoundError):
+    with pytest.raises(ModuleNotFoundError, match="gitlab.v1.objects"):
         gitlab.Gitlab(api_version="1")
 
 


### PR DESCRIPTION
Previously in commit 233b79ed442aac66faf9eb4b0087ea126d6dffc5 I had
used the `name` argument for `ModuleNotFoundError()`. This basically
is the equivalent of not passing any message to
`ModuleNotFoundError()`. So when the exception was raised it wasn't
very helpful.

Correct that and add a unit-test that shows we get the message we
expect.