### PR TITLE
test(functional): simplify token creation

### DIFF
--- a/tests/functional/fixtures/docker-compose.yml
+++ b/tests/functional/fixtures/docker-compose.yml
@@ -31,6 +31,12 @@ services:
         gitlab_exporter['enable'] = false
         grafana['enable'] = false
         letsencrypt['enable'] = false
+    entrypoint:
+      - /bin/sh
+      - -c
+      - chmod 644 /opt/gitlab/embedded/service/gitlab-rails/db/fixtures/production/* && /assets/wrapper
+    volumes:
+      - ${PWD}/tests/functional/fixtures/set_token.rb:/opt/gitlab/embedded/service/gitlab-rails/db/fixtures/production/003_set_token.rb
     ports:
       - '8080:80'
       - '2222:22'

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters = True
 envlist = py310,py39,py38,py37,flake8,black,twine-check,mypy,isort,cz,pylint
 
 [testenv]
-passenv = GITLAB_IMAGE GITLAB_TAG PY_COLORS NO_COLOR FORCE_COLOR DOCKER_HOST
+passenv = GITLAB_IMAGE GITLAB_TAG PY_COLORS NO_COLOR FORCE_COLOR DOCKER_HOST PWD
 setenv = VIRTUAL_ENV={envdir}
 whitelist_externals = true
 usedevelop = True


### PR DESCRIPTION
Inspired by discussions in https://github.com/python-gitlab/python-gitlab/pull/1778#discussion_r928321056, takes some of the docker stuff back into docker instead of writing to a file and executing it from the host.