### PR TITLE
chore(docs): ignore nitpicky warnings, drop deprecated setuptools build_sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -287,6 +287,7 @@ man_pages = [
 # If true, show URL addresses after external links.
 # man_show_urls = False
 
+nitpick_ignore_regex = [(r"py:.*", r".*")]
 
 # -- Options for Texinfo output -------------------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[build_sphinx]
-warning-is-error = 1
-keep-going = 1

--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,7 @@ per-file-ignores =
 
 [testenv:docs]
 deps = -r{toxinidir}/requirements-docs.txt
-commands = sphinx-build -W --keep-going -b html docs build/sphinx/html
+commands = sphinx-build -n -W --keep-going -b html docs build/sphinx/html
 
 [testenv:cover]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,7 @@ per-file-ignores =
 
 [testenv:docs]
 deps = -r{toxinidir}/requirements-docs.txt
-commands = python setup.py build_sphinx
+commands = sphinx-build -W --keep-going -b html docs build/sphinx/html
 
 [testenv:cover]
 commands =


### PR DESCRIPTION
Closes #1992 by ignoring nitpicky warnings because some will be out of our control anyway (at least without intersphinx).

Drops use of the now-deprecated `build_sphinx` command. One less config file!