### PR TITLE
chore: add link to Commitizen in Github workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v3
       - run: pip install --upgrade tox
-      - name: Run commitizen
+      - name: Run commitizen (https://commitizen-tools.github.io/commitizen/)
         run: tox -e cz
       - name: Run black code formatter (https://black.readthedocs.io/en/stable/)
         run: tox -e black -- --check


### PR DESCRIPTION
Add a link to the Commitizen website in the Github workflow. Hopefully
this will help people when their job fails.