### PR TITLE
chore: update type-hints return signature for GetWithoutIdMixin methods

### DIFF
--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -126,7 +126,7 @@ class GetWithoutIdMixin(_RestManagerBase):
     @exc.on_http_error(exc.GitlabGetError)
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[base.RESTObject]:
+    ) -> base.RESTObject:
         """Retrieve a single object.
 
         Args:

--- a/gitlab/v4/objects/appearance.py
+++ b/gitlab/v4/objects/appearance.py
@@ -60,5 +60,5 @@ class ApplicationAppearanceManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
 
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[ApplicationAppearance]:
-        return cast(Optional[ApplicationAppearance], super().get(id=id, **kwargs))
+    ) -> ApplicationAppearance:
+        return cast(ApplicationAppearance, super().get(id=id, **kwargs))

--- a/gitlab/v4/objects/export_import.py
+++ b/gitlab/v4/objects/export_import.py
@@ -24,10 +24,8 @@ class GroupExportManager(GetWithoutIdMixin, CreateMixin, RESTManager):
     _obj_cls = GroupExport
     _from_parent_attrs = {"group_id": "id"}
 
-    def get(
-        self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[GroupExport]:
-        return cast(Optional[GroupExport], super().get(id=id, **kwargs))
+    def get(self, id: Optional[Union[int, str]] = None, **kwargs: Any) -> GroupExport:
+        return cast(GroupExport, super().get(id=id, **kwargs))
 
 
 class GroupImport(RESTObject):
@@ -39,10 +37,8 @@ class GroupImportManager(GetWithoutIdMixin, RESTManager):
     _obj_cls = GroupImport
     _from_parent_attrs = {"group_id": "id"}
 
-    def get(
-        self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[GroupImport]:
-        return cast(Optional[GroupImport], super().get(id=id, **kwargs))
+    def get(self, id: Optional[Union[int, str]] = None, **kwargs: Any) -> GroupImport:
+        return cast(GroupImport, super().get(id=id, **kwargs))
 
 
 class ProjectExport(DownloadMixin, RefreshMixin, RESTObject):
@@ -55,10 +51,8 @@ class ProjectExportManager(GetWithoutIdMixin, CreateMixin, RESTManager):
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(optional=("description",))
 
-    def get(
-        self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[ProjectExport]:
-        return cast(Optional[ProjectExport], super().get(id=id, **kwargs))
+    def get(self, id: Optional[Union[int, str]] = None, **kwargs: Any) -> ProjectExport:
+        return cast(ProjectExport, super().get(id=id, **kwargs))
 
 
 class ProjectImport(RefreshMixin, RESTObject):
@@ -70,7 +64,5 @@ class ProjectImportManager(GetWithoutIdMixin, RESTManager):
     _obj_cls = ProjectImport
     _from_parent_attrs = {"project_id": "id"}
 
-    def get(
-        self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[ProjectImport]:
-        return cast(Optional[ProjectImport], super().get(id=id, **kwargs))
+    def get(self, id: Optional[Union[int, str]] = None, **kwargs: Any) -> ProjectImport:
+        return cast(ProjectImport, super().get(id=id, **kwargs))

--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -47,8 +47,8 @@ class ProjectApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
 
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[ProjectApproval]:
-        return cast(Optional[ProjectApproval], super().get(id=id, **kwargs))
+    ) -> ProjectApproval:
+        return cast(ProjectApproval, super().get(id=id, **kwargs))
 
     @exc.on_http_error(exc.GitlabUpdateError)
     def set_approvers(
@@ -112,8 +112,8 @@ class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTMan
 
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[ProjectMergeRequestApproval]:
-        return cast(Optional[ProjectMergeRequestApproval], super().get(id=id, **kwargs))
+    ) -> ProjectMergeRequestApproval:
+        return cast(ProjectMergeRequestApproval, super().get(id=id, **kwargs))
 
     @exc.on_http_error(exc.GitlabUpdateError)
     def set_approvers(
@@ -254,7 +254,5 @@ class ProjectMergeRequestApprovalStateManager(GetWithoutIdMixin, RESTManager):
 
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[ProjectMergeRequestApprovalState]:
-        return cast(
-            Optional[ProjectMergeRequestApprovalState], super().get(id=id, **kwargs)
-        )
+    ) -> ProjectMergeRequestApprovalState:
+        return cast(ProjectMergeRequestApprovalState, super().get(id=id, **kwargs))

--- a/gitlab/v4/objects/notification_settings.py
+++ b/gitlab/v4/objects/notification_settings.py
@@ -40,8 +40,8 @@ class NotificationSettingsManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
 
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[NotificationSettings]:
-        return cast(Optional[NotificationSettings], super().get(id=id, **kwargs))
+    ) -> NotificationSettings:
+        return cast(NotificationSettings, super().get(id=id, **kwargs))
 
 
 class GroupNotificationSettings(NotificationSettings):
@@ -55,8 +55,8 @@ class GroupNotificationSettingsManager(NotificationSettingsManager):
 
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[GroupNotificationSettings]:
-        return cast(Optional[GroupNotificationSettings], super().get(id=id, **kwargs))
+    ) -> GroupNotificationSettings:
+        return cast(GroupNotificationSettings, super().get(id=id, **kwargs))
 
 
 class ProjectNotificationSettings(NotificationSettings):
@@ -70,5 +70,5 @@ class ProjectNotificationSettingsManager(NotificationSettingsManager):
 
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[ProjectNotificationSettings]:
-        return cast(Optional[ProjectNotificationSettings], super().get(id=id, **kwargs))
+    ) -> ProjectNotificationSettings:
+        return cast(ProjectNotificationSettings, super().get(id=id, **kwargs))

--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -252,8 +252,8 @@ class ProjectPipelineTestReportManager(GetWithoutIdMixin, RESTManager):
 
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[ProjectPipelineTestReport]:
-        return cast(Optional[ProjectPipelineTestReport], super().get(id=id, **kwargs))
+    ) -> ProjectPipelineTestReport:
+        return cast(ProjectPipelineTestReport, super().get(id=id, **kwargs))
 
 
 class ProjectPipelineTestReportSummary(RESTObject):
@@ -267,7 +267,5 @@ class ProjectPipelineTestReportSummaryManager(GetWithoutIdMixin, RESTManager):
 
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[ProjectPipelineTestReportSummary]:
-        return cast(
-            Optional[ProjectPipelineTestReportSummary], super().get(id=id, **kwargs)
-        )
+    ) -> ProjectPipelineTestReportSummary:
+        return cast(ProjectPipelineTestReportSummary, super().get(id=id, **kwargs))

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -1030,5 +1030,5 @@ class ProjectStorageManager(GetWithoutIdMixin, RESTManager):
 
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[ProjectStorage]:
-        return cast(Optional[ProjectStorage], super().get(id=id, **kwargs))
+    ) -> ProjectStorage:
+        return cast(ProjectStorage, super().get(id=id, **kwargs))

--- a/gitlab/v4/objects/push_rules.py
+++ b/gitlab/v4/objects/push_rules.py
@@ -53,5 +53,5 @@ class ProjectPushRulesManager(
 
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[ProjectPushRules]:
-        return cast(Optional[ProjectPushRules], super().get(id=id, **kwargs))
+    ) -> ProjectPushRules:
+        return cast(ProjectPushRules, super().get(id=id, **kwargs))

--- a/gitlab/v4/objects/settings.py
+++ b/gitlab/v4/objects/settings.py
@@ -117,5 +117,5 @@ class ApplicationSettingsManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
 
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[ApplicationSettings]:
-        return cast(Optional[ApplicationSettings], super().get(id=id, **kwargs))
+    ) -> ApplicationSettings:
+        return cast(ApplicationSettings, super().get(id=id, **kwargs))

--- a/gitlab/v4/objects/statistics.py
+++ b/gitlab/v4/objects/statistics.py
@@ -26,8 +26,8 @@ class ProjectAdditionalStatisticsManager(GetWithoutIdMixin, RESTManager):
 
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[ProjectAdditionalStatistics]:
-        return cast(Optional[ProjectAdditionalStatistics], super().get(id=id, **kwargs))
+    ) -> ProjectAdditionalStatistics:
+        return cast(ProjectAdditionalStatistics, super().get(id=id, **kwargs))
 
 
 class IssuesStatistics(RefreshMixin, RESTObject):
@@ -40,8 +40,8 @@ class IssuesStatisticsManager(GetWithoutIdMixin, RESTManager):
 
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[IssuesStatistics]:
-        return cast(Optional[IssuesStatistics], super().get(id=id, **kwargs))
+    ) -> IssuesStatistics:
+        return cast(IssuesStatistics, super().get(id=id, **kwargs))
 
 
 class GroupIssuesStatistics(RefreshMixin, RESTObject):
@@ -55,8 +55,8 @@ class GroupIssuesStatisticsManager(GetWithoutIdMixin, RESTManager):
 
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[GroupIssuesStatistics]:
-        return cast(Optional[GroupIssuesStatistics], super().get(id=id, **kwargs))
+    ) -> GroupIssuesStatistics:
+        return cast(GroupIssuesStatistics, super().get(id=id, **kwargs))
 
 
 class ProjectIssuesStatistics(RefreshMixin, RESTObject):
@@ -70,5 +70,5 @@ class ProjectIssuesStatisticsManager(GetWithoutIdMixin, RESTManager):
 
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[ProjectIssuesStatistics]:
-        return cast(Optional[ProjectIssuesStatistics], super().get(id=id, **kwargs))
+    ) -> ProjectIssuesStatistics:
+        return cast(ProjectIssuesStatistics, super().get(id=id, **kwargs))

--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -122,8 +122,8 @@ class CurrentUserStatusManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
 
     def get(
         self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[CurrentUserStatus]:
-        return cast(Optional[CurrentUserStatus], super().get(id=id, **kwargs))
+    ) -> CurrentUserStatus:
+        return cast(CurrentUserStatus, super().get(id=id, **kwargs))
 
 
 class CurrentUser(RESTObject):
@@ -140,10 +140,8 @@ class CurrentUserManager(GetWithoutIdMixin, RESTManager):
     _path = "/user"
     _obj_cls = CurrentUser
 
-    def get(
-        self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[CurrentUser]:
-        return cast(Optional[CurrentUser], super().get(id=id, **kwargs))
+    def get(self, id: Optional[Union[int, str]] = None, **kwargs: Any) -> CurrentUser:
+        return cast(CurrentUser, super().get(id=id, **kwargs))
 
 
 class User(SaveMixin, ObjectDeleteMixin, RESTObject):
@@ -400,10 +398,8 @@ class UserStatusManager(GetWithoutIdMixin, RESTManager):
     _obj_cls = UserStatus
     _from_parent_attrs = {"user_id": "id"}
 
-    def get(
-        self, id: Optional[Union[int, str]] = None, **kwargs: Any
-    ) -> Optional[UserStatus]:
-        return cast(Optional[UserStatus], super().get(id=id, **kwargs))
+    def get(self, id: Optional[Union[int, str]] = None, **kwargs: Any) -> UserStatus:
+        return cast(UserStatus, super().get(id=id, **kwargs))
 
 
 class UserActivitiesManager(ListMixin, RESTManager):

--- a/tests/meta/test_ensure_type_hints.py
+++ b/tests/meta/test_ensure_type_hints.py
@@ -72,8 +72,8 @@ from typing import Any, cast, Union"
 GET_WITHOUT_ID_METHOD_TEMPLATE = """
 def get(
     self, id: Optional[Union[int, str]] = None, **kwargs: Any
-) -> Optional[{obj_cls.__name__}]:
-    return cast(Optional[{obj_cls.__name__}], super().get(id=id, **kwargs))
+) -> {obj_cls.__name__}:
+    return cast({obj_cls.__name__}, super().get(id=id, **kwargs))
 
 You may also need to add the following imports:
 from typing import Any, cast, Optional, Union"
@@ -102,7 +102,7 @@ class TestTypeHints:
             base_type=gitlab.mixins.GetWithoutIdMixin,
             class_info=class_info,
             method_template=GET_WITHOUT_ID_METHOD_TEMPLATE,
-            optional_return=True,
+            optional_return=False,
         )
 
     def get_check_helper(


### PR DESCRIPTION
Commit f0152dc3cc9a42aa4dc3c0014b4c29381e9b39d6 removed situation
where `get()` in a `GetWithoutIdMixin` based class could return `None`

Update the type-hints to no longer return `Optional` AKA `None`