### PR TITLE
refactor: pre-commit triggered from tox

### DIFF
--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -33,9 +33,7 @@ jobs:
       - uses: actions/setup-python@v4.3.0
         with:
           python-version: "3.10"
-      - name: Install pre-commit
-        run: pip install -r requirements-precommit.txt
-      - name: Run pre-commit install
-        run: pre-commit install
-      - name: pre-commit run all-files
-        run: pre-commit run --all-files
+      - name: install tox
+        run: pip install tox==3.26.0
+      - name: pre-commit
+        run: tox -e pre-commit

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 1.6
 skipsdist = True
 skip_missing_interpreters = True
-envlist = py310,py39,py38,py37,flake8,black,twine-check,mypy,isort,cz,pylint
+envlist = py310,py39,py38,py37,flake8,black,twine-check,mypy,isort,cz,pylint,pre-commit
 
 [testenv]
 passenv =
@@ -123,3 +123,8 @@ commands =
 [testenv:smoke]
 deps = -r{toxinidir}/requirements-test.txt
 commands = pytest tests/smoke {posargs}
+
+[testenv:pre-commit]
+skip_install = true
+deps = -r requirements-precommit.txt
+commands = pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
The project is using two liniting frameworks: tox and pre-commit.  Each has its own configuration files and a CI workflow. 
The purpose of this PR is to consolidate linting  into one framework: tox
Discussion -  #2321

This PR is a baby step towards a full transition