### PR TITLE
docs(ext): fix rendering for RequiredOptional and refer to upstream docs

### DIFF
--- a/docs/api-usage.rst
+++ b/docs/api-usage.rst
@@ -102,28 +102,26 @@ Examples:
    for project in group.projects.list(iterator=True):
        print(project)
 
-   # create a new user
-   user_data = {'email': 'jen@foo.com', 'username': 'jen', 'name': 'Jen'}
-   user = gl.users.create(user_data)
-   print(user)
-
 .. warning::
    Calling ``list()`` without any arguments will by default not return the complete list
    of items. Use either the ``all=True`` or ``iterator=True`` parameters to get all the
    items when using listing methods. See the :ref:`pagination` section for more
    information.
 
-You can list the mandatory, optional, and mutually exclusive attributes for object
-creation and update with the manager's ``get_create_attrs()`` and ``get_update_attrs()``
-methods. They return 3 tuples. The first tuple is the list of mandatory attributes.
-The second tuple is the list of optional attributes. The third tuple is the mutually
-exclusive attributes:
-
 .. code-block:: python
 
-   # v4 only
-   print(gl.projects.get_create_attrs())
-   (('name',), ('path', 'namespace_id', ...))
+   # create a new user
+   user_data = {'email': 'jen@foo.com', 'username': 'jen', 'name': 'Jen'}
+   user = gl.users.create(user_data)
+   print(user)
+
+.. note:: 
+   python-gitlab attempts to sync the required, optional, and mutually exclusive attributes
+   for resource creation and update with the upstream API.
+   
+   You are encouraged to follow upstream API documentation for each resource to find these -
+   each resource documented here links to the corresponding upstream resource documentation
+   at the top of the page.
 
 The attributes of objects are defined upon object creation, and depend on the
 GitLab API itself. To list the available information associated with an object

--- a/docs/ext/manager_tmpl.j2
+++ b/docs/ext/manager_tmpl.j2
@@ -7,21 +7,21 @@
 
 {% if cls._create_attrs %}
 **Object Creation**
-{% if cls._create_attrs[0] %}
-Mandatory attributes for object create:
+{% if cls._create_attrs.required %}
+Required attributes for object create:
 {% for item in cls._create_attrs.required %}
 - ``{{ item }}``
 {% endfor %}
 {% endif %}
-{% if cls._create_attrs[1] %}
+{% if cls._create_attrs.optional %}
 Optional attributes for object create:
 {% for item in cls._create_attrs.optional %}
 - ``{{ item }}``
 {% endfor %}
 {% endif %}
-{% if cls._create_attrs[2] %}
+{% if cls._create_attrs.exclusive %}
 Mutually exclusive attributes for object create:
-{% for item in cls._create_attrs.exlusive %}
+{% for item in cls._create_attrs.exclusive %}
 - ``{{ item }}``
 {% endfor %}
 {% endif %}
@@ -29,21 +29,21 @@ Mutually exclusive attributes for object create:
 
 {% if cls._update_attrs %}
 **Object update**
-{% if cls._update_attrs[0] %}
-Mandatory attributes for object update:
+{% if cls._update_attrs.required %}
+Required attributes for object update:
 {% for item in cls._update_attrs.required %}
 - ``{{ item }}``
 {% endfor %}
 {% endif %}
-{% if cls._update_attrs[1] %}
+{% if cls._update_attrs.optional %}
 Optional attributes for object update:
 {% for item in cls._update_attrs.optional %}
 - ``{{ item }}``
 {% endfor %}
 {% endif %}
-{% if cls._update_attrs[2] %}
+{% if cls._update_attrs.exclusive %}
 Mutually exclusive attributes for object update:
-{% for item in cls._update_attrs.exlusive %}
+{% for item in cls._update_attrs.exclusive %}
 - ``{{ item }}``
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Turns out the index-based template and related docs have been outdated since https://github.com/python-gitlab/python-gitlab/commit/30117a3b6a8ee24362de798b2fa596a343b8774f and https://github.com/python-gitlab/python-gitlab/commit/147f05d43d302d9a04bc87d957c79ce9e54cdaed.

Also stop pointing to our own custom (non-existent) code and point people to upstream docs, which is the single source of truth.