### PR TITLE
fix: ensure path elements are escaped

### DIFF
--- a/gitlab/base.py
+++ b/gitlab/base.py
@@ -380,10 +380,12 @@ class RESTManager:
         if self._parent is None or not self._from_parent_attrs:
             return path
 
-        data = {
-            self_attr: getattr(self._parent, parent_attr, None)
-            for self_attr, parent_attr in self._from_parent_attrs.items()
-        }
+        data: Dict[str, Optional[gitlab.utils.EncodedId]] = {}
+        for self_attr, parent_attr in self._from_parent_attrs.items():
+            if not hasattr(self._parent, parent_attr):
+                data[self_attr] = None
+                continue
+            data[self_attr] = gitlab.utils.EncodedId(getattr(self._parent, parent_attr))
         self._parent_attrs = data
         return path.format(**data)
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -391,7 +391,7 @@ def project_file(project):
 @pytest.fixture(scope="function")
 def release(project, project_file):
     _id = uuid.uuid4().hex
-    name = f"test-release-{_id}"
+    name = f"we_have_a_slash/test-release-{_id}"
 
     project.refresh()  # Gets us the current default branch
     release = project.releases.create(


### PR DESCRIPTION
Ensure the path elements that are passed to the server are escaped.
For example a "/" will be changed to "%2F"

Closes: #2116