### PR TITLE
test(ci): create a dummy ~/.python-gitlab.cfg file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,8 @@ jobs:
           python-version: ${{ matrix.python.version }}
       - name: Install dependencies
         run: pip3 install tox pytest-github-actions-annotate-failures
+      - name: Setup dummy config
+        run: tests/ci_tools/setup-dummy-config.sh
       - name: Run tests
         env:
           TOXENV: ${{ matrix.python.toxenv }}

--- a/tests/ci_tools/setup-dummy-config.sh
+++ b/tests/ci_tools/setup-dummy-config.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -u
+
+if [[ -z "${CI:-}" || -z "${GITHUB_ACTIONS:-}" ]]; then
+    echo "ERROR: Not running in the GitHub CI."
+    exit 2
+fi
+
+CONFIG_FILE=~/.python-gitlab.cfg
+if [[ -e "${CONFIG_FILE}" ]]; then
+    echo "ERROR: Config file already exists: ${CONFIG_FILE}"
+    echo "Saved you from destroying your config"
+    exit 2
+fi
+
+cat <<EOF >"${CONFIG_FILE}"
+[global]
+default = gitlab
+ssl_verify = true
+timeout = 5
+api_version = 4
+
+[gitlab]
+url = https://gitlab.com/
+private_token = not-a-valid-token
+EOF
+
+echo "Setup config at: ${CONFIG_FILE}"


### PR DESCRIPTION
Create a working ~/.python-gitlab.cfg file when running the unit
tests in the CI. This is to ensure our unit tests still work if a config file
exists.