### PR TITLE
chore: require f-strings

### DIFF
--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -73,9 +73,9 @@ class RESTObject:
     ) -> None:
         if not isinstance(attrs, dict):
             raise GitlabParsingError(
-                "Attempted to initialize RESTObject with a non-dictionary value: "
-                "{!r}\nThis likely indicates an incorrect or malformed server "
-                "response.".format(attrs)
+                f"Attempted to initialize RESTObject with a non-dictionary value: "
+                f"{attrs!r}\nThis likely indicates an incorrect or malformed server "
+                f"response."
             )
         self.__dict__.update(
             {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ disable = [
     "arguments-renamed",
     "attribute-defined-outside-init",
     "broad-except",
-    "consider-using-f-string",
     "consider-using-generator",
     "consider-using-sys-exit",
     "cyclic-import",


### PR DESCRIPTION
We previously converted all string formatting to use f-strings. Enable
pylint check to enforce this.