### PR TITLE
fix: use epic id instead of iid for epic notes

### DIFF
--- a/gitlab/v4/objects/notes.py
+++ b/gitlab/v4/objects/notes.py
@@ -49,9 +49,9 @@ class GroupEpicNote(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class GroupEpicNoteManager(CRUDMixin, RESTManager):
-    _path = "/groups/{group_id}/epics/{epic_iid}/notes"
+    _path = "/groups/{group_id}/epics/{epic_id}/notes"
     _obj_cls = GroupEpicNote
-    _from_parent_attrs = {"group_id": "group_id", "epic_iid": "iid"}
+    _from_parent_attrs = {"group_id": "group_id", "epic_id": "id"}
     _create_attrs = RequiredOptional(required=("body",), optional=("created_at",))
     _update_attrs = RequiredOptional(required=("body",))
 
@@ -68,11 +68,11 @@ class GroupEpicDiscussionNote(SaveMixin, ObjectDeleteMixin, RESTObject):
 class GroupEpicDiscussionNoteManager(
     GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
 ):
-    _path = "/groups/{group_id}/epics/{epic_iid}/discussions/{discussion_id}/notes"
+    _path = "/groups/{group_id}/epics/{epic_id}/discussions/{discussion_id}/notes"
     _obj_cls = GroupEpicDiscussionNote
     _from_parent_attrs = {
         "group_id": "group_id",
-        "epic_iid": "epic_iid",
+        "epic_id": "epic_id",
         "discussion_id": "id",
     }
     _create_attrs = RequiredOptional(required=("body",), optional=("created_at",))

--- a/tests/functional/ee-test.py
+++ b/tests/functional/ee-test.py
@@ -8,6 +8,7 @@ MR_P1 = 1
 I_P1 = 1
 I_P2 = 1
 EPIC_ISSUES = [4, 5]
+EPIC_NOTES = ["rubeus", "hagrid"]
 G1 = "group1"
 LDAP_CN = "app1"
 LDAP_PROVIDER = "ldapmain"
@@ -153,6 +154,12 @@ for i in EPIC_ISSUES:
 assert len(EPIC_ISSUES) == len(epic.issues.list())
 for ei in epic.issues.list():
     ei.delete()
+
+# epic notes
+assert not epic.notes.list()
+for i in EPIC_NOTES:
+    epic.notes.create({"body": i})
+assert len(EPIC_NOTES == len(epic.notes.list()))
 
 epic.delete()
 end_log()


### PR DESCRIPTION
fixes #2234
Corresponding GitLab issue: https://gitlab.com/gitlab-org/gitlab/-/issues/351656 

This PR also fixes the same issue related to epic discussion notes, GitLab API ref: https://docs.gitlab.com/ee/api/discussions.html#epics 