### PR TITLE
feat: Add reset_approvals api

### DIFF
--- a/docs/gl_objects/merge_requests.rst
+++ b/docs/gl_objects/merge_requests.rst
@@ -189,6 +189,10 @@ Attempt to rebase an MR::
 
     mr.rebase()
 
+Clear all approvals of a merge request (possible with project or group access tokens only)::
+
+    mr.reset_approvals()
+
 Get status of a rebase for an MR::
 
     mr = project.mergerequests.get(mr_id, include_rebase_in_progress=True)

--- a/gitlab/exceptions.py
+++ b/gitlab/exceptions.py
@@ -205,6 +205,10 @@ class GitlabMRRebaseError(GitlabOperationError):
     pass
 
 
+class GitlabMRResetApprovalError(GitlabOperationError):
+    pass
+
+
 class GitlabMRClosedError(GitlabOperationError):
     pass
 

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -328,6 +328,24 @@ class ProjectMergeRequest(
         return self.manager.gitlab.http_put(path, post_data=data, **kwargs)
 
     @cli.register_custom_action("ProjectMergeRequest")
+    @exc.on_http_error(exc.GitlabMRResetApprovalError)
+    def reset_approvals(
+        self, **kwargs: Any
+    ) -> Union[Dict[str, Any], requests.Response]:
+        """Clear all approvals of the merge request.
+
+        Args:
+            **kwargs: Extra options to send to the server (e.g. sudo)
+
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabMRResetApprovalError: If reset approval failed
+        """
+        path = f"{self.manager.path}/{self.encoded_id}/reset_approvals"
+        data: Dict[str, Any] = {}
+        return self.manager.gitlab.http_put(path, post_data=data, **kwargs)
+
+    @cli.register_custom_action("ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabGetError)
     def merge_ref(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Attempt to merge changes between source and target branches into

--- a/tests/functional/api/test_merge_requests.py
+++ b/tests/functional/api/test_merge_requests.py
@@ -117,6 +117,15 @@ def test_merge_request_rebase(project):
     assert mr.rebase()
 
 
+def test_merge_request_reset_approvals(gitlab_url, project):
+    bot = project.access_tokens.create({"name": "bot", "scopes": ["api"]})
+    bot_gitlab = gitlab.Gitlab(gitlab_url, private_token=bot.token)
+    bot_project = bot_gitlab.projects.get(project.id, lazy=True)
+
+    mr = bot_project.mergerequests.list()[0]
+    assert mr.reset_approvals()
+
+
 @pytest.mark.skip(reason="flaky test")
 def test_merge_request_merge(project):
     mr = project.mergerequests.list()[0]


### PR DESCRIPTION
Added the newly added reset_approvals merge request api.
https://docs.gitlab.com/ee/api/merge_requests.html#reset-approvals-of-a-merge-request

Signed-off-by: Lucas Zampieri <lzampier@redhat.com>