### PR TITLE
feat(issues): add support for issue reorder API

### DIFF
--- a/docs/gl_objects/issues.rst
+++ b/docs/gl_objects/issues.rst
@@ -153,6 +153,10 @@ Move an issue to another project::
 
     issue.move(other_project_id)
 
+Reorder an issue on a board::
+
+    issue.reorder(move_after_id=2, move_before_id=3)
+
 Make an issue as todo::
 
     issue.todo()

--- a/gitlab/v4/objects/issues.py
+++ b/gitlab/v4/objects/issues.py
@@ -1,4 +1,4 @@
-from typing import Any, cast, Dict, Tuple, TYPE_CHECKING, Union
+from typing import Any, cast, Dict, Optional, Tuple, TYPE_CHECKING, Union
 
 from gitlab import cli
 from gitlab import exceptions as exc
@@ -136,6 +136,38 @@ class ProjectIssue(
         path = f"{self.manager.path}/{self.encoded_id}/move"
         data = {"to_project_id": to_project_id}
         server_data = self.manager.gitlab.http_post(path, post_data=data, **kwargs)
+        if TYPE_CHECKING:
+            assert isinstance(server_data, dict)
+        self._update_attrs(server_data)
+
+    @cli.register_custom_action("ProjectIssue", ("move_after_id", "move_before_id"))
+    @exc.on_http_error(exc.GitlabUpdateError)
+    def reorder(
+        self,
+        move_after_id: Optional[int] = None,
+        move_before_id: Optional[int] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Reorder an issue on a board.
+
+        Args:
+            move_after_id: ID of an issue that should be placed after this issue
+            move_before_id: ID of an issue that should be placed before this issue
+            **kwargs: Extra options to send to the server (e.g. sudo)
+
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabUpdateError: If the issue could not be reordered
+        """
+        path = f"{self.manager.path}/{self.encoded_id}/reorder"
+        data: Dict[str, Any] = {}
+
+        if move_after_id is not None:
+            data["move_after_id"] = move_after_id
+        if move_before_id is not None:
+            data["move_before_id"] = move_before_id
+
+        server_data = self.manager.gitlab.http_put(path, post_data=data, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(server_data, dict)
         self._update_attrs(server_data)

--- a/tests/unit/objects/test_issues.py
+++ b/tests/unit/objects/test_issues.py
@@ -42,6 +42,21 @@ def resp_get_issue():
 
 
 @pytest.fixture
+def resp_reorder_issue():
+    match_params = {"move_after_id": 2, "move_before_id": 3}
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.PUT,
+            url="http://localhost/api/v4/projects/1/issues/1/reorder",
+            json={"name": "name", "id": 1},
+            content_type="application/json",
+            status=200,
+            match=[responses.matchers.json_params_matcher(match_params)],
+        )
+        yield rsps
+
+
+@pytest.fixture
 def resp_issue_statistics():
     content = {"statistics": {"counts": {"all": 20, "closed": 5, "opened": 15}}}
 
@@ -68,6 +83,11 @@ def test_get_issue(gl, resp_get_issue):
     issue = gl.issues.get(1)
     assert issue.id == 1
     assert issue.name == "name"
+
+
+def test_reorder_issue(project, resp_reorder_issue):
+    issue = project.issues.get(1, lazy=True)
+    issue.reorder(move_after_id=2, move_before_id=3)
 
 
 def test_get_issues_statistics(gl, resp_issue_statistics):


### PR DESCRIPTION
Closes https://github.com/python-gitlab/python-gitlab/issues/1675.

At some point it might be nice to get rid of the explicit arguments here for the same reason as https://github.com/python-gitlab/python-gitlab/issues/1982.