### PR TITLE
test(pylint): enable pylint "unused-argument" check

### DIFF
--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -967,6 +967,7 @@ class Gitlab:
             query_data=query_data,
             post_data=post_data,
             files=files,
+            raw=raw,
             **kwargs,
         )
         try:

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -381,7 +381,7 @@ def get_dict(
 
 class JSONPrinter:
     @staticmethod
-    def display(d: Union[str, Dict[str, Any]], **kwargs: Any) -> None:
+    def display(d: Union[str, Dict[str, Any]], **_kwargs: Any) -> None:
         import json  # noqa
 
         print(json.dumps(d))
@@ -390,7 +390,7 @@ class JSONPrinter:
     def display_list(
         data: List[Union[str, gitlab.base.RESTObject]],
         fields: List[str],
-        **kwargs: Any,
+        **_kwargs: Any,
     ) -> None:
         import json  # noqa
 
@@ -399,7 +399,7 @@ class JSONPrinter:
 
 class YAMLPrinter:
     @staticmethod
-    def display(d: Union[str, Dict[str, Any]], **kwargs: Any) -> None:
+    def display(d: Union[str, Dict[str, Any]], **_kwargs: Any) -> None:
         try:
             import yaml  # noqa
 
@@ -415,7 +415,7 @@ class YAMLPrinter:
     def display_list(
         data: List[Union[str, gitlab.base.RESTObject]],
         fields: List[str],
-        **kwargs: Any,
+        **_kwargs: Any,
     ) -> None:
         try:
             import yaml  # noqa
@@ -434,7 +434,7 @@ class YAMLPrinter:
 
 
 class LegacyPrinter:
-    def display(self, d: Union[str, Dict[str, Any]], **kwargs: Any) -> None:
+    def display(self, _d: Union[str, Dict[str, Any]], **kwargs: Any) -> None:
         verbose = kwargs.get("verbose", False)
         padding = kwargs.get("padding", 0)
         obj: Optional[Union[Dict[str, Any], gitlab.base.RESTObject]] = kwargs.get("obj")

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -183,7 +183,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
         if provider is not None:
             path += f"/{provider}"
         path += f"/{cn}"
-        self.manager.gitlab.http_delete(path)
+        self.manager.gitlab.http_delete(path, **kwargs)
 
     @cli.register_custom_action("Group")
     @exc.on_http_error(exc.GitlabCreateError)

--- a/gitlab/v4/objects/jobs.py
+++ b/gitlab/v4/objects/jobs.py
@@ -28,7 +28,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabJobCancelError: If the job could not be canceled
         """
         path = f"{self.manager.path}/{self.encoded_id}/cancel"
-        result = self.manager.gitlab.http_post(path)
+        result = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(result, dict)
         return result
@@ -46,7 +46,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabJobRetryError: If the job could not be retried
         """
         path = f"{self.manager.path}/{self.encoded_id}/retry"
-        result = self.manager.gitlab.http_post(path)
+        result = self.manager.gitlab.http_post(path, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(result, dict)
         return result
@@ -64,7 +64,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabJobPlayError: If the job could not be triggered
         """
         path = f"{self.manager.path}/{self.encoded_id}/play"
-        self.manager.gitlab.http_post(path)
+        self.manager.gitlab.http_post(path, **kwargs)
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabJobEraseError)
@@ -79,7 +79,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabJobEraseError: If the job could not be erased
         """
         path = f"{self.manager.path}/{self.encoded_id}/erase"
-        self.manager.gitlab.http_post(path)
+        self.manager.gitlab.http_post(path, **kwargs)
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabCreateError)
@@ -94,7 +94,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabCreateError: If the request could not be performed
         """
         path = f"{self.manager.path}/{self.encoded_id}/artifacts/keep"
-        self.manager.gitlab.http_post(path)
+        self.manager.gitlab.http_post(path, **kwargs)
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabCreateError)
@@ -109,7 +109,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabDeleteError: If the request could not be performed
         """
         path = f"{self.manager.path}/{self.encoded_id}/artifacts"
-        self.manager.gitlab.http_delete(path)
+        self.manager.gitlab.http_delete(path, **kwargs)
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabGetError)

--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -157,7 +157,7 @@ class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTMan
                 ar.save()
                 return ar
         # if there was no rule matching the rule name, create a new one
-        return approval_rules.create(data=data)
+        return approval_rules.create(data=data, **kwargs)
 
 
 class ProjectMergeRequestApprovalRule(SaveMixin, ObjectDeleteMixin, RESTObject):

--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -71,7 +71,7 @@ class ProjectPipeline(RefreshMixin, ObjectDeleteMixin, RESTObject):
             GitlabPipelineCancelError: If the request failed
         """
         path = f"{self.manager.path}/{self.encoded_id}/cancel"
-        return self.manager.gitlab.http_post(path)
+        return self.manager.gitlab.http_post(path, **kwargs)
 
     @cli.register_custom_action("ProjectPipeline")
     @exc.on_http_error(exc.GitlabPipelineRetryError)
@@ -86,7 +86,7 @@ class ProjectPipeline(RefreshMixin, ObjectDeleteMixin, RESTObject):
             GitlabPipelineRetryError: If the request failed
         """
         path = f"{self.manager.path}/{self.encoded_id}/retry"
-        return self.manager.gitlab.http_post(path)
+        return self.manager.gitlab.http_post(path, **kwargs)
 
 
 class ProjectPipelineManager(RetrieveMixin, CreateMixin, DeleteMixin, RESTManager):

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -464,7 +464,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
 
         url = f"/projects/{self.encoded_id}/uploads"
         file_info = {"file": (filename, filedata)}
-        data = self.manager.gitlab.http_post(url, files=file_info)
+        data = self.manager.gitlab.http_post(url, files=file_info, **kwargs)
 
         if TYPE_CHECKING:
             assert isinstance(data, dict)
@@ -504,7 +504,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         """
         path = f"/projects/{self.encoded_id}/snapshot"
         result = self.manager.gitlab.http_get(
-            path, streamed=streamed, raw=True, **kwargs
+            path, streamed=streamed, raw=True, wiki=wiki, **kwargs
         )
         if TYPE_CHECKING:
             assert isinstance(result, requests.Response)

--- a/gitlab/v4/objects/services.py
+++ b/gitlab/v4/objects/services.py
@@ -267,7 +267,7 @@ class ProjectServiceManager(GetMixin, UpdateMixin, DeleteMixin, ListMixin, RESTM
         return cast(ProjectService, super().get(id=id, lazy=lazy, **kwargs))
 
     @cli.register_custom_action("ProjectServiceManager")
-    def available(self, **kwargs: Any) -> List[str]:
+    def available(self) -> List[str]:
         """List the services known by python-gitlab.
 
         Returns:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,6 @@ disable = [
     "too-many-locals",
     "too-many-statements",
     "unsubscriptable-object",
-    "unused-argument",
-
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Enable the pylint "unused-argument" check and resolve issues it found.

  * Quite a few functions were accepting `**kwargs` but not then
    passing them on through to the next level. Now pass `**kwargs` to
    next level.
  * Other functions had no reason to accept `**kwargs`, so remove it
  * And a few other fixes.