### PR TITLE
feat(client): warn user on misconfigured URL in `auth()`

### DIFF
--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -1130,13 +1130,8 @@ class GitlabList:
         query_data = query_data or {}
         result = self._gl.http_request("get", url, query_data=query_data, **kwargs)
         try:
-            links = result.links
-            if links:
-                next_url = links["next"]["url"]
-            else:
-                next_url = requests.utils.parse_header_links(result.headers["links"])[
-                    0
-                ]["url"]
+            next_url = result.links["next"]["url"]
+
             # if the next url is different with user provided server URL
             # then give a warning it may because of misconfiguration
             # but if the option to fix provided then just reconstruct it

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -363,12 +363,14 @@ class Gitlab:
         return (None, None, None)
 
     def auth(self) -> None:
-        """Performs an authentication using private token.
+        """Performs an authentication using private token. Warns the user if a
+        potentially misconfigured URL is detected on the client or server side.
 
         The `user` attribute will hold a `gitlab.objects.CurrentUser` object on
         success.
         """
         self.user = self._objects.CurrentUserManager(self).get()
+        self._check_url(self.user.web_url, path=self.user.username)
 
     def version(self) -> Tuple[str, str]:
         """Returns the version and revision of the gitlab server.

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -576,6 +576,36 @@ class Gitlab:
             return path
         return f"{self._url}{path}"
 
+    def _check_url(self, url: Optional[str], *, path: str = "api") -> Optional[str]:
+        """
+        Checks if ``url`` starts with a different base URL from the user-provided base
+        URL and warns the user before returning it. If ``keep_base_url`` is set to
+        ``True``, instead returns the URL massaged to match the user-provided base URL.
+        """
+        if not url or url.startswith(self.url):
+            return url
+
+        match = re.match(rf"(^.*?)/{path}", url)
+        if not match:
+            return url
+
+        base_url = match.group(1)
+        if self.keep_base_url:
+            return url.replace(base_url, f"{self._base_url}")
+
+        utils.warn(
+            message=(
+                f"The base URL in the server response differs from the user-provided "
+                f"base URL ({self.url} -> {base_url}).\nThis is usually caused by a "
+                f"misconfigured base URL on your side or a misconfigured external_url "
+                f"on the server side, and can lead to broken pagination and unexpected "
+                f"behavior. If this is intentional, use `keep_base_url=True` when "
+                f"initializing the Gitlab instance to keep the user-provided base URL."
+            ),
+            category=UserWarning,
+        )
+        return url
+
     @staticmethod
     def _check_redirects(result: requests.Response) -> None:
         # Check the requests history to detect 301/302 redirections.
@@ -1131,34 +1161,10 @@ class GitlabList:
         result = self._gl.http_request("get", url, query_data=query_data, **kwargs)
         try:
             next_url = result.links["next"]["url"]
-
-            # if the next url is different with user provided server URL
-            # then give a warning it may because of misconfiguration
-            # but if the option to fix provided then just reconstruct it
-            if not next_url.startswith(self._gl.url):
-                search_api_url = re.search(r"(^.*?/api)", next_url)
-                if search_api_url:
-                    next_api_url = search_api_url.group(1)
-                    if self._gl.keep_base_url:
-                        next_url = next_url.replace(
-                            next_api_url, f"{self._gl._base_url}/api"
-                        )
-                    else:
-                        utils.warn(
-                            message=(
-                                f"The base URL in the server response"
-                                f"differs from the user-provided base URL "
-                                f"({self._gl.url}/api/ -> {next_api_url}/). "
-                                f"This may lead to unexpected behavior and  "
-                                f"broken pagination. Use `keep_base_url=True` "
-                                f"when initializing the Gitlab instance "
-                                f"to follow the user-provided base URL."
-                            ),
-                            category=UserWarning,
-                        )
-            self._next_url = next_url
         except KeyError:
-            self._next_url = None
+            next_url = None
+
+        self._next_url = self._gl._check_url(next_url)
         self._current_page: Optional[str] = result.headers.get("X-Page")
         self._prev_page: Optional[str] = result.headers.get("X-Prev-Page")
         self._next_page: Optional[str] = result.headers.get("X-Next-Page")

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -100,6 +100,7 @@ def test_private_token_overrides_job_token(
     # CLI first calls .auth() when private token is present
     resp_auth_with_token = copy.deepcopy(resp_get_project_with_token)
     resp_auth_with_token.update(url=f"{DEFAULT_URL}/api/v4/user")
+    resp_auth_with_token["json"].update(username="user", web_url=f"{DEFAULT_URL}/user")
 
     responses.add(**resp_get_project_with_token)
     responses.add(**resp_auth_with_token)


### PR DESCRIPTION
Closes https://github.com/python-gitlab/python-gitlab/issues/1978.

3 steps here:
* https://github.com/python-gitlab/python-gitlab/commit/7b61ae6a561ca39399e3feedbe9aa2a701ca8a1f removes a hack to handle gitlab's non-standard headers. That was only valid for 13.0 and fixed in 13.1 - super old now and I wouldn't say we're expected to support that.
* https://github.com/python-gitlab/python-gitlab/commit/31c9c2f00f49500de9c74c2eb3f7f06036521755 refactors the nested code out into a slightly more generic helper (that's where it should live anyway, as most of the attributes are from the Gitlab instance)
* https://github.com/python-gitlab/python-gitlab/commit/d71c1dbe349dca044bf9e236c937b2d4d6923d06 adds it to `auth()` so the user gets a warning ASAP.

Other than that I haven't changed any of the `str`/`None` handling to keep the `next_url` code the same in `_query`.