### PR TITLE
test(functional): replace len() calls with list membership checks

### DIFF
--- a/tests/functional/api/test_clusters.py
+++ b/tests/functional/api/test_clusters.py
@@ -1,5 +1,5 @@
 def test_project_clusters(project):
-    project.clusters.create(
+    cluster = project.clusters.create(
         {
             "name": "cluster1",
             "platform_kubernetes_attributes": {
@@ -9,9 +9,8 @@ def test_project_clusters(project):
         }
     )
     clusters = project.clusters.list()
-    assert len(clusters) == 1
+    assert cluster in clusters
 
-    cluster = clusters[0]
     cluster.platform_kubernetes_attributes = {"api_url": "http://newurl"}
     cluster.save()
 
@@ -19,11 +18,11 @@ def test_project_clusters(project):
     assert cluster.platform_kubernetes["api_url"] == "http://newurl"
 
     cluster.delete()
-    assert len(project.clusters.list()) == 0
+    assert cluster not in project.clusters.list()
 
 
 def test_group_clusters(group):
-    group.clusters.create(
+    cluster = group.clusters.create(
         {
             "name": "cluster1",
             "platform_kubernetes_attributes": {
@@ -33,9 +32,8 @@ def test_group_clusters(group):
         }
     )
     clusters = group.clusters.list()
-    assert len(clusters) == 1
+    assert cluster in clusters
 
-    cluster = clusters[0]
     cluster.platform_kubernetes_attributes = {"api_url": "http://newurl"}
     cluster.save()
 
@@ -43,4 +41,4 @@ def test_group_clusters(group):
     assert cluster.platform_kubernetes["api_url"] == "http://newurl"
 
     cluster.delete()
-    assert len(group.clusters.list()) == 0
+    assert cluster not in group.clusters.list()

--- a/tests/functional/api/test_current_user.py
+++ b/tests/functional/api/test_current_user.py
@@ -1,30 +1,30 @@
 def test_current_user_email(gl):
     gl.auth()
     mail = gl.user.emails.create({"email": "current@user.com"})
-    assert len(gl.user.emails.list()) == 2
+    assert mail in gl.user.emails.list()
 
     mail.delete()
-    assert len(gl.user.emails.list()) == 1
+    assert mail not in gl.user.emails.list()
 
 
 def test_current_user_gpg_keys(gl, GPG_KEY):
     gl.auth()
     gkey = gl.user.gpgkeys.create({"key": GPG_KEY})
-    assert len(gl.user.gpgkeys.list()) == 1
+    assert gkey in gl.user.gpgkeys.list()
 
     # Seems broken on the gitlab side
     gkey = gl.user.gpgkeys.get(gkey.id)
     gkey.delete()
-    assert len(gl.user.gpgkeys.list()) == 0
+    assert gkey not in gl.user.gpgkeys.list()
 
 
 def test_current_user_ssh_keys(gl, SSH_KEY):
     gl.auth()
     key = gl.user.keys.create({"title": "testkey", "key": SSH_KEY})
-    assert len(gl.user.keys.list()) == 1
+    assert key in gl.user.keys.list()
 
     key.delete()
-    assert len(gl.user.keys.list()) == 0
+    assert key not in gl.user.keys.list()
 
 
 def test_current_user_status(gl):

--- a/tests/functional/api/test_deploy_keys.py
+++ b/tests/functional/api/test_deploy_keys.py
@@ -1,12 +1,11 @@
 def test_project_deploy_keys(gl, project, DEPLOY_KEY):
     deploy_key = project.keys.create({"title": "foo@bar", "key": DEPLOY_KEY})
-    project_keys = list(project.keys.list())
-    assert len(project_keys) == 1
+    assert deploy_key in project.keys.list()
 
     project2 = gl.projects.create({"name": "deploy-key-project"})
     project2.keys.enable(deploy_key.id)
-    assert len(project2.keys.list()) == 1
+    assert deploy_key in project2.keys.list()
 
     project2.keys.delete(deploy_key.id)
-    assert len(project2.keys.list()) == 0
+    assert deploy_key not in project2.keys.list()
     project2.delete()

--- a/tests/functional/api/test_deploy_tokens.py
+++ b/tests/functional/api/test_deploy_tokens.py
@@ -7,8 +7,8 @@ def test_project_deploy_tokens(gl, project):
             "scopes": ["read_registry"],
         }
     )
-    assert len(project.deploytokens.list()) == 1
-    assert gl.deploytokens.list() == project.deploytokens.list()
+    assert deploy_token in project.deploytokens.list()
+    assert set(project.deploytokens.list()) <= set(gl.deploytokens.list())
 
     deploy_token = project.deploytokens.get(deploy_token.id)
     assert deploy_token.name == "foo"
@@ -17,8 +17,8 @@ def test_project_deploy_tokens(gl, project):
     assert deploy_token.username == "bar"
 
     deploy_token.delete()
-    assert len(project.deploytokens.list()) == 0
-    assert len(gl.deploytokens.list()) == 0
+    assert deploy_token not in project.deploytokens.list()
+    assert deploy_token not in gl.deploytokens.list()
 
 
 def test_group_deploy_tokens(gl, group):
@@ -29,13 +29,13 @@ def test_group_deploy_tokens(gl, group):
         }
     )
 
