### PR TITLE
fix(base): do not fail repr() on lazy objects

### DIFF
--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -162,15 +162,15 @@ class RESTObject:
     def __repr__(self) -> str:
         name = self.__class__.__name__
 
-        if (self._id_attr and self._repr_attr) and (self._id_attr != self._repr_attr):
+        if (self._id_attr and self._repr_value) and (self._id_attr != self._repr_attr):
             return (
                 f"<{name} {self._id_attr}:{self.get_id()} "
-                f"{self._repr_attr}:{getattr(self, self._repr_attr)}>"
+                f"{self._repr_attr}:{self._repr_value}>"
             )
         if self._id_attr:
             return f"<{name} {self._id_attr}:{self.get_id()}>"
-        if self._repr_attr:
-            return f"<{name} {self._repr_attr}:{getattr(self, self._repr_attr)}>"
+        if self._repr_value:
+            return f"<{name} {self._repr_attr}:{self._repr_value}>"
 
         return f"<{name}>"
 
@@ -228,6 +228,13 @@ class RESTObject:
         if self._id_attr is None or not hasattr(self, self._id_attr):
             return None
         return getattr(self, self._id_attr)
+
+    @property
+    def _repr_value(self) -> Optional[str]:
+        """Safely returns the human-readable resource name if present."""
+        if self._repr_attr is None or not hasattr(self, self._repr_attr):
+            return None
+        return getattr(self, self._repr_attr)
 
     @property
     def encoded_id(self) -> Optional[Union[int, str]]:

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -251,15 +251,19 @@ class TestRESTObject:
                 "<ReprObject id:1 name:fake>",
             ),
             ("name", "name", {"name": "fake"}, "<ReprObject name:fake>"),
+            ("id", "name", {"id": 1}, "<ReprObject id:1>"),
             (None, None, {}, "<ReprObject>"),
             (None, "name", {"name": "fake"}, "<ReprObject name:fake>"),
+            (None, "name", {}, "<ReprObject>"),
         ],
         ids=[
             "GetMixin with id",
             "GetMixin with id and _repr_attr",
             "GetMixin with _repr_attr matching _id_attr",
+            "GetMixin with _repr_attr without _repr_attr value defined",
             "GetWithoutIDMixin",
             "GetWithoutIDMixin with _repr_attr",
+            "GetWithoutIDMixin with _repr_attr without _repr_attr value defined",
         ],
     )
     def test_dunder_repr(self, fake_manager, id_attr, repr_attr, attrs, expected_repr):


### PR DESCRIPTION
While looking at https://github.com/python-gitlab/python-gitlab/pull/2066 I realized I actually introduced a regression in https://github.com/python-gitlab/python-gitlab/pull/2010, if someone tries to do `repr(resource)` on a lazy object.

I don't think doing that really makes sense on a lazy object, and shouldn't happen in real life, but we should be safe just to avoid that scenario producing confusing errors.