### PR TITLE
chore: enable 'consider-using-sys-exit' pylint check

### DIFF
--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -394,7 +394,7 @@ class YAMLPrinter:
 
             print(yaml.safe_dump(d, default_flow_style=False))
         except ImportError:
-            exit(
+            sys.exit(
                 "PyYaml is not installed.\n"
                 "Install it with `pip install PyYaml` "
                 "to use the yaml output feature"
@@ -415,7 +415,7 @@ class YAMLPrinter:
                 )
             )
         except ImportError:
-            exit(
+            sys.exit(
                 "PyYaml is not installed.\n"
                 "Install it with `pip install PyYaml` "
                 "to use the yaml output feature"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ disable = [
     "attribute-defined-outside-init",
     "broad-except",
     "consider-using-generator",
-    "consider-using-sys-exit",
     "cyclic-import",
     "duplicate-code",
     "fixme",


### PR DESCRIPTION
Enable the 'consider-using-sys-exit' pylint check and fix errors
raised.