-    assert len(group.deploytokens.list()) == 1
-    assert gl.deploytokens.list() == group.deploytokens.list()
+    assert deploy_token in group.deploytokens.list()
+    assert set(group.deploytokens.list()) <= set(gl.deploytokens.list())
 
     deploy_token = group.deploytokens.get(deploy_token.id)
     assert deploy_token.name == "foo"
     assert deploy_token.scopes == ["read_registry"]
 
     deploy_token.delete()
-    assert len(group.deploytokens.list()) == 0
-    assert len(gl.deploytokens.list()) == 0
+    assert deploy_token not in group.deploytokens.list()
+    assert deploy_token not in gl.deploytokens.list()

--- a/tests/functional/api/test_merge_requests.py
+++ b/tests/functional/api/test_merge_requests.py
@@ -50,10 +50,9 @@ def test_merge_requests_get_lazy(project, merge_request):
 
 def test_merge_request_discussion(project):
     mr = project.mergerequests.list()[0]
-    size = len(mr.discussions.list())
 
     discussion = mr.discussions.create({"body": "Discussion body"})
-    assert len(mr.discussions.list()) == size + 1
+    assert discussion in mr.discussions.list()
 
     note = discussion.notes.create({"body": "first note"})
     note_from_get = discussion.notes.get(note.id)

--- a/tests/functional/api/test_releases.py
+++ b/tests/functional/api/test_releases.py
@@ -16,7 +16,7 @@ def test_create_project_release(project, project_file):
         }
     )
 
-    assert len(project.releases.list()) == 1
+    assert release in project.releases.list()
     assert project.releases.get(release_tag_name)
     assert release.name == release_name
     assert release.tag_name == release_tag_name
@@ -35,7 +35,7 @@ def test_create_project_release_no_name(project, project_file):
         }
     )
 
-    assert len(project.releases.list()) >= 1
+    assert release in project.releases.list()
     assert project.releases.get(unnamed_release_tag_name)
     assert release.tag_name == unnamed_release_tag_name
     assert release.description == release_description

--- a/tests/functional/api/test_repository.py
+++ b/tests/functional/api/test_repository.py
@@ -107,9 +107,8 @@ def test_create_commit(project):
 
 def test_create_commit_status(project):
     commit = project.commits.list()[0]
-    size = len(commit.statuses.list())
-    commit.statuses.create({"state": "success", "sha": commit.id})
-    assert len(commit.statuses.list()) == size + 1
+    status = commit.statuses.create({"state": "success", "sha": commit.id})
+    assert status in commit.statuses.list()
 
 
 def test_commit_signature(project):
