### PR TITLE
docs(api): Update `merge_requests.rst`: `mr_id` to `mr_iid`

### DIFF
--- a/docs/gl_objects/merge_requests.rst
+++ b/docs/gl_objects/merge_requests.rst
@@ -92,7 +92,7 @@ For example::
 
 Get a single MR::
 
-    mr = project.mergerequests.get(mr_id)
+    mr = project.mergerequests.get(mr_iid)
 
 Create a MR::
 
@@ -114,7 +114,7 @@ Change the state of a MR (close or reopen)::
 
 Delete a MR::
 
-    project.mergerequests.delete(mr_id)
+    project.mergerequests.delete(mr_iid)
     # or
     mr.delete()
 


### PR DESCRIPTION
Typo: Author probably meant `mr_iid` (i.e. project-specific MR ID)
and **not** `mr_id` (i.e. server-wide MR ID)

Closes: https://github.com/python-gitlab/python-gitlab/issues/2295

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>