### PR TITLE
fix(client): ensure encoded query params are never duplicated 

### DIFF
--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -20,6 +20,7 @@ import os
 import re
 import time
 from typing import Any, cast, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
+from urllib import parse
 
 import requests
 import requests.utils
@@ -677,10 +678,14 @@ class Gitlab:
             GitlabHttpError: When the return code is not 2xx
         """
         query_data = query_data or {}
-        url = self._build_url(path)
+        raw_url = self._build_url(path)
 
-        params: Dict[str, Any] = {}
+        # parse user-provided URL params to ensure we don't add our own duplicates
+        parsed = parse.urlparse(raw_url)
+        params = parse.parse_qs(parsed.query)
         utils.copy_dict(src=query_data, dest=params)
+
+        url = raw_url.replace(parsed.query, "").strip("?")
 
         # Deal with kwargs: by default a user uses kwargs to send data to the
         # gitlab server, but this generates problems (python keyword conflicts

--- a/tests/unit/test_gitlab_http_methods.py
+++ b/tests/unit/test_gitlab_http_methods.py
@@ -37,6 +37,24 @@ def test_http_request(gl):
 
 
 @responses.activate
+def test_http_request_with_url_encoded_kwargs_does_not_duplicate_params(gl):
+    url = "http://localhost/api/v4/projects?topics%5B%5D=python"
+    responses.add(
+        method=responses.GET,
+        url=url,
+        json=[{"name": "project1"}],
+        status=200,
+        match=[responses.matchers.query_param_matcher({"topics[]": "python"})],
+    )
+
+    kwargs = {"topics[]": "python"}
+    http_r = gl.http_request("get", "/projects?topics%5B%5D=python", **kwargs)
+    http_r.json()
+    assert http_r.status_code == 200
+    assert responses.assert_call_count(url, 1)
+
+
+@responses.activate
 def test_http_request_404(gl):
     url = "http://localhost/api/v4/not_there"
     responses.add(


### PR DESCRIPTION
Closes #2218 

This provides a small generic fix at the http_request level instead of messing even more with our own flows.

(I've always thought it was a bit weird that GitLab returns a lot of boilerplate query params in ther `next` header links, so I think this will also make other things more robust in the future).