### PR TITLE
feat: support validating CI lint results

### DIFF
--- a/docs/cli-examples.rst
+++ b/docs/cli-examples.rst
@@ -15,6 +15,9 @@ Lint a CI YAML configuration from a string:
 
    To see output, you will need to use the ``-v``/``--verbose`` flag.
 
+   To exit with non-zero on YAML lint failures instead, use the ``validate``
+   subcommand shown below.
+
 .. code-block:: console
 
    $ gitlab --verbose ci-lint create --content \
@@ -30,11 +33,23 @@ Lint a CI YAML configuration from a file (see :ref:`cli_from_files`):
 
    $ gitlab --verbose ci-lint create --content @.gitlab-ci.yml
 
+Validate a CI YAML configuration from a file (lints and exits with non-zero on failure):
+
+.. code-block:: console
+
+   $ gitlab ci-lint validate --content @.gitlab-ci.yml
+
 Lint a project's CI YAML configuration:
 
 .. code-block:: console
 
    $ gitlab --verbose project-ci-lint create --project-id group/my-project --content @.gitlab-ci.yml
+
+Validate a project's CI YAML configuration (lints and exits with non-zero on failure):
+
+.. code-block:: console
+
+   $ gitlab project-ci-lint validate --project-id group/my-project --content @.gitlab-ci.yml
 
 Lint a project's current CI YAML configuration:
 

--- a/docs/gl_objects/ci_lint.rst
+++ b/docs/gl_objects/ci_lint.rst
@@ -19,7 +19,7 @@ Reference
 Examples
 ---------
 
-Validate a CI YAML configuration::
+Lint a CI YAML configuration::
 
     gitlab_ci_yml = """.api_test:
       rules:
@@ -40,14 +40,30 @@ Validate a CI YAML configuration::
     print(lint_result.status)  # Print the status of the CI YAML
     print(lint_result.merged_yaml)  # Print the merged YAML file
 
-Validate a project's CI configuration::
+Lint a project's CI configuration::
 
     lint_result = project.ci_lint.get()
     assert lint_result.valid is True  # Test that the .gitlab-ci.yml is valid
     print(lint_result.merged_yaml)    # Print the merged YAML file
 
-Validate a CI YAML configuration with a namespace::
+Lint a CI YAML configuration with a namespace::
 
     lint_result = project.ci_lint.create({"content": gitlab_ci_yml})
     assert lint_result.valid is True  # Test that the .gitlab-ci.yml is valid
     print(lint_result.merged_yaml)    # Print the merged YAML file
+
+Validate a CI YAML configuration (raises ``GitlabCiLintError`` on failures)::
+
+    # returns None
+    gl.ci_lint.validate({"content": gitlab_ci_yml})
+
+    # raises GitlabCiLintError
+    gl.ci_lint.validate({"content": "invalid"})
+
+Validate a CI YAML configuration with a namespace::
+
+    # returns None
+    project.ci_lint.validate({"content": gitlab_ci_yml})
+
+    # raises GitlabCiLintError
+    project.ci_lint.validate({"content": "invalid"})

--- a/gitlab/exceptions.py
+++ b/gitlab/exceptions.py
@@ -62,6 +62,10 @@ class GitlabParsingError(GitlabError):
     pass
 
 
+class GitlabCiLintError(GitlabError):
+    pass
+
+
 class GitlabConnectionError(GitlabError):
     pass
 

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -25,6 +25,7 @@ import gitlab
 import gitlab.base
 import gitlab.v4.objects
 from gitlab import cli
+from gitlab.exceptions import GitlabCiLintError
 
 
 class GitlabCLI:
@@ -132,6 +133,16 @@ class GitlabCLI:
 
         except Exception as e:  # pragma: no cover, cli.die is unit-tested
             cli.die("Impossible to download the export", e)
+
+    def do_validate(self) -> None:
+        if TYPE_CHECKING:
+            assert isinstance(self.mgr, gitlab.v4.objects.CiLintManager)
+        try:
+            self.mgr.validate(self.args)
+        except GitlabCiLintError as e:  # pragma: no cover, cli.die is unit-tested
+            cli.die("CI YAML Lint failed", e)
+        except Exception as e:  # pragma: no cover, cli.die is unit-tested
+            cli.die("Cannot validate CI YAML", e)
 
     def do_create(self) -> gitlab.base.RESTObject:
         if TYPE_CHECKING:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,3 +4,16 @@ import pytest
 @pytest.fixture(scope="session")
 def test_dir(pytestconfig):
     return pytestconfig.rootdir / "tests"
+
+
+@pytest.fixture
+def valid_gitlab_ci_yml():
+    return """---
+:test_job:
+  :script: echo 1
+"""
+
+
+@pytest.fixture
+def invalid_gitlab_ci_yml():
+    return "invalid"

--- a/tests/functional/cli/test_cli_v4.py
+++ b/tests/functional/cli/test_cli_v4.py
@@ -22,6 +22,59 @@ def test_update_project(gitlab_cli, project):
     assert description in ret.stdout
 
 
+def test_create_ci_lint(gitlab_cli, valid_gitlab_ci_yml):
+    cmd = ["ci-lint", "create", "--content", valid_gitlab_ci_yml]
+    ret = gitlab_cli(cmd)
+
+    assert ret.success
+
+
+def test_validate_ci_lint(gitlab_cli, valid_gitlab_ci_yml):
+    cmd = ["ci-lint", "validate", "--content", valid_gitlab_ci_yml]
+    ret = gitlab_cli(cmd)
+
+    assert ret.success
+
+
+def test_validate_ci_lint_invalid_exits_non_zero(gitlab_cli, invalid_gitlab_ci_yml):
+    cmd = ["ci-lint", "validate", "--content", invalid_gitlab_ci_yml]
+    ret = gitlab_cli(cmd)
+
+    assert not ret.success
+    assert "CI YAML Lint failed (Invalid configuration format)" in ret.stderr
+
+
+def test_validate_project_ci_lint(gitlab_cli, project, valid_gitlab_ci_yml):
+    cmd = [
+        "project-ci-lint",
+        "validate",
+        "--project-id",
+        project.id,
+        "--content",
+        valid_gitlab_ci_yml,
+    ]
+    ret = gitlab_cli(cmd)
+
+    assert ret.success
+
+
+def test_validate_project_ci_lint_invalid_exits_non_zero(
+    gitlab_cli, project, invalid_gitlab_ci_yml
+):
+    cmd = [
+        "project-ci-lint",
+        "validate",
+        "--project-id",
+        project.id,
+        "--content",
+        invalid_gitlab_ci_yml,
+    ]
+    ret = gitlab_cli(cmd)
+
+    assert not ret.success
+    assert "CI YAML Lint failed (Invalid configuration format)" in ret.stderr
+
+
 def test_create_group(gitlab_cli):
     name = "test-group1"
     path = "group1"


### PR DESCRIPTION
Closes https://github.com/python-gitlab/python-gitlab/issues/546.

There's a bit of duplication because of the inconsistent APIs between global/project endpoints.