### PR TITLE
chore: have `EncodedId` creation always return `EncodedId`

### DIFF
--- a/gitlab/utils.py
+++ b/gitlab/utils.py
@@ -113,16 +113,14 @@ class EncodedId(str):
         https://docs.gitlab.com/ee/api/index.html#path-parameters
     """
 
-    # mypy complains if return type other than the class type. So we ignore issue.
-    def __new__(  # type: ignore
-        cls, value: Union[str, int, "EncodedId"]
-    ) -> Union[int, "EncodedId"]:
-        if isinstance(value, (int, EncodedId)):
+    def __new__(cls, value: Union[str, int, "EncodedId"]) -> "EncodedId":
+        if isinstance(value, EncodedId):
             return value
 
-        if not isinstance(value, str):
+        if not isinstance(value, (int, str)):
             raise TypeError(f"Unsupported type received: {type(value)}")
-        value = urllib.parse.quote(value, safe="")
+        if isinstance(value, str):
+            value = urllib.parse.quote(value, safe="")
         return super().__new__(cls, value)
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -48,16 +48,18 @@ class TestEncodedId:
         assert "Hello" == obj
         assert "Hello" == str(obj)
         assert "Hello" == f"{obj}"
+        assert isinstance(obj, utils.EncodedId)
 
         obj = utils.EncodedId("this/is a/path")
         assert "this%2Fis%20a%2Fpath" == str(obj)
         assert "this%2Fis%20a%2Fpath" == f"{obj}"
+        assert isinstance(obj, utils.EncodedId)
 
     def test_init_int(self):
         obj = utils.EncodedId(23)
-        assert 23 == obj
-        assert "23" == str(obj)
+        assert "23" == obj
         assert "23" == f"{obj}"
+        assert isinstance(obj, utils.EncodedId)
 
     def test_init_invalid_type_raises(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
There is no reason to return an `int` as we can always return a `str`
version of the `int`

Change `EncodedId` to always return an `EncodedId`. This removes the
need to have `mypy` ignore the error raised.