### PR TITLE
test(api_func_v4): catch deprecation warning for `gl.lint()`

### DIFF
--- a/tests/functional/api/test_gitlab.py
+++ b/tests/functional/api/test_gitlab.py
@@ -50,7 +50,8 @@ def test_markdown_in_project(gl, project):
 
 
 def test_lint(gl):
-    success, errors = gl.lint("Invalid")
+    with pytest.deprecated_call():
+        success, errors = gl.lint("Invalid")
     assert success is False
     assert errors
 


### PR DESCRIPTION
Catch the deprecation warning for the call to `gl.lint()`, so it won't
show up in the log.