### PR TITLE
fix: remove `project.approvals.set_approvals()` method

### DIFF
--- a/docs/gl_objects/merge_request_approvals.rst
+++ b/docs/gl_objects/merge_request_approvals.rst
@@ -63,11 +63,6 @@ Change project-level or MR-level MR approvals settings::
     mr_mras.approvals_required = 1
     mr_mras.save()
 
-Change project-level MR allowed approvers::
-
-    project.approvals.set_approvers(approver_ids=[105],
-                                    approver_group_ids=[653, 654])
-
 Create a new MR-level approval rule or change an existing MR-level approval rule::
 
     mr.approvals.set_approvers(approvals_required = 1, approver_ids=[105],

--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -50,38 +50,6 @@ class ProjectApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
     def get(self, **kwargs: Any) -> ProjectApproval:
         return cast(ProjectApproval, super().get(**kwargs))
 
-    @exc.on_http_error(exc.GitlabUpdateError)
-    def set_approvers(
-        self,
-        approver_ids: Optional[List[int]] = None,
-        approver_group_ids: Optional[List[int]] = None,
-        **kwargs: Any,
-    ) -> Dict[str, Any]:
-        """Change project-level allowed approvers and approver groups.
-
-        Args:
-            approver_ids: User IDs that can approve MRs
-            approver_group_ids: Group IDs whose members can approve MRs
-
-        Raises:
-            GitlabAuthenticationError: If authentication is not correct
-            GitlabUpdateError: If the server failed to perform the request
-
-        Returns:
-            A dict value of the result
-        """
-        approver_ids = approver_ids or []
-        approver_group_ids = approver_group_ids or []
-
-        if TYPE_CHECKING:
-            assert self._parent is not None
-        path = f"/projects/{self._parent.encoded_id}/approvers"
-        data = {"approver_ids": approver_ids, "approver_group_ids": approver_group_ids}
-        result = self.gitlab.http_put(path, post_data=data, **kwargs)
-        if TYPE_CHECKING:
-            assert isinstance(result, dict)
-        return result
-
 
 class ProjectApprovalRule(SaveMixin, ObjectDeleteMixin, RESTObject):
     _id_attr = "id"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ disable = [
     "missing-class-docstring",
     "missing-function-docstring",
     "missing-module-docstring",
+    "not-callable",
     "protected-access",
     "redefined-builtin",
     "signature-differs",


### PR DESCRIPTION
The `project.approvals.set_approvals()` method used the
`/projects/:id/approvers` end point. That end point was removed from
GitLab in the 13.11 release, on 2-Apr-2021 in commit
27dc2f2fe81249bbdc25f7bd8fe799752aac05e6 via merge commit
e482597a8cf1bae8e27abd6774b684fb90491835. It was deprecated on
19-Aug-2019.

See merge request:
https://gitlab.com/gitlab-org/gitlab/-/merge_requests/57473