### PR TITLE
chore: don't use `Enum` as we don't need it.

### DIFF
--- a/docs/gl_objects/access_requests.rst
+++ b/docs/gl_objects/access_requests.rst
@@ -43,7 +43,7 @@ Create an access request::
 Approve an access request::
 
     ar.approve()  # defaults to DEVELOPER level
-    ar.approve(access_level=gitlab.const.AccessLevel.MAINTAINER.value)  # explicitly set access level
+    ar.approve(access_level=gitlab.const.AccessLevel.MAINTAINER)  # explicitly set access level
 
 Deny (delete) an access request::
 

--- a/docs/gl_objects/groups.rst
+++ b/docs/gl_objects/groups.rst
@@ -80,7 +80,7 @@ Remove a group::
 
 Share/unshare the group with a group::
 
-    group.share(group2.id, gitlab.const.AccessLevel.DEVELOPER.value)
+    group.share(group2.id, gitlab.const.AccessLevel.DEVELOPER)
     group.unshare(group2.id)
 
 Import / Export
@@ -284,11 +284,11 @@ Get a member of a group, including members inherited through ancestor groups::
 Add a member to the group::
 
     member = group.members.create({'user_id': user_id,
-                                   'access_level': gitlab.const.AccessLevel.GUEST.value})
+                                   'access_level': gitlab.const.AccessLevel.GUEST})
 
 Update a member (change the access level)::
 
-    member.access_level = gitlab.const.AccessLevel.DEVELOPER.value
+    member.access_level = gitlab.const.AccessLevel.DEVELOPER
     member.save()
 
 Remove a member from the group::
@@ -316,7 +316,7 @@ LDAP group links
 
 Add an LDAP group link to an existing GitLab group::
 
-    group.add_ldap_group_link(ldap_group_cn, gitlab.const.AccessLevel.DEVELOPER.value, 'ldapmain')
+    group.add_ldap_group_link(ldap_group_cn, gitlab.const.AccessLevel.DEVELOPER, 'ldapmain')
 
 Remove a link::
 

--- a/docs/gl_objects/notifications.rst
+++ b/docs/gl_objects/notifications.rst
@@ -47,10 +47,10 @@ Get the notifications settings::
 Update the notifications settings::
 
     # use a predefined level
-    settings.level = gitlab.const.NotificationLevel.WATCH.value
+    settings.level = gitlab.const.NotificationLevel.WATCH
 
     # create a custom setup
-    settings.level = gitlab.const.NotificationLevel.CUSTOM.value
+    settings.level = gitlab.const.NotificationLevel.CUSTOM
     settings.save()  # will create additional attributes, but not mandatory
 
     settings.new_merge_request = True

--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -487,7 +487,7 @@ Create a snippet::
                                        'file_name': 'foo.py',
                                        'code': 'import gitlab',
                                        'visibility_level':
-                                       gitlab.const.Visibility.PRIVATE.value})
+                                       gitlab.const.Visibility.PRIVATE})
 
 Update a snippet::
 
@@ -553,11 +553,11 @@ Get a member of a project, including members inherited through ancestor groups::
 Add a project member::
 
     member = project.members.create({'user_id': user.id, 'access_level':
-                                     gitlab.const.AccessLevel.DEVELOPER.value})
+                                     gitlab.const.AccessLevel.DEVELOPER})
 
 Modify a project member (change the access level)::
 
-    member.access_level = gitlab.const.AccessLevel.MAINTAINER.value
+    member.access_level = gitlab.const.AccessLevel.MAINTAINER
     member.save()
 
 Remove a member from the project team::
@@ -568,7 +568,7 @@ Remove a member from the project team::
 
 Share/unshare the project with a group::
 
-    project.share(group.id, gitlab.const.AccessLevel.DEVELOPER.value)
+    project.share(group.id, gitlab.const.AccessLevel.DEVELOPER)
     project.unshare(group.id)
 
 Project hooks