@@ -130,10 +129,9 @@ def test_commit_comment(project):
 
 def test_commit_discussion(project):
     commit = project.commits.list()[0]
-    count = len(commit.discussions.list())
 
     discussion = commit.discussions.create({"body": "Discussion body"})
-    assert len(commit.discussions.list()) == (count + 1)
+    assert discussion in commit.discussions.list()
 
     note = discussion.notes.create({"body": "first note"})
     note_from_get = discussion.notes.get(note.id)

--- a/tests/functional/api/test_snippets.py
+++ b/tests/functional/api/test_snippets.py
@@ -3,7 +3,7 @@ import gitlab
 
 def test_snippets(gl):
     snippets = gl.snippets.list(all=True)
-    assert len(snippets) == 0
+    assert not snippets
 
     snippet = gl.snippets.create(
         {"title": "snippet1", "file_name": "snippet1.py", "content": "import gitlab"}
@@ -20,8 +20,7 @@ def test_snippets(gl):
     assert snippet.user_agent_detail()["user_agent"]
 
     snippet.delete()
-    snippets = gl.snippets.list(all=True)
-    assert len(snippets) == 0
+    assert snippet not in gl.snippets.list(all=True)
 
 
 def test_project_snippets(project):
@@ -42,10 +41,9 @@ def test_project_snippets(project):
 
 def test_project_snippet_discussion(project):
     snippet = project.snippets.list()[0]
-    size = len(snippet.discussions.list())
 
     discussion = snippet.discussions.create({"body": "Discussion body"})
-    assert len(snippet.discussions.list()) == size + 1
+    assert discussion in snippet.discussions.list()
 
     note = discussion.notes.create({"body": "first note"})
     note_from_get = discussion.notes.get(note.id)
@@ -68,7 +66,7 @@ def test_project_snippet_file(project):
     snippet = project.snippets.get(snippet.id)
     assert snippet.content().decode() == "initial content"
     assert snippet.file_name == "bar.py"
+    assert snippet in project.snippets.list()
 
-    size = len(project.snippets.list())
     snippet.delete()
-    assert len(project.snippets.list()) == (size - 1)
+    assert snippet not in project.snippets.list()

--- a/tests/functional/api/test_users.py
+++ b/tests/functional/api/test_users.py
@@ -97,72 +97,68 @@ def test_list_multiple_users(gl, user):
     expected = [user, second_user]
     actual = list(gl.users.list(search=user.username))
 
-    assert len(expected) == len(actual)
-    assert len(gl.users.list(search="asdf")) == 0
+    assert set(expected) == set(actual)
+    assert not gl.users.list(search="asdf")
 
 
 def test_user_gpg_keys(gl, user, GPG_KEY):
     gkey = user.gpgkeys.create({"key": GPG_KEY})
-    assert len(user.gpgkeys.list()) == 1
+    assert gkey in user.gpgkeys.list()
 
     # Seems broken on the gitlab side
     # gkey = user.gpgkeys.get(gkey.id)
 
     gkey.delete()
-    assert len(user.gpgkeys.list()) == 0
+    assert gkey not in user.gpgkeys.list()
 
 
 def test_user_ssh_keys(gl, user, SSH_KEY):
     key = user.keys.create({"title": "testkey", "key": SSH_KEY})
-    assert len(user.keys.list()) == 1
+    assert key in user.keys.list()
 
     get_key = user.keys.get(key.id)
     assert get_key.key == key.key
 
     key.delete()
-    assert len(user.keys.list()) == 0
+    assert key not in user.keys.list()
 
 
 def test_user_email(gl, user):
     email = user.emails.create({"email": "foo2@bar.com"})
-    assert len(user.emails.list()) == 1
+    assert email in user.emails.list()
 
     email.delete()
-    assert len(user.emails.list()) == 0
+    assert email not in user.emails.list()
 
 
 def test_user_custom_attributes(gl, user):
     attrs = user.customattributes.list()
-    assert len(attrs) == 0
+    assert not attrs
 
     attr = user.customattributes.set("key", "value1")
-    assert len(gl.users.list(custom_attributes={"key": "value1"})) == 1
+    assert user in gl.users.list(custom_attributes={"key": "value1"})
     assert attr.key == "key"
     assert attr.value == "value1"
-    assert len(user.customattributes.list()) == 1
+    assert attr in user.customattributes.list()
 
     attr = user.customattributes.set("key", "value2")
     attr = user.customattributes.get("key")
     assert attr.value == "value2"
-    assert len(user.customattributes.list()) == 1
+    assert attr in user.customattributes.list()
 
     attr.delete()
-    assert len(user.customattributes.list()) == 0
+    assert attr not in user.customattributes.list()
 
 
 def test_user_impersonation_tokens(gl, user):
     token = user.impersonationtokens.create(
         {"name": "token1", "scopes": ["api", "read_user"]}
     )
-
-    tokens = user.impersonationtokens.list(state="active")
-    assert len(tokens) == 1
+    assert token in user.impersonationtokens.list(state="active")
 
     token.delete()
-    tokens = user.impersonationtokens.list(state="active")
-    assert len(tokens) == 0
-    tokens = user.impersonationtokens.list(state="inactive")
-    assert len(tokens) == 1
+    assert token not in user.impersonationtokens.list(state="active")
+    assert token in user.impersonationtokens.list(state="inactive")
 
 
 def test_user_identities(gl, user):

--- a/tests/functional/api/test_variables.py
+++ b/tests/functional/api/test_variables.py
@@ -9,7 +9,7 @@ https://docs.gitlab.com/ee/api/group_level_variables.html
 def test_instance_variables(gl):
     variable = gl.variables.create({"key": "key1", "value": "value1"})
     assert variable.value == "value1"
-    assert len(gl.variables.list()) == 1
+    assert variable in gl.variables.list()
 
     variable.value = "new_value1"
     variable.save()
@@ -17,13 +17,13 @@ def test_instance_variables(gl):
     assert variable.value == "new_value1"
 
     variable.delete()
-    assert len(gl.variables.list()) == 0
+    assert variable not in gl.variables.list()
 
 
 def test_group_variables(group):
     variable = group.variables.create({"key": "key1", "value": "value1"})
     assert variable.value == "value1"
-    assert len(group.variables.list()) == 1
+    assert variable in group.variables.list()
 
     variable.value = "new_value1"
     variable.save()
@@ -31,13 +31,13 @@ def test_group_variables(group):
     assert variable.value == "new_value1"
 
     variable.delete()
-    assert len(group.variables.list()) == 0
+    assert variable not in group.variables.list()
 
 
 def test_project_variables(project):
     variable = project.variables.create({"key": "key1", "value": "value1"})
     assert variable.value == "value1"
-    assert len(project.variables.list()) == 1
+    assert variable in project.variables.list()
 
     variable.value = "new_value1"
     variable.save()
@@ -45,4 +45,4 @@ def test_project_variables(project):
     assert variable.value == "new_value1"
 
     variable.delete()
-    assert len(project.variables.list()) == 0
+    assert variable not in project.variables.list()


### PR DESCRIPTION
See https://github.com/python-gitlab/python-gitlab/pull/1784#issuecomment-1172730920.

I've felt a bit weird for a while about having these magic numbers in tests, and they don't really test whether the actual resource created is or isn't in the list. This should hopefully also help with some of the race conditions potentially introduced with async gitlab operations.

I've left a few where it would need some further refactoring (e.g. fixture factories for group/member creation) or where I thought `len()` was still useful. It was already quite tedious so it might be tedious to review, I can split it into multiple commits if needed :)