### PR TITLE
chore: update the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Python Gitlab Community Support
+    url: https://github.com/python-gitlab/python-gitlab/discussions
+    about: Please ask and answer questions here.
+  - name: 💬 Gitter Chat
+    url: https://gitter.im/python-gitlab/Lobby
+    about: Chat with devs and community

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,3 +1,12 @@
+---
+name: Issue report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
 ## Description of the problem, including code/CLI snippet
 
 


### PR DESCRIPTION
* Have an option to go to the discussions
* Have an option to go to the Gitter chat
* Move the bug/issue template into the .github/ISSUE_TEMPLATE/ directory