### PR TITLE
chore: rename `what` to `gitlab_resource`

### DIFF
--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -91,14 +91,16 @@ def die(msg: str, e: Optional[Exception] = None) -> None:
     sys.exit(1)
 
 
-def what_to_cls(what: str, namespace: ModuleType) -> Type[RESTObject]:
+def gitlab_resource_to_cls(
+    gitlab_resource: str, namespace: ModuleType
+) -> Type[RESTObject]:
     classes = CaseInsensitiveDict(namespace.__dict__)
-    lowercase_class = what.replace("-", "")
+    lowercase_class = gitlab_resource.replace("-", "")
 
     return classes[lowercase_class]
 
 
-def cls_to_what(cls: RESTObject) -> str:
+def cls_to_gitlab_resource(cls: RESTObject) -> str:
     dasherized_uppercase = camel_upperlower_regex.sub(r"\1-\2", cls.__name__)
     dasherized_lowercase = camel_lowerupper_regex.sub(r"\1-\2", dasherized_uppercase)
     return dasherized_lowercase.lower()
@@ -322,7 +324,7 @@ def main() -> None:
         fields = [x.strip() for x in args.fields.split(",")]
     debug = args.debug
     action = args.whaction
-    what = args.what
+    gitlab_resource = args.gitlab_resource
 
     args_dict = vars(args)
     # Remove CLI behavior-related args
@@ -331,7 +333,7 @@ def main() -> None:
         "config_file",
         "verbose",
         "debug",
-        "what",
+        "gitlab_resource",
         "whaction",
         "version",
         "output",
@@ -359,4 +361,4 @@ def main() -> None:
     if debug:
         gl.enable_debug()
 
-    gitlab.v4.cli.run(gl, what, action, args_dict, verbose, output, fields)
+    gitlab.v4.cli.run(gl, gitlab_resource, action, args_dict, verbose, output, fields)

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -79,7 +79,7 @@ class GitlabCLI:
             # If we don't delete it then it will be added to the URL as a query-string
             del self.args[key]
 
-    def __call__(self) -> Any:
+    def run(self) -> Any:
         # Check for a method that matches object + action
         method = f"do_{self.what}_{self.action}"
         if hasattr(self, method):
@@ -505,7 +505,7 @@ def run(
     fields: List[str],
 ) -> None:
     g_cli = GitlabCLI(gl=gl, what=what, action=action, args=args)
-    data = g_cli()
+    data = g_cli.run()
 
     printer: Union[JSONPrinter, LegacyPrinter, YAMLPrinter] = PRINTERS[output]()
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -29,7 +29,7 @@ from gitlab.exceptions import GitlabError
 
 
 @pytest.mark.parametrize(
-    "what,expected_class",
+    "gitlab_resource,expected_class",
     [
         ("class", "Class"),
         ("test-class", "TestClass"),
@@ -39,18 +39,18 @@ from gitlab.exceptions import GitlabError
         ("ldap-group", "LDAPGroup"),
     ],
 )
-def test_what_to_cls(what, expected_class):
+def test_gitlab_resource_to_cls(gitlab_resource, expected_class):
     def _namespace():
         pass
 
     ExpectedClass = type(expected_class, (), {})
     _namespace.__dict__[expected_class] = ExpectedClass
 
-    assert cli.what_to_cls(what, _namespace) == ExpectedClass
+    assert cli.gitlab_resource_to_cls(gitlab_resource, _namespace) == ExpectedClass
 
 
 @pytest.mark.parametrize(
-    "class_name,expected_what",
+    "class_name,expected_gitlab_resource",
     [
         ("Class", "class"),
         ("TestClass", "test-class"),
@@ -61,10 +61,10 @@ def test_what_to_cls(what, expected_class):
         ("LDAPGroup", "ldap-group"),
     ],
 )
-def test_cls_to_what(class_name, expected_what):
+def test_cls_to_gitlab_resource(class_name, expected_gitlab_resource):
     TestClass = type(class_name, (), {})
 
-    assert cli.cls_to_what(TestClass) == expected_what
+    assert cli.cls_to_gitlab_resource(TestClass) == expected_gitlab_resource
 
 
 @pytest.mark.parametrize(
@@ -125,7 +125,7 @@ def test_base_parser():
 def test_v4_parse_args():
     parser = cli._get_parser()
     args = parser.parse_args(["project", "list"])
-    assert args.what == "project"
+    assert args.gitlab_resource == "project"
     assert args.whaction == "list"
 
 


### PR DESCRIPTION
Naming a variable `what` makes it difficult to understand what it is
used for.

Rename it to `gitlab_resource` as that is what is being stored.

The Gitlab documentation talks about them being resources:
https://docs.gitlab.com/ee/api/api_resources.html

This will improve code readability.