### PR TITLE
fix(client): do not assume user attrs returned for auth()

### DIFF
--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -355,7 +355,9 @@ class Gitlab:
         success.
         """
         self.user = self._objects.CurrentUserManager(self).get()
-        self._check_url(self.user.web_url, path=self.user.username)
+
+        if hasattr(self.user, "web_url") and hasattr(self.user, "username"):
+            self._check_url(self.user.web_url, path=self.user.username)
 
     def version(self) -> Tuple[str, str]:
         """Returns the version and revision of the gitlab server.


### PR DESCRIPTION
This is mostly relevant for people mocking the API in tests. The real API will always return these.