### PR TITLE
refactor: do not recommend plain gitlab.const constants

### DIFF
--- a/docs/gl_objects/access_requests.rst
+++ b/docs/gl_objects/access_requests.rst
@@ -43,7 +43,7 @@ Create an access request::
 Approve an access request::
 
     ar.approve()  # defaults to DEVELOPER level
-    ar.approve(access_level=gitlab.const.AccessLevel.MAINTAINER.value)  # explicitly set access level
+    ar.approve(access_level=gitlab.const.AccessLevel.MAINTAINER)  # explicitly set access level
 
 Deny (delete) an access request::
 

--- a/docs/gl_objects/groups.rst
+++ b/docs/gl_objects/groups.rst
@@ -80,7 +80,7 @@ Remove a group::
 
 Share/unshare the group with a group::
 
-    group.share(group2.id, gitlab.const.AccessLevel.DEVELOPER.value)
+    group.share(group2.id, gitlab.const.AccessLevel.DEVELOPER)
     group.unshare(group2.id)
 
 Import / Export
@@ -284,11 +284,11 @@ Get a member of a group, including members inherited through ancestor groups::
 Add a member to the group::
 
     member = group.members.create({'user_id': user_id,
-                                   'access_level': gitlab.const.AccessLevel.GUEST.value})
+                                   'access_level': gitlab.const.AccessLevel.GUEST})
 
 Update a member (change the access level)::
 
-    member.access_level = gitlab.const.AccessLevel.DEVELOPER.value
+    member.access_level = gitlab.const.AccessLevel.DEVELOPER
     member.save()
 
 Remove a member from the group::
@@ -316,7 +316,7 @@ LDAP group links
 
 Add an LDAP group link to an existing GitLab group::
 
-    group.add_ldap_group_link(ldap_group_cn, gitlab.const.AccessLevel.DEVELOPER.value, 'ldapmain')
+    group.add_ldap_group_link(ldap_group_cn, gitlab.const.AccessLevel.DEVELOPER, 'ldapmain')
 
 Remove a link::
 

--- a/docs/gl_objects/notifications.rst
+++ b/docs/gl_objects/notifications.rst
@@ -47,10 +47,10 @@ Get the notifications settings::
 Update the notifications settings::
 
     # use a predefined level
-    settings.level = gitlab.const.NotificationLevel.WATCH.value
+    settings.level = gitlab.const.NotificationLevel.WATCH
 
     # create a custom setup
-    settings.level = gitlab.const.NotificationLevel.CUSTOM.value
+    settings.level = gitlab.const.NotificationLevel.CUSTOM
     settings.save()  # will create additional attributes, but not mandatory
 
     settings.new_merge_request = True

--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -511,7 +511,7 @@ Create a snippet::
                                        'file_name': 'foo.py',
                                        'code': 'import gitlab',
                                        'visibility_level':
-                                       gitlab.const.Visibility.PRIVATE.value})
+                                       gitlab.const.Visibility.PRIVATE})
 
 Update a snippet::
 
@@ -577,11 +577,11 @@ Get a member of a project, including members inherited through ancestor groups::
 Add a project member::
 
     member = project.members.create({'user_id': user.id, 'access_level':
-                                     gitlab.const.AccessLevel.DEVELOPER.value})
+                                     gitlab.const.AccessLevel.DEVELOPER})
 
 Modify a project member (change the access level)::
 
-    member.access_level = gitlab.const.AccessLevel.MAINTAINER.value
+    member.access_level = gitlab.const.AccessLevel.MAINTAINER
     member.save()
 
 Remove a member from the project team::
@@ -592,7 +592,7 @@ Remove a member from the project team::
 
 Share/unshare the project with a group::
 
-    project.share(group.id, gitlab.const.AccessLevel.DEVELOPER.value)
+    project.share(group.id, gitlab.const.AccessLevel.DEVELOPER)
     project.unshare(group.id)
 
 Project hooks

--- a/docs/gl_objects/protected_branches.rst
+++ b/docs/gl_objects/protected_branches.rst
@@ -31,8 +31,8 @@ Create a protected branch::
 
     p_branch = project.protectedbranches.create({
         'name': '*-stable',
-        'merge_access_level': gitlab.const.AccessLevel.DEVELOPER.value,
-        'push_access_level': gitlab.const.AccessLevel.MAINTAINER.value
+        'merge_access_level': gitlab.const.AccessLevel.DEVELOPER,
+        'push_access_level': gitlab.const.AccessLevel.MAINTAINER
     })
 
 Create a protected branch with more granular access control::
