### PR TITLE
chore: rename `whaction` and `action` to `resource_action` in CLI

### DIFF
--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -323,8 +323,8 @@ def main() -> None:
     if args.fields:
         fields = [x.strip() for x in args.fields.split(",")]
     debug = args.debug
-    action = args.whaction
     gitlab_resource = args.gitlab_resource
+    resource_action = args.resource_action
 
     args_dict = vars(args)
     # Remove CLI behavior-related args
@@ -334,7 +334,7 @@ def main() -> None:
         "verbose",
         "debug",
         "gitlab_resource",
-        "whaction",
+        "resource_action",
         "version",
         "output",
         "fields",
@@ -361,4 +361,6 @@ def main() -> None:
     if debug:
         gl.enable_debug()
 
-    gitlab.v4.cli.run(gl, gitlab_resource, action, args_dict, verbose, output, fields)
+    gitlab.v4.cli.run(
+        gl, gitlab_resource, resource_action, args_dict, verbose, output, fields
+    )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -126,7 +126,7 @@ def test_v4_parse_args():
     parser = cli._get_parser()
     args = parser.parse_args(["project", "list"])
     assert args.gitlab_resource == "project"
-    assert args.whaction == "list"
+    assert args.resource_action == "list"
 
 
 def test_v4_parser():


### PR DESCRIPTION
Rename the variables `whaction` and `action` to `resource_action` to
improve code-readability.