### PR TITLE
chore(ci): bump semantic-release for fixed commit parser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
     - name: Python Semantic Release
-      uses: relekang/python-semantic-release@v7.28.1
+      uses: relekang/python-semantic-release@v7.31.2
       with:
         github_token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
         pypi_token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
I'd like to push a hotfix for #2219. I checked upstream and https://github.com/relekang/python-semantic-release/issues/442 has been fixed.

I looked at also adding a dry run on `main` - I'd prefer if it was close to the github-action they use, but they don't have a `--no-op` option there. So I need to add that upstream first.