--- a/docs/gl_objects/protected_branches.rst
+++ b/docs/gl_objects/protected_branches.rst
@@ -31,8 +31,8 @@ Create a protected branch::
 
     p_branch = project.protectedbranches.create({
         'name': '*-stable',
-        'merge_access_level': gitlab.const.AccessLevel.DEVELOPER.value,
-        'push_access_level': gitlab.const.AccessLevel.MAINTAINER.value
+        'merge_access_level': gitlab.const.AccessLevel.DEVELOPER,
+        'push_access_level': gitlab.const.AccessLevel.MAINTAINER
     })
 
 Create a protected branch with more granular access control::
@@ -41,7 +41,7 @@ Create a protected branch with more granular access control::
         'name': '*-stable',
         'allowed_to_push': [{"user_id": 99}, {"user_id": 98}],
         'allowed_to_merge': [{"group_id": 653}],
-        'allowed_to_unprotect': [{"access_level": gitlab.const.AccessLevel.MAINTAINER.value}]
+        'allowed_to_unprotect': [{"access_level": gitlab.const.AccessLevel.MAINTAINER}]
     })
 
 Delete a protected branch::

--- a/docs/gl_objects/search.rst
+++ b/docs/gl_objects/search.rst
@@ -46,30 +46,30 @@ Examples
 Search for issues matching a specific string::
 
     # global search
-    gl.search(gitlab.const.SearchScope.ISSUES.value, 'regression')
+    gl.search(gitlab.const.SearchScope.ISSUES, 'regression')
 
     # group search
     group = gl.groups.get('mygroup')
-    group.search(gitlab.const.SearchScope.ISSUES.value, 'regression')
+    group.search(gitlab.const.SearchScope.ISSUES, 'regression')
 
     # project search
     project = gl.projects.get('myproject')
-    project.search(gitlab.const.SearchScope.ISSUES.value, 'regression')
+    project.search(gitlab.const.SearchScope.ISSUES, 'regression')
 
 The ``search()`` methods implement the pagination support::
 
     # get lists of 10 items, and start at page 2
-    gl.search(gitlab.const.SearchScope.ISSUES.value, search_str, page=2, per_page=10)
+    gl.search(gitlab.const.SearchScope.ISSUES, search_str, page=2, per_page=10)
 
     # get a generator that will automatically make required API calls for
     # pagination
-    for item in gl.search(gitlab.const.SearchScope.ISSUES.value, search_str, iterator=True):
+    for item in gl.search(gitlab.const.SearchScope.ISSUES, search_str, iterator=True):
         do_something(item)
 
 The search API doesn't return objects, but dicts. If you need to act on
 objects, you need to create them explicitly::
 
-    for item in gl.search(gitlab.const.SearchScope.ISSUES.value, search_str, iterator=True):
+    for item in gl.search(gitlab.const.SearchScope.ISSUES, search_str, iterator=True):
         issue_project = gl.projects.get(item['project_id'], lazy=True)
         issue = issue_project.issues.get(item['iid'])
         issue.state = 'closed'

--- a/docs/gl_objects/snippets.rst
+++ b/docs/gl_objects/snippets.rst
@@ -44,7 +44,7 @@ Create a snippet::
 
 Update the snippet attributes::
 
-    snippet.visibility_level = gitlab.const.Visibility.PUBLIC.value
+    snippet.visibility_level = gitlab.const.Visibility.PUBLIC
     snippet.save()
 
 To update a snippet code you need to create a ``ProjectSnippet`` object::

--- a/gitlab/const.py
+++ b/gitlab/const.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2016-2017 Gauvain Pocentek <gauvain@pocentek.net>
-#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -15,7 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from enum import Enum, IntEnum
+from typing import Any
 
 from gitlab._version import __title__, __version__
 
@@ -56,8 +54,18 @@ _DEPRECATED = [
 ]
 
 