@@ -41,7 +41,7 @@ Create a protected branch with more granular access control::
         'name': '*-stable',
         'allowed_to_push': [{"user_id": 99}, {"user_id": 98}],
         'allowed_to_merge': [{"group_id": 653}],
-        'allowed_to_unprotect': [{"access_level": gitlab.const.AccessLevel.MAINTAINER.value}]
+        'allowed_to_unprotect': [{"access_level": gitlab.const.AccessLevel.MAINTAINER}]
     })
 
 Delete a protected branch::

--- a/docs/gl_objects/search.rst
+++ b/docs/gl_objects/search.rst
@@ -46,30 +46,30 @@ Examples
 Search for issues matching a specific string::
 
     # global search
-    gl.search(gitlab.const.SearchScope.ISSUES.value, 'regression')
+    gl.search(gitlab.const.SearchScope.ISSUES, 'regression')
 
     # group search
     group = gl.groups.get('mygroup')
-    group.search(gitlab.const.SearchScope.ISSUES.value, 'regression')
+    group.search(gitlab.const.SearchScope.ISSUES, 'regression')
 
     # project search
     project = gl.projects.get('myproject')
-    project.search(gitlab.const.SearchScope.ISSUES.value, 'regression')
+    project.search(gitlab.const.SearchScope.ISSUES, 'regression')
 
 The ``search()`` methods implement the pagination support::
 
     # get lists of 10 items, and start at page 2
-    gl.search(gitlab.const.SearchScope.ISSUES.value, search_str, page=2, per_page=10)
+    gl.search(gitlab.const.SearchScope.ISSUES, search_str, page=2, per_page=10)
 
     # get a generator that will automatically make required API calls for
     # pagination
-    for item in gl.search(gitlab.const.SearchScope.ISSUES.value, search_str, iterator=True):
+    for item in gl.search(gitlab.const.SearchScope.ISSUES, search_str, iterator=True):
         do_something(item)
 
 The search API doesn't return objects, but dicts. If you need to act on
 objects, you need to create them explicitly::
 
-    for item in gl.search(gitlab.const.SearchScope.ISSUES.value, search_str, iterator=True):
+    for item in gl.search(gitlab.const.SearchScope.ISSUES, search_str, iterator=True):
         issue_project = gl.projects.get(item['project_id'], lazy=True)
         issue = issue_project.issues.get(item['iid'])
         issue.state = 'closed'

--- a/docs/gl_objects/snippets.rst
+++ b/docs/gl_objects/snippets.rst
@@ -44,7 +44,7 @@ Create a snippet::
 
 Update the snippet attributes::
 
-    snippet.visibility_level = gitlab.const.Visibility.PUBLIC.value
+    snippet.visibility_level = gitlab.const.Visibility.PUBLIC
     snippet.save()
 
 To update a snippet code you need to create a ``ProjectSnippet`` object::

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -43,9 +43,9 @@ def __getattr__(name: str) -> Any:
     if name in gitlab.const._DEPRECATED:
         _utils.warn(
             message=(
-                f"\nDirect access to 'gitlab.{name}' is deprecated and will be "
-                f"removed in a future major python-gitlab release. Please "
-                f"use 'gitlab.const.{name}' instead."
+                f"\nDirect access to constants as 'gitlab.{name}' is deprecated and "
+                f"will be removed in a future major python-gitlab release. Please "
+                f"see the usage of constants in the 'gitlab.const' module instead."
             ),
             category=DeprecationWarning,
         )

--- a/gitlab/const.py
+++ b/gitlab/const.py
@@ -56,6 +56,10 @@ _DEPRECATED = [
 ]
 
 
+class GitlabEnum(str, Enum):
+    """An enum mixed in with str to make it JSON-serializable."""
+
+
 # https://gitlab.com/gitlab-org/gitlab/-/blob/e97357824bedf007e75f8782259fe07435b64fbb/lib/gitlab/access.rb#L12-18
 class AccessLevel(IntEnum):
     NO_ACCESS: int = 0
@@ -69,13 +73,13 @@ class AccessLevel(IntEnum):
 
 
 # https://gitlab.com/gitlab-org/gitlab/-/blob/e97357824bedf007e75f8782259fe07435b64fbb/lib/gitlab/visibility_level.rb#L23-25
-class Visibility(Enum):
+class Visibility(GitlabEnum):
     PRIVATE: str = "private"
     INTERNAL: str = "internal"
     PUBLIC: str = "public"
 
 
-class NotificationLevel(Enum):
+class NotificationLevel(GitlabEnum):
     DISABLED: str = "disabled"
     PARTICIPATING: str = "participating"
     WATCH: str = "watch"
