### PR TITLE
docs(api): stop linking to python-requests.org

### DIFF
--- a/docs/api-usage.rst
+++ b/docs/api-usage.rst
@@ -369,7 +369,7 @@ python-gitlab:
    gl = gitlab.gitlab(url, token, api_version=4, session=session)
 
 Reference:
-https://2.python-requests.org/en/master/user/advanced/#proxies
+https://requests.readthedocs.io/en/latest/user/advanced/#proxies
 
 SSL certificate verification
 ----------------------------
@@ -381,7 +381,7 @@ If you need python-gitlab to use your system CA store instead, you can provide
 the path to the CA bundle in the `REQUESTS_CA_BUNDLE` environment variable.
 
 Reference:
-https://2.python-requests.org/en/master/user/advanced/#ssl-cert-verification
+https://requests.readthedocs.io/en/latest/user/advanced/#ssl-cert-verification
 
 Client side certificate
 -----------------------
@@ -398,7 +398,7 @@ The following sample illustrates how to use a client-side certificate:
    gl = gitlab.gitlab(url, token, api_version=4, session=session)
 
 Reference:
-https://2.python-requests.org/en/master/user/advanced/#client-side-certificates
+https://requests.readthedocs.io/en/latest/user/advanced/#client-side-certificates
 
 Rate limits
 -----------


### PR DESCRIPTION
See https://github.com/psf/requests/issues/6140 for more context.

python-requests.org is not owned by the current maintainers and doesn't seem like it's going to be reliable in the future.