+class GitlabConstant:
+    def __new__(cls, value: Any) -> str:  # type: ignore
+        # This allows us to get a string representation of a value.
+        # For example: AccessLevel(10)
+        for attr, attr_value in cls.__dict__.items():
+            if value == attr_value:
+                return attr
+        raise ValueError(f"{value!r} is not a valid {cls.__qualname__}")
+
+
 # https://gitlab.com/gitlab-org/gitlab/-/blob/e97357824bedf007e75f8782259fe07435b64fbb/lib/gitlab/access.rb#L12-18
-class AccessLevel(IntEnum):
+class AccessLevel(GitlabConstant):
     NO_ACCESS: int = 0
     MINIMAL_ACCESS: int = 5
     GUEST: int = 10
@@ -69,13 +77,13 @@ class AccessLevel(IntEnum):
 
 
 # https://gitlab.com/gitlab-org/gitlab/-/blob/e97357824bedf007e75f8782259fe07435b64fbb/lib/gitlab/visibility_level.rb#L23-25
-class Visibility(Enum):
+class Visibility(GitlabConstant):
     PRIVATE: str = "private"
     INTERNAL: str = "internal"
     PUBLIC: str = "public"
 
 
-class NotificationLevel(Enum):
+class NotificationLevel(GitlabConstant):
     DISABLED: str = "disabled"
     PARTICIPATING: str = "participating"
     WATCH: str = "watch"
@@ -85,7 +93,7 @@ class NotificationLevel(Enum):
 
 
 # https://gitlab.com/gitlab-org/gitlab/-/blob/e97357824bedf007e75f8782259fe07435b64fbb/app/views/search/_category.html.haml#L10-37
-class SearchScope(Enum):
+class SearchScope(GitlabConstant):
     # all scopes (global, group and  project)
     PROJECTS: str = "projects"
     ISSUES: str = "issues"
@@ -105,41 +113,41 @@ class SearchScope(Enum):
 
 DEFAULT_URL: str = "https://gitlab.com"
 
-NO_ACCESS = AccessLevel.NO_ACCESS.value
-MINIMAL_ACCESS = AccessLevel.MINIMAL_ACCESS.value
-GUEST_ACCESS = AccessLevel.GUEST.value
-REPORTER_ACCESS = AccessLevel.REPORTER.value
-DEVELOPER_ACCESS = AccessLevel.DEVELOPER.value
-MAINTAINER_ACCESS = AccessLevel.MAINTAINER.value
-OWNER_ACCESS = AccessLevel.OWNER.value
-ADMIN_ACCESS = AccessLevel.ADMIN.value
+NO_ACCESS = AccessLevel.NO_ACCESS
+MINIMAL_ACCESS = AccessLevel.MINIMAL_ACCESS
+GUEST_ACCESS = AccessLevel.GUEST
+REPORTER_ACCESS = AccessLevel.REPORTER
+DEVELOPER_ACCESS = AccessLevel.DEVELOPER
+MAINTAINER_ACCESS = AccessLevel.MAINTAINER
+OWNER_ACCESS = AccessLevel.OWNER
+ADMIN_ACCESS = AccessLevel.ADMIN
 
-VISIBILITY_PRIVATE = Visibility.PRIVATE.value
-VISIBILITY_INTERNAL = Visibility.INTERNAL.value
-VISIBILITY_PUBLIC = Visibility.PUBLIC.value
+VISIBILITY_PRIVATE = Visibility.PRIVATE
+VISIBILITY_INTERNAL = Visibility.INTERNAL
+VISIBILITY_PUBLIC = Visibility.PUBLIC
 
