### PR TITLE
Setting default wait_time to 1 minute

### DIFF
--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -729,8 +729,10 @@ class Gitlab:
             ):
                 # Response headers documentation:
                 # https://docs.gitlab.com/ee/user/admin_area/settings/user_and_ip_rate_limits.html#response-headers
+                # For gitlab.com:
+                # https://docs.gitlab.com/ee/user/gitlab_com/index.html#gitlabcom-specific-rate-limits
                 if max_retries == -1 or cur_retries < max_retries:
-                    wait_time = 2**cur_retries * 0.1
+                    wait_time = 60  # In gitlab.com limits are calculated per minute. Better to be on the safe side in case headers are missing
                     if "Retry-After" in result.headers:
                         wait_time = int(result.headers["Retry-After"])
                     elif "RateLimit-Reset" in result.headers:


### PR DESCRIPTION
While debugging my code against gitlab.com (SaaS, not self-hosted) I realized that the SDK bombards the API with the same request.
I found out that for some reason, headers such as `Retry-After` are missing from the response so only the default `wait_time` is taken into account. This means that the SDK basically doesn't wait at all.

Since for Gitlab.com most rate limits are calculated per 1 minute, I think it's better to set the default timeout to that value in case rate limit headers are missing.