@@ -85,7 +89,7 @@ class NotificationLevel(Enum):
 
 
 # https://gitlab.com/gitlab-org/gitlab/-/blob/e97357824bedf007e75f8782259fe07435b64fbb/app/views/search/_category.html.haml#L10-37
-class SearchScope(Enum):
+class SearchScope(GitlabEnum):
     # all scopes (global, group and  project)
     PROJECTS: str = "projects"
     ISSUES: str = "issues"

--- a/tests/functional/api/test_gitlab.py
+++ b/tests/functional/api/test_gitlab.py
@@ -125,15 +125,15 @@ def test_namespaces(gl):
 
 def test_notification_settings(gl):
     settings = gl.notificationsettings.get()
-    settings.level = gitlab.const.NOTIFICATION_LEVEL_WATCH
+    settings.level = gitlab.const.NotificationLevel.WATCH
     settings.save()
 
     settings = gl.notificationsettings.get()
-    assert settings.level == gitlab.const.NOTIFICATION_LEVEL_WATCH
+    assert settings.level == gitlab.const.NotificationLevel.WATCH
 
 
 def test_search(gl):
-    result = gl.search(scope=gitlab.const.SEARCH_SCOPE_USERS, search="Administrator")
+    result = gl.search(scope=gitlab.const.SearchScope.USERS, search="Administrator")
     assert result[0]["id"] == 1
 
 

--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -43,17 +43,17 @@ def test_groups(gl):
     assert group4 in filtered_groups
 
     group1.members.create(
-        {"access_level": gitlab.const.OWNER_ACCESS, "user_id": user.id}
+        {"access_level": gitlab.const.AccessLevel.OWNER, "user_id": user.id}
     )
     group1.members.create(
-        {"access_level": gitlab.const.GUEST_ACCESS, "user_id": user2.id}
+        {"access_level": gitlab.const.AccessLevel.GUEST, "user_id": user2.id}
     )
     group2.members.create(
-        {"access_level": gitlab.const.OWNER_ACCESS, "user_id": user2.id}
+        {"access_level": gitlab.const.AccessLevel.OWNER, "user_id": user2.id}
     )
 
-    group4.share(group1.id, gitlab.const.DEVELOPER_ACCESS)
-    group4.share(group2.id, gitlab.const.MAINTAINER_ACCESS)
+    group4.share(group1.id, gitlab.const.AccessLevel.DEVELOPER)
+    group4.share(group2.id, gitlab.const.AccessLevel.MAINTAINER)
     # Reload group4 to have updated shared_with_groups
     group4 = gl.groups.get(group4.id)
     assert len(group4.shared_with_groups) == 2
@@ -71,7 +71,7 @@ def test_groups(gl):
 
     membership = memberships1[0]
     assert membership.source_type == "Namespace"
-    assert membership.access_level == gitlab.const.OWNER_ACCESS
+    assert membership.access_level == gitlab.const.AccessLevel.OWNER
 
     project_memberships = user.memberships.list(type="Project")
     assert len(project_memberships) == 0
@@ -95,10 +95,10 @@ def test_groups(gl):
     assert len(group1.members.list()) == 2
     assert len(group1.members_all.list())
     member = group1.members.get(user2.id)
-    member.access_level = gitlab.const.OWNER_ACCESS
+    member.access_level = gitlab.const.AccessLevel.OWNER
     member.save()
     member = group1.members.get(user2.id)
-    assert member.access_level == gitlab.const.OWNER_ACCESS
+    assert member.access_level == gitlab.const.AccessLevel.OWNER
 
     gl.auth()
     group2.members.delete(gl.user.id)

--- a/tests/functional/api/test_projects.py
+++ b/tests/functional/api/test_projects.py
@@ -3,6 +3,7 @@ import uuid
 import pytest
 
 import gitlab
+from gitlab.const import AccessLevel
 from gitlab.v4.objects.projects import ProjectStorage
 
 
@@ -34,6 +35,17 @@ def test_create_project(gl, user):
 
     admin_project.delete()
     sudo_project.delete()
+
+
+def test_project_members(user, project):
+    member = project.members.create(
+        {"user_id": user.id, "access_level": AccessLevel.DEVELOPER}
+    )
+    assert member in project.members.list()
+    assert member.access_level == 30
+
+    member.delete()
+    assert member not in project.members.list()
 
 
 def test_project_badges(project):


### PR DESCRIPTION
Since we now have enums, we shouldn't tell people to use the plain constants :) also cleans up the use of old constants in tests.