### PR TITLE
fix: optionally keep user-provided base URL for pagination

### DIFF
--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -66,6 +66,7 @@ class Gitlab:
         user_agent: A custom user agent to use for making HTTP requests.
         retry_transient_errors: Whether to retry after 500, 502, 503, 504
             or 52x responses. Defaults to False.
+        persist_base_url: reconstruct next url if found not same as user provided url
     """
 
     def __init__(
@@ -85,6 +86,7 @@ class Gitlab:
         order_by: Optional[str] = None,
         user_agent: str = gitlab.const.USER_AGENT,
         retry_transient_errors: bool = False,
+        persist_base_url: bool = False,
     ) -> None:
 
         self._api_version = str(api_version)
@@ -95,6 +97,7 @@ class Gitlab:
         #: Timeout to use for requests to gitlab server
         self.timeout = timeout
         self.retry_transient_errors = retry_transient_errors
+        self.persist_base_url = persist_base_url
         #: Headers that will be used in request to GitLab
         self.headers = {"User-Agent": user_agent}
 
@@ -1133,8 +1136,29 @@ class GitlabList:
                 next_url = requests.utils.parse_header_links(result.headers["links"])[
                     0
                 ]["url"]
-            if not next_url.startswith(self._gl._base_url):
-                next_url = re.sub(r"^.*?/api", f"{self._gl._base_url}/api", next_url)
+            # if the next url is different with user provided server URL
+            # then give a warning it may because of misconfiguration
+            # but if the option to fix provided then just reconstruct it
+            if not next_url.startswith(self._gl.url):
+                search_api_url = re.search(r"(^.*?/api)", next_url)
+                if search_api_url:
+                    next_api_url = search_api_url.group(1)
+                    if self._gl.persist_base_url:
+                        next_url = next_url.replace(
+                            next_api_url, f"{self._gl._base_url}/api"
+                        )
+                    else:
+                        utils.warn(
+                            message=(
+                                f"The base url of the returned next page got "
+                                f"different with the user provided "
+                                f"{self._gl.url}/api* ~> {next_api_url}*, "
+                                f"since this may can lead to unexpected behaviour. "
+                                f"set argument persist_base_url to True for "
+                                f"resonctruct it with the origin one."
+                            ),
+                            category=UserWarning,
+                        )
             self._next_url = next_url
         except KeyError:
             self._next_url = None

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -17,6 +17,7 @@
 """Wrapper for the GitLab API."""
 
 import os
+import re
 import time
 from typing import Any, cast, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
@@ -1132,6 +1133,8 @@ class GitlabList:
                 next_url = requests.utils.parse_header_links(result.headers["links"])[
                     0
                 ]["url"]
+            if not next_url.startswith(self._gl._base_url):
+                next_url = re.sub(r"^.*?/api", f"{self._gl._base_url}/api", next_url)
             self._next_url = next_url
         except KeyError:
             self._next_url = None

--- a/tests/unit/test_gitlab.py
+++ b/tests/unit/test_gitlab.py
@@ -359,30 +359,28 @@ def test_gitlab_plain_const_does_not_warn(recwarn):
 @pytest.mark.parametrize(
     "kwargs,link_header,expected_next_url,show_warning",
     [
-        # normal execution
         (
             {},
             "<http://localhost/api/v4/tests?per_page=1&page=2>;" ' rel="next"',
             "http://localhost/api/v4/tests?per_page=1&page=2",
             False,
         ),
-        # got different url and will show the warning
         (
             {},
             "<http://orig_host/api/v4/tests?per_page=1&page=2>;" ' rel="next"',
             "http://orig_host/api/v4/tests?per_page=1&page=2",
             True,
         ),
-        # persist the base url
         (
-            {"persist_base_url": True},
+            {"keep_base_url": True},
             "<http://orig_host/api/v4/tests?per_page=1&page=2>;" ' rel="next"',
             "http://localhost/api/v4/tests?per_page=1&page=2",
             False,
         ),
     ],
+    ids=["url-match-does-not-warn", "url-mismatch-warns", "url-mismatch-keeps-url"],
 )
-def test_gitlab_persist_base_url(kwargs, link_header, expected_next_url, show_warning):
+def test_gitlab_keep_base_url(kwargs, link_header, expected_next_url, show_warning):
     responses.add(
         **{
             "method": responses.GET,


### PR DESCRIPTION
# Background

To enhance HTTP security our Gitlab is fronted by [IAP](https://cloud.google.com/iap) for example `https://gitlab.tools.domain.io` but for internal communication from runner to Gitlab API we create another endpoint that protected by firewall rules so then it only can be accessed from certain IP only, for example `https://runner.gitlab.tools.domain.io/` it actually using the reverse proxy that in the upstream destination will set `Host` header to the original one (`gitlab.tools.domain.io`). 

But when we run a python script inside Gitlab pipeline to the endpoint (`runner.gitlab.tools.domain.io`) and pass argument `all=True` or `iterator=True` [for loop all the data to all page](https://python-gitlab.readthedocs.io/en/stable/api-usage.html#pagination) will returning the base url as `gitlab.tools.domain.io` whereas it will causing the error due the request will be blocked by IAP.

# Expected

The base url will be persist same as the first time set in the next url so the request will be expected goes as the first page when using pagination iterrator (`all=True`).

# Fix

This MR will make sure the base in next url is the same. It's been tested in my case and working as expected.