### PR TITLE
test: allow `podman` users to run functional tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters = True
 envlist = py310,py39,py38,py37,flake8,black,twine-check,mypy,isort,cz,pylint
 
 [testenv]
-passenv = GITLAB_IMAGE GITLAB_TAG PY_COLORS NO_COLOR FORCE_COLOR
+passenv = GITLAB_IMAGE GITLAB_TAG PY_COLORS NO_COLOR FORCE_COLOR DOCKER_HOST
 setenv = VIRTUAL_ENV={envdir}
 whitelist_externals = true
 usedevelop = True


### PR DESCRIPTION
Users of `podman` will likely have `DOCKER_HOST` set to something like
`unix:///run/user/1000/podman/podman.sock`

Pass this environment variable so that it will be used during the
functional tests.