### PR TITLE
chore: move `RequiredOptional` to the `gitlab.types` module

### DIFF
--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -18,9 +18,8 @@
 import importlib
 import pprint
 import textwrap
-from dataclasses import dataclass
 from types import ModuleType
-from typing import Any, Dict, Iterable, Optional, Tuple, Type, Union
+from typing import Any, Dict, Iterable, Optional, Type, Union
 
 import gitlab
 from gitlab import types as g_types
@@ -29,7 +28,6 @@ from gitlab.exceptions import GitlabParsingError
 from .client import Gitlab, GitlabList
 
 __all__ = [
-    "RequiredOptional",
     "RESTObject",
     "RESTObjectList",
     "RESTManager",
@@ -330,12 +328,6 @@ class RESTObjectList:
         return self._list.total
 
 
-@dataclass(frozen=True)
-class RequiredOptional:
-    required: Tuple[str, ...] = ()
-    optional: Tuple[str, ...] = ()
-
-
 class RESTManager:
     """Base class for CRUD operations on objects.
 
@@ -345,8 +337,8 @@ class RESTManager:
     ``_obj_cls``: The class of objects that will be created
     """
 
-    _create_attrs: RequiredOptional = RequiredOptional()
-    _update_attrs: RequiredOptional = RequiredOptional()
+    _create_attrs: g_types.RequiredOptional = g_types.RequiredOptional()
+    _update_attrs: g_types.RequiredOptional = g_types.RequiredOptional()
     _path: Optional[str] = None
     _obj_cls: Optional[Type[RESTObject]] = None
     _from_parent_attrs: Dict[str, Any] = {}

--- a/gitlab/types.py
+++ b/gitlab/types.py
@@ -15,7 +15,14 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Any, Optional, TYPE_CHECKING
+import dataclasses
+from typing import Any, Optional, Tuple, TYPE_CHECKING
+
+
+@dataclasses.dataclass(frozen=True)
+class RequiredOptional:
+    required: Tuple[str, ...] = ()
+    optional: Tuple[str, ...] = ()
 
 
 class GitlabAttribute:

--- a/gitlab/v4/objects/appearance.py
+++ b/gitlab/v4/objects/appearance.py
@@ -1,8 +1,9 @@
 from typing import Any, cast, Dict, Optional, Union
 
 from gitlab import exceptions as exc
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import GetWithoutIdMixin, SaveMixin, UpdateMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "ApplicationAppearance",

--- a/gitlab/v4/objects/applications.py
+++ b/gitlab/v4/objects/applications.py
@@ -1,5 +1,6 @@
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CreateMixin, DeleteMixin, ListMixin, ObjectDeleteMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "Application",

--- a/gitlab/v4/objects/award_emojis.py
+++ b/gitlab/v4/objects/award_emojis.py
@@ -1,7 +1,8 @@
 from typing import Any, cast, Union
 
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import NoUpdateMixin, ObjectDeleteMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "GroupEpicAwardEmoji",

--- a/gitlab/v4/objects/badges.py
+++ b/gitlab/v4/objects/badges.py
@@ -1,7 +1,8 @@
 from typing import Any, cast, Union
 
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import BadgeRenderMixin, CRUDMixin, ObjectDeleteMixin, SaveMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "GroupBadge",

--- a/gitlab/v4/objects/boards.py
+++ b/gitlab/v4/objects/boards.py
@@ -1,7 +1,8 @@
 from typing import Any, cast, Union
 
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "GroupBoardList",

--- a/gitlab/v4/objects/branches.py
+++ b/gitlab/v4/objects/branches.py
@@ -1,7 +1,8 @@
 from typing import Any, cast, Union
 
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import NoUpdateMixin, ObjectDeleteMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "ProjectBranch",

--- a/gitlab/v4/objects/broadcast_messages.py
+++ b/gitlab/v4/objects/broadcast_messages.py
@@ -1,7 +1,8 @@
 from typing import Any, cast, Union
 
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "BroadcastMessage",

--- a/gitlab/v4/objects/clusters.py
+++ b/gitlab/v4/objects/clusters.py
@@ -1,8 +1,9 @@
 from typing import Any, cast, Dict, Optional, Union
 
 from gitlab import exceptions as exc
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CreateMixin, CRUDMixin, ObjectDeleteMixin, SaveMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "GroupCluster",

--- a/gitlab/v4/objects/commits.py
+++ b/gitlab/v4/objects/commits.py
@@ -5,8 +5,9 @@ import requests
 import gitlab
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CreateMixin, ListMixin, RefreshMixin, RetrieveMixin
+from gitlab.types import RequiredOptional
 
 from .discussions import ProjectCommitDiscussionManager  # noqa: F401
 

--- a/gitlab/v4/objects/deploy_keys.py
+++ b/gitlab/v4/objects/deploy_keys.py
@@ -4,8 +4,9 @@ import requests
 
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ListMixin, ObjectDeleteMixin, SaveMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "DeployKey",

--- a/gitlab/v4/objects/deploy_tokens.py
+++ b/gitlab/v4/objects/deploy_tokens.py
@@ -1,7 +1,7 @@
 from typing import Any, cast, Union
 
 from gitlab import types
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,
     DeleteMixin,
@@ -9,6 +9,7 @@ from gitlab.mixins import (
     ObjectDeleteMixin,
     RetrieveMixin,
 )
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "DeployToken",

--- a/gitlab/v4/objects/deployments.py
+++ b/gitlab/v4/objects/deployments.py
@@ -1,7 +1,8 @@
 from typing import Any, cast, Union
 
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CreateMixin, RetrieveMixin, SaveMixin, UpdateMixin
+from gitlab.types import RequiredOptional
 
 from .merge_requests import ProjectDeploymentMergeRequestManager  # noqa: F401
 

--- a/gitlab/v4/objects/discussions.py
+++ b/gitlab/v4/objects/discussions.py
@@ -1,7 +1,8 @@
 from typing import Any, cast, Union
 
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CreateMixin, RetrieveMixin, SaveMixin, UpdateMixin
+from gitlab.types import RequiredOptional
 
 from .notes import (  # noqa: F401
     ProjectCommitDiscussionNoteManager,

--- a/gitlab/v4/objects/environments.py
+++ b/gitlab/v4/objects/environments.py
@@ -4,7 +4,7 @@ import requests
 
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,
     DeleteMixin,
@@ -13,6 +13,7 @@ from gitlab.mixins import (
     SaveMixin,
     UpdateMixin,
 )
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "ProjectEnvironment",

--- a/gitlab/v4/objects/epics.py
+++ b/gitlab/v4/objects/epics.py
@@ -2,7 +2,7 @@ from typing import Any, cast, Dict, Optional, TYPE_CHECKING, Union
 
 from gitlab import exceptions as exc
 from gitlab import types
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,
     CRUDMixin,
@@ -12,6 +12,7 @@ from gitlab.mixins import (
     SaveMixin,
     UpdateMixin,
 )
+from gitlab.types import RequiredOptional
 
 from .events import GroupEpicResourceLabelEventManager  # noqa: F401
 

--- a/gitlab/v4/objects/export_import.py
+++ b/gitlab/v4/objects/export_import.py
@@ -1,7 +1,8 @@
 from typing import Any, cast, Optional, Union
 
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CreateMixin, DownloadMixin, GetWithoutIdMixin, RefreshMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "GroupExport",

--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -6,7 +6,7 @@ import requests
 from gitlab import cli
 from gitlab import exceptions as exc
 from gitlab import utils
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,
     DeleteMixin,
@@ -15,6 +15,7 @@ from gitlab.mixins import (
     SaveMixin,
     UpdateMixin,
 )
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "ProjectFile",

--- a/gitlab/v4/objects/geo_nodes.py
+++ b/gitlab/v4/objects/geo_nodes.py
@@ -2,7 +2,7 @@ from typing import Any, cast, Dict, List, TYPE_CHECKING, Union
 
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     DeleteMixin,
     ObjectDeleteMixin,
@@ -10,6 +10,7 @@ from gitlab.mixins import (
     SaveMixin,
     UpdateMixin,
 )
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "GeoNode",

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -6,8 +6,9 @@ import gitlab
 from gitlab import cli
 from gitlab import exceptions as exc
 from gitlab import types
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ListMixin, ObjectDeleteMixin, SaveMixin
+from gitlab.types import RequiredOptional
 
 from .access_requests import GroupAccessRequestManager  # noqa: F401
 from .audit_events import GroupAuditEventManager  # noqa: F401

--- a/gitlab/v4/objects/hooks.py
+++ b/gitlab/v4/objects/hooks.py
@@ -1,7 +1,8 @@
 from typing import Any, cast, Union
 
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, NoUpdateMixin, ObjectDeleteMixin, SaveMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "Hook",

--- a/gitlab/v4/objects/issues.py
+++ b/gitlab/v4/objects/issues.py
@@ -3,7 +3,7 @@ from typing import Any, cast, Dict, Tuple, TYPE_CHECKING, Union
 from gitlab import cli
 from gitlab import exceptions as exc
 from gitlab import types
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,
     CRUDMixin,
@@ -18,6 +18,7 @@ from gitlab.mixins import (
     TodoMixin,
     UserAgentDetailMixin,
 )
+from gitlab.types import RequiredOptional
 
 from .award_emojis import ProjectIssueAwardEmojiManager  # noqa: F401
 from .discussions import ProjectIssueDiscussionManager  # noqa: F401

--- a/gitlab/v4/objects/labels.py
+++ b/gitlab/v4/objects/labels.py
@@ -1,7 +1,7 @@
 from typing import Any, cast, Dict, Optional, Union
 
 from gitlab import exceptions as exc
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,
     DeleteMixin,
@@ -12,6 +12,7 @@ from gitlab.mixins import (
     SubscribableMixin,
     UpdateMixin,
 )
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "GroupLabel",

--- a/gitlab/v4/objects/members.py
+++ b/gitlab/v4/objects/members.py
@@ -1,7 +1,7 @@
 from typing import Any, cast, Union
 
 from gitlab import types
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CRUDMixin,
     DeleteMixin,
@@ -10,6 +10,7 @@ from gitlab.mixins import (
     RetrieveMixin,
     SaveMixin,
 )
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "GroupBillableMember",

--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -1,7 +1,7 @@
 from typing import Any, cast, Dict, List, Optional, TYPE_CHECKING, Union
 
 from gitlab import exceptions as exc
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,
     DeleteMixin,
@@ -11,6 +11,7 @@ from gitlab.mixins import (
     SaveMixin,
     UpdateMixin,
 )
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "ProjectApproval",

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -11,7 +11,7 @@ import gitlab
 from gitlab import cli
 from gitlab import exceptions as exc
 from gitlab import types
-from gitlab.base import RequiredOptional, RESTManager, RESTObject, RESTObjectList
+from gitlab.base import RESTManager, RESTObject, RESTObjectList
 from gitlab.mixins import (
     CRUDMixin,
     ListMixin,
@@ -23,6 +23,7 @@ from gitlab.mixins import (
     TimeTrackingMixin,
     TodoMixin,
 )
+from gitlab.types import RequiredOptional
 
 from .award_emojis import ProjectMergeRequestAwardEmojiManager  # noqa: F401
 from .commits import ProjectCommit, ProjectCommitManager

--- a/gitlab/v4/objects/milestones.py
+++ b/gitlab/v4/objects/milestones.py
@@ -3,8 +3,9 @@ from typing import Any, cast, TYPE_CHECKING, Union
 from gitlab import cli
 from gitlab import exceptions as exc
 from gitlab import types
-from gitlab.base import RequiredOptional, RESTManager, RESTObject, RESTObjectList
+from gitlab.base import RESTManager, RESTObject, RESTObjectList
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, PromoteMixin, SaveMixin
+from gitlab.types import RequiredOptional
 
 from .issues import GroupIssue, GroupIssueManager, ProjectIssue, ProjectIssueManager
 from .merge_requests import (

--- a/gitlab/v4/objects/notes.py
+++ b/gitlab/v4/objects/notes.py
@@ -1,6 +1,6 @@
 from typing import Any, cast, Union
 
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,
     CRUDMixin,
@@ -11,6 +11,7 @@ from gitlab.mixins import (
     SaveMixin,
     UpdateMixin,
 )
+from gitlab.types import RequiredOptional
 
 from .award_emojis import (  # noqa: F401
     GroupEpicNoteAwardEmojiManager,

--- a/gitlab/v4/objects/notification_settings.py
+++ b/gitlab/v4/objects/notification_settings.py
@@ -1,7 +1,8 @@
 from typing import Any, cast, Optional, Union
 
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import GetWithoutIdMixin, SaveMixin, UpdateMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "NotificationSettings",

--- a/gitlab/v4/objects/pages.py
+++ b/gitlab/v4/objects/pages.py
@@ -1,7 +1,8 @@
 from typing import Any, cast, Union
 
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ListMixin, ObjectDeleteMixin, SaveMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "PagesDomain",

--- a/gitlab/v4/objects/personal_access_tokens.py
+++ b/gitlab/v4/objects/personal_access_tokens.py
@@ -1,5 +1,6 @@
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CreateMixin, DeleteMixin, ListMixin, ObjectDeleteMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "PersonalAccessToken",

--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -4,7 +4,7 @@ import requests
 
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,
     CRUDMixin,
@@ -17,6 +17,7 @@ from gitlab.mixins import (
     SaveMixin,
     UpdateMixin,
 )
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "ProjectMergeRequestPipeline",

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -5,7 +5,7 @@ import requests
 from gitlab import cli, client
 from gitlab import exceptions as exc
 from gitlab import types, utils
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,
     CRUDMixin,
@@ -16,6 +16,7 @@ from gitlab.mixins import (
     SaveMixin,
     UpdateMixin,
 )
+from gitlab.types import RequiredOptional
 
 from .access_requests import ProjectAccessRequestManager  # noqa: F401
 from .artifacts import ProjectArtifactManager  # noqa: F401

--- a/gitlab/v4/objects/push_rules.py
+++ b/gitlab/v4/objects/push_rules.py
@@ -1,6 +1,6 @@
 from typing import Any, cast, Optional, Union
 
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,
     DeleteMixin,
@@ -9,6 +9,7 @@ from gitlab.mixins import (
     SaveMixin,
     UpdateMixin,
 )
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "ProjectPushRules",

--- a/gitlab/v4/objects/releases.py
+++ b/gitlab/v4/objects/releases.py
@@ -1,7 +1,8 @@
 from typing import Any, cast, Union
 
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "ProjectRelease",

--- a/gitlab/v4/objects/runners.py
+++ b/gitlab/v4/objects/runners.py
@@ -3,7 +3,7 @@ from typing import Any, cast, List, Optional, Union
 from gitlab import cli
 from gitlab import exceptions as exc
 from gitlab import types
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,
     CRUDMixin,
@@ -12,6 +12,7 @@ from gitlab.mixins import (
     ObjectDeleteMixin,
     SaveMixin,
 )
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "RunnerJob",

--- a/gitlab/v4/objects/settings.py
+++ b/gitlab/v4/objects/settings.py
@@ -2,8 +2,9 @@ from typing import Any, cast, Dict, Optional, Union
 
 from gitlab import exceptions as exc
 from gitlab import types
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import GetWithoutIdMixin, SaveMixin, UpdateMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "ApplicationSettings",

--- a/gitlab/v4/objects/snippets.py
+++ b/gitlab/v4/objects/snippets.py
@@ -5,8 +5,9 @@ import requests
 from gitlab import cli
 from gitlab import exceptions as exc
 from gitlab import utils
-from gitlab.base import RequiredOptional, RESTManager, RESTObject, RESTObjectList
+from gitlab.base import RESTManager, RESTObject, RESTObjectList
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin, UserAgentDetailMixin
+from gitlab.types import RequiredOptional
 
 from .award_emojis import ProjectSnippetAwardEmojiManager  # noqa: F401
 from .discussions import ProjectSnippetDiscussionManager  # noqa: F401

--- a/gitlab/v4/objects/tags.py
+++ b/gitlab/v4/objects/tags.py
@@ -1,7 +1,8 @@
 from typing import Any, cast, Union
 
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import NoUpdateMixin, ObjectDeleteMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "ProjectTag",

--- a/gitlab/v4/objects/topics.py
+++ b/gitlab/v4/objects/topics.py
@@ -1,8 +1,9 @@
 from typing import Any, cast, Union
 
 from gitlab import types
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "Topic",

--- a/gitlab/v4/objects/triggers.py
+++ b/gitlab/v4/objects/triggers.py
@@ -1,7 +1,8 @@
 from typing import Any, cast, Union
 
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "ProjectTrigger",

--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -10,7 +10,7 @@ import requests
 from gitlab import cli
 from gitlab import exceptions as exc
 from gitlab import types
-from gitlab.base import RequiredOptional, RESTManager, RESTObject, RESTObjectList
+from gitlab.base import RESTManager, RESTObject, RESTObjectList
 from gitlab.mixins import (
     CreateMixin,
     CRUDMixin,
@@ -23,6 +23,7 @@ from gitlab.mixins import (
     SaveMixin,
     UpdateMixin,
 )
+from gitlab.types import RequiredOptional
 
 from .custom_attributes import UserCustomAttributeManager  # noqa: F401
 from .events import UserEventManager  # noqa: F401

--- a/gitlab/v4/objects/variables.py
+++ b/gitlab/v4/objects/variables.py
@@ -6,8 +6,9 @@ https://docs.gitlab.com/ee/api/group_level_variables.html
 """
 from typing import Any, cast, Union
 
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "Variable",

--- a/gitlab/v4/objects/wikis.py
+++ b/gitlab/v4/objects/wikis.py
@@ -1,7 +1,8 @@
 from typing import Any, cast, Union
 
-from gitlab.base import RequiredOptional, RESTManager, RESTObject
+from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
+from gitlab.types import RequiredOptional
 
 __all__ = [
     "ProjectWiki",

--- a/tests/unit/mixins/test_mixin_methods.py
+++ b/tests/unit/mixins/test_mixin_methods.py
@@ -2,6 +2,7 @@ import pytest
 import responses
 
 from gitlab import base
+from gitlab import types as gl_types
 from gitlab.mixins import (
     CreateMixin,
     DeleteMixin,
@@ -166,7 +167,7 @@ def test_list_other_url(gl):
 
 def test_create_mixin_missing_attrs(gl):
     class M(CreateMixin, FakeManager):
-        _create_attrs = base.RequiredOptional(
+        _create_attrs = gl_types.RequiredOptional(
             required=("foo",), optional=("bar", "baz")
         )
 
@@ -183,10 +184,10 @@ def test_create_mixin_missing_attrs(gl):
 @responses.activate
 def test_create_mixin(gl):
     class M(CreateMixin, FakeManager):
-        _create_attrs = base.RequiredOptional(
+        _create_attrs = gl_types.RequiredOptional(
             required=("foo",), optional=("bar", "baz")
         )
-        _update_attrs = base.RequiredOptional(required=("foo",), optional=("bam",))
+        _update_attrs = gl_types.RequiredOptional(required=("foo",), optional=("bam",))
 
     url = "http://localhost/api/v4/tests"
     responses.add(
@@ -208,10 +209,10 @@ def test_create_mixin(gl):
 @responses.activate
 def test_create_mixin_custom_path(gl):
     class M(CreateMixin, FakeManager):
-        _create_attrs = base.RequiredOptional(
+        _create_attrs = gl_types.RequiredOptional(
             required=("foo",), optional=("bar", "baz")
         )
-        _update_attrs = base.RequiredOptional(required=("foo",), optional=("bam",))
+        _update_attrs = gl_types.RequiredOptional(required=("foo",), optional=("bam",))
 
     url = "http://localhost/api/v4/others"
     responses.add(
@@ -232,7 +233,7 @@ def test_create_mixin_custom_path(gl):
 
 def test_update_mixin_missing_attrs(gl):
     class M(UpdateMixin, FakeManager):
-        _update_attrs = base.RequiredOptional(
+        _update_attrs = gl_types.RequiredOptional(
             required=("foo",), optional=("bar", "baz")
         )
 
@@ -249,10 +250,10 @@ def test_update_mixin_missing_attrs(gl):
 @responses.activate
 def test_update_mixin(gl):
     class M(UpdateMixin, FakeManager):
-        _create_attrs = base.RequiredOptional(
+        _create_attrs = gl_types.RequiredOptional(
             required=("foo",), optional=("bar", "baz")
         )
-        _update_attrs = base.RequiredOptional(required=("foo",), optional=("bam",))
+        _update_attrs = gl_types.RequiredOptional(required=("foo",), optional=("bam",))
 
     url = "http://localhost/api/v4/tests/42"
     responses.add(
@@ -293,10 +294,10 @@ def test_update_mixin_uses_post(gl):
 @responses.activate
 def test_update_mixin_no_id(gl):
     class M(UpdateMixin, FakeManager):
-        _create_attrs = base.RequiredOptional(
+        _create_attrs = gl_types.RequiredOptional(
             required=("foo",), optional=("bar", "baz")
         )
-        _update_attrs = base.RequiredOptional(required=("foo",), optional=("bam",))
+        _update_attrs = gl_types.RequiredOptional(required=("foo",), optional=("bam",))
 
     url = "http://localhost/api/v4/tests"
     responses.add(


### PR DESCRIPTION
By having `RequiredOptional` in the `gitlab.base` module it makes it
difficult with circular imports. Move it to the `gitlab.types`
module which has no dependencies on any other gitlab module.