### PR TITLE
chore(cli): rename "object" to "GitLab resource"

### DIFF
--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -337,7 +337,9 @@ def _populate_sub_parser_by_class(
 
 def extend_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(
-        title="object", dest="gitlab_resource", help="Object to manipulate."
+        title="resource",
+        dest="gitlab_resource",
+        help="The GitLab resource to manipulate.",
     )
     subparsers.required = True
 


### PR DESCRIPTION
Make the parser name more user friendly by renaming from generic
"object" to "GitLab resource"