### PR TITLE
test: attempt to make functional test startup more reliable

### DIFF
--- a/tests/functional/fixtures/docker-compose.yml
+++ b/tests/functional/fixtures/docker-compose.yml
@@ -32,6 +32,7 @@ services:
         grafana['enable'] = false
         letsencrypt['enable'] = false
         gitlab_rails['initial_license_file'] = '/python-gitlab-ci.gitlab-license'
+        gitlab_rails['monitoring_whitelist'] = ['0.0.0.0/0']
     entrypoint:
       - /bin/sh
       - -c


### PR DESCRIPTION
The functional tests have been erratic. Current theory is that we are
starting the tests before the GitLab container is fully up and
running.

  * Add checking of the Health Check[1] endpoints.
  * Add a 20 second delay after we believe it is up and running.
  * Increase timeout from 300 to 400 seconds

[1] https://docs.gitlab.com/ee/user/admin_area/monitoring/health_check.html

