### PR TITLE
chore: use multiple processors when running PyLint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ commit_message = ""
 
 [tool.pylint.messages_control]
 max-line-length = 88
+jobs = 0  # Use auto-detected number of multiple processes to speed up Pylint.
 # TODO(jlvilla): Work on removing these disables over time.
 disable = [
     "arguments-differ",


### PR DESCRIPTION
Use multiple processors when running PyLint. On my system it took
about 10.3 seconds to run PyLint before this change. After this change
it takes about 5.8 seconds to run PyLint.