### PR TITLE
fix(runners): fix listing for /runners/all

### DIFF
--- a/docs/cli-examples.rst
+++ b/docs/cli-examples.rst
@@ -236,6 +236,33 @@ Download the artifacts zip archive of a job:
 
    $ gitlab project-job artifacts --id 10 --project-id 1 > artifacts.zip
 
+Runners
+-------
+
+List owned runners:
+
+.. code-block:: console
+
+   $ gitlab runner list
+
+List owned runners with a filter:
+
+.. code-block:: console
+
+   $ gitlab runner list --scope active
+
+List all runners in the GitLab instance (specific and shared):
+
+.. code-block:: console
+
+   $ gitlab runner-all list
+
+Get a runner's details:
+
+.. code-block:: console
+
+   $ gitlab -v runner get --id 123
+
 Other
 -----
 

--- a/docs/gl_objects/runners.rst
+++ b/docs/gl_objects/runners.rst
@@ -19,6 +19,9 @@ Reference
   + :class:`gitlab.v4.objects.Runner`
   + :class:`gitlab.v4.objects.RunnerManager`
   + :attr:`gitlab.Gitlab.runners`
+  + :class:`gitlab.v4.objects.RunnerAll`
+  + :class:`gitlab.v4.objects.RunnerAllManager`
+  + :attr:`gitlab.Gitlab.runners_all`
 
 * GitLab API: https://docs.gitlab.com/ce/api/runners.html
 
@@ -41,14 +44,20 @@ for this parameter are:
    The returned objects hold minimal information about the runners. Use the
    ``get()`` method to retrieve detail about a runner.
 
+   Runners returned via ``runners_all.list()`` also cannot be manipulated
+   directly. You will need to use the ``get()`` method to create an editable
+   object.
+
 ::
 
     # List owned runners
     runners = gl.runners.list()
-    # With a filter
+
+    # List owned runners with a filter
     runners = gl.runners.list(scope='active')
-    # List all runners, using a filter
-    runners = gl.runners.all(scope='paused')
+
+    # List all runners in the GitLab instance (specific and shared), using a filter
+    runners = gl.runners_all.list(scope='paused')
 
 Get a runner's detail::
 

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -164,6 +164,8 @@ class Gitlab:
         """See :class:`~gitlab.v4.objects.RegistryRepositoryManager`"""
         self.runners = objects.RunnerManager(self)
         """See :class:`~gitlab.v4.objects.RunnerManager`"""
+        self.runners_all = objects.RunnerAllManager(self)
+        """See :class:`~gitlab.v4.objects.RunnerManager`"""
         self.settings = objects.ApplicationSettingsManager(self)
         """See :class:`~gitlab.v4.objects.ApplicationSettingsManager`"""
         self.appearance = objects.ApplicationAppearanceManager(self)

--- a/gitlab/v4/objects/runners.py
+++ b/gitlab/v4/objects/runners.py
@@ -19,6 +19,8 @@ __all__ = [
     "RunnerJobManager",
     "Runner",
     "RunnerManager",
+    "RunnerAll",
+    "RunnerAllManager",
     "GroupRunner",
     "GroupRunnerManager",
     "ProjectRunner",
@@ -39,6 +41,7 @@ class RunnerJobManager(ListMixin, RESTManager):
 
 class Runner(SaveMixin, ObjectDeleteMixin, RESTObject):
     jobs: RunnerJobManager
+    _repr_attr = "description"
 
 
 class RunnerManager(CRUDMixin, RESTManager):
@@ -68,7 +71,7 @@ class RunnerManager(CRUDMixin, RESTManager):
             "maximum_timeout",
         ),
     )
-    _list_filters = ("scope", "tag_list")
+    _list_filters = ("scope", "type", "status", "paused", "tag_list")
     _types = {"tag_list": types.CommaSeparatedListAttribute}
 
     @cli.register_custom_action("RunnerManager", (), ("scope",))
@@ -119,6 +122,17 @@ class RunnerManager(CRUDMixin, RESTManager):
 
     def get(self, id: Union[str, int], lazy: bool = False, **kwargs: Any) -> Runner:
         return cast(Runner, super().get(id=id, lazy=lazy, **kwargs))
+
+
+class RunnerAll(RESTObject):
+    _repr_attr = "description"
+
+
+class RunnerAllManager(ListMixin, RESTManager):
+    _path = "/runners/all"
+    _obj_cls = RunnerAll
+    _list_filters = ("scope", "type", "status", "paused", "tag_list")
+    _types = {"tag_list": types.CommaSeparatedListAttribute}
 
 
 class GroupRunner(RESTObject):

--- a/tests/unit/objects/test_runners.py
+++ b/tests/unit/objects/test_runners.py
@@ -4,6 +4,7 @@ import pytest
 import responses
 
 import gitlab
+from gitlab.v4.objects.runners import Runner, RunnerAll
 
 runner_detail = {
     "active": True,
@@ -233,8 +234,18 @@ def test_group_runners_list(gl: gitlab.Gitlab, resp_get_runners_list):
     assert len(runners) == 1
 
 
-def test_all_runners_list(gl: gitlab.Gitlab, resp_get_runners_list):
+def test_runners_all(gl: gitlab.Gitlab, resp_get_runners_list):
     runners = gl.runners.all()
+    assert isinstance(runners[0], Runner)
+    assert runners[0].active is True
+    assert runners[0].id == 6
+    assert runners[0].name == "test-name"
+    assert len(runners) == 1
+
+
+def test_runners_all_list(gl: gitlab.Gitlab, resp_get_runners_list):
+    runners = gl.runners_all.list()
+    assert isinstance(runners[0], RunnerAll)
     assert runners[0].active is True
     assert runners[0].id == 6
     assert runners[0].name == "test-name"


### PR DESCRIPTION
Makes listing all runners (admin endpoint) possible via the CLI and fixes arguments that were being ignored in `runners.all()` by reusing our standard `list()` from the mixin instead. I haven't deprecated yet to give people time to change before warnings start to emit.

Closes https://github.com/python-gitlab/python-gitlab/issues/593
Replaces https://github.com/python-gitlab/python-gitlab/pull/2115