-NOTIFICATION_LEVEL_DISABLED = NotificationLevel.DISABLED.value
-NOTIFICATION_LEVEL_PARTICIPATING = NotificationLevel.PARTICIPATING.value
-NOTIFICATION_LEVEL_WATCH = NotificationLevel.WATCH.value
-NOTIFICATION_LEVEL_GLOBAL = NotificationLevel.GLOBAL.value
-NOTIFICATION_LEVEL_MENTION = NotificationLevel.MENTION.value
-NOTIFICATION_LEVEL_CUSTOM = NotificationLevel.CUSTOM.value
+NOTIFICATION_LEVEL_DISABLED = NotificationLevel.DISABLED
+NOTIFICATION_LEVEL_PARTICIPATING = NotificationLevel.PARTICIPATING
+NOTIFICATION_LEVEL_WATCH = NotificationLevel.WATCH
+NOTIFICATION_LEVEL_GLOBAL = NotificationLevel.GLOBAL
+NOTIFICATION_LEVEL_MENTION = NotificationLevel.MENTION
+NOTIFICATION_LEVEL_CUSTOM = NotificationLevel.CUSTOM
 
 # Search scopes
 # all scopes (global, group and  project)
-SEARCH_SCOPE_PROJECTS = SearchScope.PROJECTS.value
-SEARCH_SCOPE_ISSUES = SearchScope.ISSUES.value
-SEARCH_SCOPE_MERGE_REQUESTS = SearchScope.MERGE_REQUESTS.value
-SEARCH_SCOPE_MILESTONES = SearchScope.MILESTONES.value
-SEARCH_SCOPE_WIKI_BLOBS = SearchScope.WIKI_BLOBS.value
-SEARCH_SCOPE_COMMITS = SearchScope.COMMITS.value
-SEARCH_SCOPE_BLOBS = SearchScope.BLOBS.value
-SEARCH_SCOPE_USERS = SearchScope.USERS.value
+SEARCH_SCOPE_PROJECTS = SearchScope.PROJECTS
+SEARCH_SCOPE_ISSUES = SearchScope.ISSUES
+SEARCH_SCOPE_MERGE_REQUESTS = SearchScope.MERGE_REQUESTS
+SEARCH_SCOPE_MILESTONES = SearchScope.MILESTONES
+SEARCH_SCOPE_WIKI_BLOBS = SearchScope.WIKI_BLOBS
+SEARCH_SCOPE_COMMITS = SearchScope.COMMITS
+SEARCH_SCOPE_BLOBS = SearchScope.BLOBS
+SEARCH_SCOPE_USERS = SearchScope.USERS
 
 # specific global scope
-SEARCH_SCOPE_GLOBAL_SNIPPET_TITLES = SearchScope.GLOBAL_SNIPPET_TITLES.value
+SEARCH_SCOPE_GLOBAL_SNIPPET_TITLES = SearchScope.GLOBAL_SNIPPET_TITLES
 
 # specific project scope
-SEARCH_SCOPE_PROJECT_NOTES = SearchScope.PROJECT_NOTES.value
+SEARCH_SCOPE_PROJECT_NOTES = SearchScope.PROJECT_NOTES
 
 USER_AGENT: str = f"{__title__}/{__version__}"

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -193,7 +193,7 @@ def gitlab_config(check_is_alive, docker_ip, docker_services, temp_dir, fixture_
 
     logging.info("Waiting for GitLab container to become ready.")
     docker_services.wait_until_responsive(
-        timeout=200, pause=10, check=lambda: check_is_alive("gitlab-test")
+        timeout=300, pause=10, check=lambda: check_is_alive("gitlab-test")
     )
     logging.info("GitLab container is now ready.")
 

--- a/tests/unit/test_const.py
+++ b/tests/unit/test_const.py
@@ -1,0 +1,6 @@
+from gitlab import const
+
+
+def test_access_level():
+    assert 50 == const.AccessLevel.OWNER
+    assert "OWNER" == const.AccessLevel(50)


### PR DESCRIPTION
For our use case `Enum` is overkill. We can just use simple classes
instead.

Looking for some feedback on this.

@nejch  When I saw how we are going from `gitlab.OWNER` -> `gitlab.const.OWNER` -> `gitlab.const.AccessLevel.OWNER.value`, it just seemed verbose, especially the `.value`. So that is why I thought of this idea. So with this it would be `gitlab.const.AccessLevel.OWNER`