### PR TITLE
docs(api): fix incorrect docs for merge_request_approvals

### DIFF
--- a/docs/gl_objects/merge_request_approvals.rst
+++ b/docs/gl_objects/merge_request_approvals.rst
@@ -58,7 +58,10 @@ Change project-level or MR-level MR approvals settings::
     p_mras.approvals_before_merge = 2
     p_mras.save()
 
-    mr_mras.set_approvers(approvals_required = 1)
+    mr.approvals.set_approvers(approvals_required = 1)
+    # or
+    mr_mras.approvals_required = 1
+    mr_mras.save()
 
 Change project-level MR allowed approvers::
 

--- a/docs/gl_objects/merge_request_approvals.rst
+++ b/docs/gl_objects/merge_request_approvals.rst
@@ -58,7 +58,7 @@ Change project-level or MR-level MR approvals settings::
     p_mras.approvals_before_merge = 2
     p_mras.save()
 
-    mr.approvals.set_approvers(approvals_required = 1)
+    mr.approvals.set_approvers(approvals_required=1)
     # or
     mr_mras.approvals_required = 1
     mr_mras.save()


### PR DESCRIPTION
The `set_approvers()` method is on the `ProjectApprovalManager` class.
It is not part of the `ProjectApproval` class.

The docs were previously showing to call `set_approvers` using a
`ProjectApproval` instance, which would fail. Correct the
documentation.

This was pointed out by a question on the Gitter channel.