### PR TITLE
feat(api): support head() method for get and list endpoints

### DIFF
--- a/docs/api-usage.rst
+++ b/docs/api-usage.rst
@@ -238,6 +238,28 @@ a project (the previous example used 2 API calls):
    project = gl.projects.get(1, lazy=True)  # no API call
    project.star()  # API call
 
+``head()`` methods
+========================
+
+All endpoints that support ``get()`` and ``list()`` also support a ``head()`` method.
+In this case, the server responds only with headers and not the response JSON or body.
+This allows more efficient API calls, such as checking repository file size without
+fetching its content.
+
+.. note::
+
+   In some cases, GitLab may omit specific headers. See more in the :ref:`pagination` section.
+
+.. code-block:: python
+
+   # See total number of personal access tokens for current user
+   gl.personal_access_tokens.head()
+   print(headers["X-Total"])
+
+   # See returned content-type for project GET endpoint
+   headers = gl.projects.head("gitlab-org/gitlab")
+   print(headers["Content-Type"])
+
 .. _pagination:
 
 Pagination

--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -365,7 +365,16 @@ Get a file::
 
     # get the decoded content
     print(f.decode())
-    
+
+Get file details from headers, without fetching its entire content::
+
+    headers = project.files.head('README.rst', ref='main')
+
+    # Get the file size:
+    # For a full list of headers returned, see upstream documentation.
+    # https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
+    print(headers["X-Gitlab-Size"])
+
 Get a raw file::
     
     raw_content = project.files.raw(file_path='README.rst', ref='main')

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -805,6 +805,27 @@ class Gitlab:
         else:
             return result
 
+    def http_head(
+        self, path: str, query_data: Optional[Dict[str, Any]] = None, **kwargs: Any
+    ) -> requests.structures.CaseInsensitiveDict:
+        """Make a HEAD request to the Gitlab server.
+
+        Args:
+            path: Path or full URL to query ('/projects' or
+                        'http://whatever/v4/api/projecs')
+            query_data: Data to send as query parameters
+            **kwargs: Extra options to send to the server (e.g. sudo, page,
+                      per_page)
+        Returns:
+            A requests.header object
+        Raises:
+            GitlabHttpError: When the return code is not 2xx
+        """
+
+        query_data = query_data or {}
+        result = self.http_request("head", path, query_data=query_data, **kwargs)
+        return result.headers
+
     def http_list(
         self,
         path: str,

--- a/gitlab/exceptions.py
+++ b/gitlab/exceptions.py
@@ -82,6 +82,10 @@ class GitlabGetError(GitlabOperationError):
     pass
 
 
+class GitlabHeadError(GitlabOperationError):
+    pass
+
+
 class GitlabCreateError(GitlabOperationError):
     pass
 

--- a/tests/functional/api/test_projects.py
+++ b/tests/functional/api/test_projects.py
@@ -6,6 +6,16 @@ import gitlab
 from gitlab.v4.objects.projects import ProjectStorage
 
 
+def test_projects_head(gl):
+    headers = gl.projects.head()
+    assert headers["x-total"]
+
+
+def test_project_head(gl, project):
+    headers = gl.projects.head(project.id)
+    assert headers["content-type"] == "application/json"
+
+
 def test_create_project(gl, user):
     # Moved from group tests chunk in legacy tests, TODO cleanup
     admin_project = gl.projects.create({"name": "admin_project"})

--- a/tests/functional/api/test_repository.py
+++ b/tests/functional/api/test_repository.py
@@ -40,6 +40,9 @@ def test_repository_files(project):
     # object method
     assert readme.decode().decode() == "Initial content"
 
+    headers = project.files.head("README.rst", ref="main")
+    assert headers["X-Gitlab-File-Path"] == "README.rst"
+
     blame = project.files.blame(file_path="README.rst", ref="main")
     assert blame
 

--- a/tests/unit/mixins/test_mixin_methods.py
+++ b/tests/unit/mixins/test_mixin_methods.py
@@ -1,4 +1,5 @@
 import pytest
+import requests
 import responses
 
 from gitlab import base
@@ -45,6 +46,26 @@ def test_get_mixin(gl):
     assert obj.foo == "bar"
     assert obj.id == 42
     assert responses.assert_call_count(url, 1) is True
+
+
+@responses.activate
+def test_head_mixin(gl):
+    class M(GetMixin, FakeManager):
+        pass
+
+    url = "http://localhost/api/v4/tests/42"
+    responses.add(
+        method=responses.HEAD,
+        url=url,
+        headers={"X-GitLab-Header": "test"},
+        status=200,
+        match=[responses.matchers.query_param_matcher({})],
+    )
+
+    manager = M(gl)
+    result = manager.head(42)
+    assert isinstance(result, requests.structures.CaseInsensitiveDict)
+    assert result["x-gitlab-header"] == "test"
 
 
 @responses.activate

--- a/tests/unit/test_gitlab_http_methods.py
+++ b/tests/unit/test_gitlab_http_methods.py
@@ -424,6 +424,22 @@ def test_get_request_invalid_data(gl):
 
 
 @responses.activate
+def test_head_request(gl):
+    url = "http://localhost/api/v4/projects"
+    responses.add(
+        method=responses.HEAD,
+        url=url,
+        headers={"X-Total": "1"},
+        status=200,
+        match=helpers.MATCH_EMPTY_QUERY_PARAMS,
+    )
+
+    result = gl.http_head("/projects")
+    assert isinstance(result, requests.structures.CaseInsensitiveDict)
+    assert result["X-Total"] == "1"
+
+
+@responses.activate
 def test_list_request(gl):
     url = "http://localhost/api/v4/projects"
     responses.add(


### PR DESCRIPTION
Mainly used for checking file existence and size without actually fetching all the content (see linked issue). I made Gauvain author of the first commit as it's based on https://github.com/python-gitlab/python-gitlab/commit/f404d394960683d68ccaf3c129f75a2582a2fb77.

Closes https://github.com/python-gitlab/python-gitlab/issues/1447
Closes https://github.com/python-gitlab/python-gitlab/issues/682
Related - https://github.com/python-gitlab/python-gitlab/issues/985