### PR TITLE
refactor: pytest-docker fixtures

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -12,6 +12,7 @@ import requests
 import gitlab
 import gitlab.base
 from tests.functional import helpers
+from tests.functional.fixtures.docker import *  # noqa
 
 SLEEP_TIME = 10
 
@@ -32,11 +33,6 @@ def gitlab_version(gl) -> GitlabVersion:
     version, revision = gl.version()
     major, minor, patch = version.split(".")
     return GitlabVersion(major=major, minor=minor, patch=patch, revision=revision)
-
-
-@pytest.fixture(scope="session")
-def docker_compose_command():
-    return "docker compose"
 
 
 @pytest.fixture(scope="session")
@@ -158,26 +154,6 @@ def pytest_addoption(parser):
 @pytest.fixture(scope="session")
 def temp_dir() -> pathlib.Path:
     return pathlib.Path(tempfile.gettempdir())
-
-
-@pytest.fixture(scope="session")
-def docker_compose_file(fixture_dir):
-    return fixture_dir / "docker-compose.yml"
-
-
-@pytest.fixture(scope="session")
-def docker_compose_project_name():
-    """Set a consistent project name to enable optional reuse of containers."""
-    return "pytest-python-gitlab"
-
-
-@pytest.fixture(scope="session")
-def docker_cleanup(request):
-    """Conditionally keep containers around by overriding the cleanup command."""
-    if request.config.getoption("--keep-containers"):
-        # Print version and exit.
-        return "-v"
-    return "down -v"
 
 
 @pytest.fixture(scope="session")

--- a/tests/functional/fixtures/docker.py
+++ b/tests/functional/fixtures/docker.py
@@ -1,0 +1,30 @@
+"""
+pytest-docker fixture overrides.
+See https://github.com/avast/pytest-docker#available-fixtures.
+"""
+import pytest
+
+
+@pytest.fixture(scope="session")
+def docker_compose_command():
+    return "docker compose"
+
+
+@pytest.fixture(scope="session")
+def docker_compose_project_name():
+    """Set a consistent project name to enable optional reuse of containers."""
+    return "pytest-python-gitlab"
+
+
+@pytest.fixture(scope="session")
+def docker_compose_file(fixture_dir):
+    return fixture_dir / "docker-compose.yml"
+
+
+@pytest.fixture(scope="session")
+def docker_cleanup(request):
+    """Conditionally keep containers around by overriding the cleanup command."""
+    if request.config.getoption("--keep-containers"):
+        # Print version and exit.
+        return "-v"
+    return "down -v"


### PR DESCRIPTION
Splitting out the pytest-docker fixtures from conftest.py file. 
At first I was thinking to gather those functions in conftest.py file and adding a starting and closing comment. 
On a second thought, moving those functions to a second fixtures file might make more sense.