### PR TITLE
refactor: migrate services to integrations

### DIFF
--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -635,56 +635,56 @@ Delete a project hook::
     # or
     hook.delete()
 
-Project Services
-================
+Project Integrations
+====================
 
 Reference
 ---------
 
 * v4 API:
 
-  + :class:`gitlab.v4.objects.ProjectService`
-  + :class:`gitlab.v4.objects.ProjectServiceManager`
-  + :attr:`gitlab.v4.objects.Project.services`
+  + :class:`gitlab.v4.objects.ProjectIntegration`
+  + :class:`gitlab.v4.objects.ProjectIntegrationManager`
+  + :attr:`gitlab.v4.objects.Project.integrations`
 
-* GitLab API: https://docs.gitlab.com/ce/api/services.html
+* GitLab API: https://docs.gitlab.com/ce/api/integrations.html
 
 Examples
 ---------
 
 .. danger::
 
-    Since GitLab 13.12, ``get()`` calls to project services return a
+    Since GitLab 13.12, ``get()`` calls to project integrations return a
     ``404 Not Found`` response until they have been activated the first time.
 
     To avoid this, we recommend using `lazy=True` to prevent making
-    the initial call when activating new services unless they have
+    the initial call when activating new integrations unless they have
     previously already been activated.
 
-Configure and enable a service for the first time::
+Configure and enable an integration for the first time::
 
-    service = project.services.get('asana', lazy=True)
+    integration = project.integrations.get('asana', lazy=True)
 
-    service.api_key = 'randomkey'
-    service.save()
+    integration.api_key = 'randomkey'
+    integration.save()
 
-Get an existing service::
+Get an existing integration::
 
-    service = project.services.get('asana')
+    integration = project.integrations.get('asana')
     # display its status (enabled/disabled)
-    print(service.active)
+    print(integration.active)
 
-List active project services::
+List active project integrations::
 
-    service = project.services.list()
+    integration = project.integrations.list()
 
-List the code names of available services (doesn't return objects)::
+List the code names of available integrations (doesn't return objects)::
 
-    services = project.services.available()
+    integrations = project.integrations.available()
 
-Disable a service::
+Disable an integration::
 
-    service.delete()
+    integration.delete()
 
 File uploads
 ============

--- a/gitlab/v4/objects/__init__.py
+++ b/gitlab/v4/objects/__init__.py
@@ -44,6 +44,7 @@ from .geo_nodes import *
 from .group_access_tokens import *
 from .groups import *
 from .hooks import *
+from .integrations import *
 from .issues import *
 from .jobs import *
 from .keys import *
@@ -67,7 +68,6 @@ from .push_rules import *
 from .releases import *
 from .repositories import *
 from .runners import *
-from .services import *
 from .settings import *
 from .sidekiq import *
 from .snippets import *

--- a/gitlab/v4/objects/integrations.py
+++ b/gitlab/v4/objects/integrations.py
@@ -17,19 +17,23 @@ from gitlab.mixins import (
 )
 
 __all__ = [
+    "ProjectIntegration",
+    "ProjectIntegrationManager",
     "ProjectService",
     "ProjectServiceManager",
 ]
 
 
-class ProjectService(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectIntegration(SaveMixin, ObjectDeleteMixin, RESTObject):
     _id_attr = "slug"
 
 
-class ProjectServiceManager(GetMixin, UpdateMixin, DeleteMixin, ListMixin, RESTManager):
-    _path = "/projects/{project_id}/services"
+class ProjectIntegrationManager(
+    GetMixin, UpdateMixin, DeleteMixin, ListMixin, RESTManager
+):
+    _path = "/projects/{project_id}/integrations"
     _from_parent_attrs = {"project_id": "id"}
-    _obj_cls = ProjectService
+    _obj_cls = ProjectIntegration
 
     _service_attrs = {
         "asana": (("api_key",), ("restrict_to_branch", "push_events")),
@@ -263,10 +267,10 @@ class ProjectServiceManager(GetMixin, UpdateMixin, DeleteMixin, ListMixin, RESTM
 
     def get(
         self, id: Union[str, int], lazy: bool = False, **kwargs: Any
-    ) -> ProjectService:
-        return cast(ProjectService, super().get(id=id, lazy=lazy, **kwargs))
+    ) -> ProjectIntegration:
+        return cast(ProjectIntegration, super().get(id=id, lazy=lazy, **kwargs))
 
-    @cli.register_custom_action("ProjectServiceManager")
+    @cli.register_custom_action(("ProjectIntegrationManager", "ProjectServiceManager"))
     def available(self) -> List[str]:
         """List the services known by python-gitlab.
 
@@ -274,3 +278,16 @@ class ProjectServiceManager(GetMixin, UpdateMixin, DeleteMixin, ListMixin, RESTM
             The list of service code names.
         """
         return list(self._service_attrs.keys())
+
+
+class ProjectService(ProjectIntegration):
+    pass
+
+
+class ProjectServiceManager(ProjectIntegrationManager):
+    _obj_cls = ProjectService
+
+    def get(
+        self, id: Union[str, int], lazy: bool = False, **kwargs: Any
+    ) -> ProjectService:
+        return cast(ProjectService, super().get(id=id, lazy=lazy, **kwargs))

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -54,6 +54,7 @@ from .events import ProjectEventManager  # noqa: F401
 from .export_import import ProjectExportManager, ProjectImportManager  # noqa: F401
 from .files import ProjectFileManager  # noqa: F401
 from .hooks import ProjectHookManager  # noqa: F401
+from .integrations import ProjectIntegrationManager, ProjectServiceManager  # noqa: F401
 from .issues import ProjectIssueManager  # noqa: F401
 from .jobs import ProjectJobManager  # noqa: F401
 from .labels import ProjectLabelManager  # noqa: F401
@@ -79,7 +80,6 @@ from .push_rules import ProjectPushRulesManager  # noqa: F401
 from .releases import ProjectReleaseManager  # noqa: F401
 from .repositories import RepositoryMixin
 from .runners import ProjectRunnerManager  # noqa: F401
-from .services import ProjectServiceManager  # noqa: F401
 from .snippets import ProjectSnippetManager  # noqa: F401
 from .statistics import (  # noqa: F401
     ProjectAdditionalStatisticsManager,
@@ -178,6 +178,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
     groups: ProjectGroupManager
     hooks: ProjectHookManager
     imports: ProjectImportManager
+    integrations: ProjectIntegrationManager
     issues: ProjectIssueManager
     issues_statistics: ProjectIssuesStatisticsManager
     jobs: ProjectJobManager


### PR DESCRIPTION
Closes https://github.com/python-gitlab/python-gitlab/issues/1676.
Keeps services for now as they are still available via the API. Also gives people time to migrate before warnings are emitted.