### PR TITLE
test: fix broken test if user had config files

### DIFF
--- a/tests/unit/test_gitlab.py
+++ b/tests/unit/test_gitlab.py
@@ -20,6 +20,7 @@ import copy
 import logging
 import pickle
 from http.client import HTTPConnection
+from typing import List, Optional, Union
 
 import pytest
 import responses
@@ -300,7 +301,11 @@ def test_gitlab_from_config(default_config):
     gitlab.Gitlab.from_config("one", [config_path])
 
 
-def test_gitlab_from_config_without_files_raises():
+def test_gitlab_from_config_without_files_raises(monkeypatch):
+    def no_files(config_files: Optional[List[str]] = None) -> Union[str, List[str]]:
+        return []
+
+    monkeypatch.setattr(gitlab.config, "_get_config_files", no_files)
     with pytest.raises(GitlabConfigMissingError, match="non-existing"):
         gitlab.Gitlab.from_config("non-existing")
 


### PR DESCRIPTION
Use `monkeypatch` to ensure that no config files are reported for the
test.

Closes: #2172