### PR TITLE
chore: change `_repr_attr` for Project to be `path_with_namespace`

### DIFF
--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -155,7 +155,7 @@ class ProjectGroupManager(ListMixin, RESTManager):
 
 
 class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTObject):
-    _repr_attr = "path"
+    _repr_attr = "path_with_namespace"
 
     access_tokens: ProjectAccessTokenManager
     accessrequests: ProjectAccessRequestManager


### PR DESCRIPTION
Previously `_repr_attr` was `path` but that only gives the basename of
the path.  So https://gitlab.com/gitlab-org/gitlab would only show
"gitlab". Using `path_with_namespace` it will now show
"gitlab-org/gitlab"