### PR TITLE
feat(api): add support for `get` for a MR approval rule

### DIFF
--- a/docs/gl_objects/merge_request_approvals.rst
+++ b/docs/gl_objects/merge_request_approvals.rst
@@ -78,6 +78,11 @@ List MR-level MR approval rules::
 
 	mr.approval_rules.list()
 
+Get a single MR approval rule::
+
+    approval_rule_id = 123
+    mr_approvalrule = mr.approval_rules.get(approval_rule_id)
+
 Delete MR-level MR approval rule::
 
     rules = mr.approval_rules.list()

--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -1,9 +1,10 @@
-from typing import Any, cast, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, cast, Dict, List, Optional, TYPE_CHECKING, Union
 
 from gitlab import exceptions as exc
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,
+    CRUDMixin,
     DeleteMixin,
     GetWithoutIdMixin,
     ListMixin,
@@ -189,9 +190,7 @@ class ProjectMergeRequestApprovalRule(SaveMixin, ObjectDeleteMixin, RESTObject):
         SaveMixin.save(self, **kwargs)
 
 
-class ProjectMergeRequestApprovalRuleManager(
-    ListMixin, UpdateMixin, CreateMixin, DeleteMixin, RESTManager
-):
+class ProjectMergeRequestApprovalRuleManager(CRUDMixin, RESTManager):
     _path = "/projects/{project_id}/merge_requests/{mr_iid}/approval_rules"
     _obj_cls = ProjectMergeRequestApprovalRule
     _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}
@@ -213,6 +212,13 @@ class ProjectMergeRequestApprovalRuleManager(
         required=("id", "merge_request_iid", "name", "approvals_required"),
         optional=("approval_project_rule_id", "user_ids", "group_ids"),
     )
+
+    def get(
+        self, id: Union[str, int], lazy: bool = False, **kwargs: Any
+    ) -> ProjectMergeRequestApprovalRule:
+        return cast(
+            ProjectMergeRequestApprovalRule, super().get(id=id, lazy=lazy, **kwargs)
+        )
 
     def create(
         self, data: Optional[Dict[str, Any]] = None, **kwargs: Any

--- a/tests/unit/objects/test_project_merge_request_approvals.py
+++ b/tests/unit/objects/test_project_merge_request_approvals.py
@@ -102,6 +102,13 @@ def resp_mr_approval_rules():
         )
         rsps.add(
             method=responses.GET,
+            url="http://localhost/api/v4/projects/1/merge_requests/1/approval_rules/1",
+            json=mr_ars_content[0],
+            content_type="application/json",
+            status=200,
+        )
+        rsps.add(
+            method=responses.GET,
             url="http://localhost/api/v4/projects/1/merge_requests/1/approval_state",
             json=mr_approval_state_content,
             content_type="application/json",
@@ -241,6 +248,17 @@ def test_update_merge_request_approval_rule(project, resp_mr_approval_rules):
     assert ar_1.approvals_required == updated_approval_rule_approvals_required
     assert len(ar_1.eligible_approvers) == len(updated_approval_rule_user_ids)
     assert ar_1.eligible_approvers[0]["id"] == updated_approval_rule_user_ids[0]
+
+
+def test_get_merge_request_approval_rule(project, resp_mr_approval_rules):
+    merge_request = project.mergerequests.get(1, lazy=True)
+    approval_rule = merge_request.approval_rules.get(approval_rule_id)
+    assert isinstance(
+        approval_rule,
+        gitlab.v4.objects.merge_request_approvals.ProjectMergeRequestApprovalRule,
+    )
+    assert approval_rule.name == approval_rule_name
+    assert approval_rule.id == approval_rule_id
 
 
 def test_get_merge_request_approval_state(project, resp_mr_approval_rules):


### PR DESCRIPTION
In GitLab 14.10 they added support to get a single merge request
approval rule [1]

Add support for it to ProjectMergeRequestApprovalRuleManager

[1] https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-a-single-merge-request-level-rule