### PR TITLE
fix: intermittent failure in test_merge_request_reset_approvals

### DIFF
--- a/tests/functional/api/test_merge_requests.py
+++ b/tests/functional/api/test_merge_requests.py
@@ -117,11 +117,12 @@ def test_merge_request_rebase(project):
     assert mr.rebase()
 
 
-def test_merge_request_reset_approvals(gitlab_url, project):
+def test_merge_request_reset_approvals(gitlab_url, project, wait_for_sidekiq):
     bot = project.access_tokens.create({"name": "bot", "scopes": ["api"]})
     bot_gitlab = gitlab.Gitlab(gitlab_url, private_token=bot.token)
     bot_project = bot_gitlab.projects.get(project.id, lazy=True)
 
+    wait_for_sidekiq(timeout=60)
     mr = bot_project.mergerequests.list()[0]
     assert mr.reset_approvals()
 

--- a/tests/functional/cli/test_cli_v4.py
+++ b/tests/functional/cli/test_cli_v4.py
@@ -252,7 +252,7 @@ def test_create_merge_request(gitlab_cli, project):
     assert ret.success
 
 
-def test_accept_request_merge(gitlab_cli, project):
+def test_accept_request_merge(gitlab_cli, project, wait_for_sidekiq):
     # MR needs at least 1 commit before we can merge
     mr = project.mergerequests.list()[0]
     file_data = {
@@ -263,6 +263,7 @@ def test_accept_request_merge(gitlab_cli, project):
     }
     project.files.create(file_data)
     time.sleep(2)
+    wait_for_sidekiq(timeout=60)
 
     cmd = [
         "project-merge-request",


### PR DESCRIPTION
Have been seeing intermittent failures in the test:
tests/functional/api/test_merge_requests.py::test_merge_request_reset_approvals

Also saw a failure in:
tests/functional/cli/test_cli_v4.py::test_accept_request_merge[subprocess]

Add a call to `wait_for_sidekiq()` to hopefully resolve the issues.