### PR TITLE
chore: fix issue if only run test_gitlab.py func test

### DIFF
--- a/tests/functional/api/test_gitlab.py
+++ b/tests/functional/api/test_gitlab.py
@@ -240,7 +240,11 @@ def test_list_all_false_nowarning(gl, recwarn):
 def test_list_all_true_nowarning(gl, get_all_kwargs, recwarn):
     """Using `get_all=True` will disable the warning"""
     items = gl.gitlabciymls.list(**get_all_kwargs)
-    assert not recwarn
+    for warn in recwarn:
+        if issubclass(warn.category, UserWarning):
+            # Our warning has a link to the docs in it, make sure we don't have
+            # that.
+            assert "python-gitlab.readthedocs.io" not in str(warn.message)
     assert len(items) > 20
 
 

--- a/tests/functional/api/test_gitlab.py
+++ b/tests/functional/api/test_gitlab.py
@@ -126,6 +126,7 @@ def test_hooks(gl):
 
 
 def test_namespaces(gl, get_all_kwargs):
+    gl.auth()
     current_user = gl.user.username
 
     namespaces = gl.namespaces.list(**get_all_kwargs)


### PR DESCRIPTION
Make it so can run just the test_gitlab.py functional test.

For example:
$ tox -e api_func_v4 -- -k test_gitlab.py