### PR TITLE
chore: make code PEP597 compliant

### DIFF
--- a/gitlab/config.py
+++ b/gitlab/config.py
@@ -135,7 +135,7 @@ class GitlabConfigParser:
 
     def _parse_config(self) -> None:
         _config = configparser.ConfigParser()
-        _config.read(self._files)
+        _config.read(self._files, encoding="utf-8")
 
         if self.gitlab_id and not _config.has_section(self.gitlab_id):
             raise GitlabDataError(

--- a/tests/meta/test_v4_objects_imported.py
+++ b/tests/meta/test_v4_objects_imported.py
@@ -13,7 +13,7 @@ def test_verify_v4_objects_imported() -> None:
     assert len(gitlab.v4.objects.__path__) == 1
 
     init_files: Set[str] = set()
-    with open(gitlab.v4.objects.__file__, "r") as in_file:
+    with open(gitlab.v4.objects.__file__, "r", encoding="utf-8") as in_file:
         for line in in_file.readlines():
             if line.startswith("from ."):
                 init_files.add(line.rstrip())

--- a/tests/unit/objects/test_packages.py
+++ b/tests/unit/objects/test_packages.py
@@ -276,7 +276,7 @@ def test_delete_project_package_file_from_package_file_object(
 
 def test_upload_generic_package(tmp_path, project, resp_upload_generic_package):
     path = tmp_path / file_name
-    path.write_text(file_content)
+    path.write_text(file_content, encoding="utf-8")
     package = project.generic_packages.upload(
         package_name=package_name,
         package_version=package_version,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -290,7 +290,8 @@ def test_data_from_helper(m_open, monkeypatch, tmp_path):
             #!/bin/sh
             echo "secret"
             """
-        )
+        ),
+        encoding="utf-8",
     )
     helper.chmod(0o755)
 


### PR DESCRIPTION
Use `encoding="utf-8"` in `open()` and open-like functions.

https://peps.python.org/pep-0597/