### PR TITLE
chore: add basic typing to functional tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
       - id: mypy
         args: []
         additional_dependencies:
+          - pytest==7.1.3
           - types-PyYAML==6.0.12
           - types-requests==2.28.11.2
           - types-setuptools==64.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,7 @@ repos:
         args: []
         additional_dependencies:
           - pytest==7.1.3
+          - responses==0.21.0
           - types-PyYAML==6.0.12
           - types-requests==2.28.11.2
           - types-setuptools==64.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
           - requests-toolbelt==0.9.1
         files: 'gitlab/'
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.961
+    rev: v0.981
     hooks:
       - id: mypy
         args: []

--- a/docs/api-usage-advanced.rst
+++ b/docs/api-usage-advanced.rst
@@ -161,3 +161,23 @@ parameter to that API invocation:
 
    gl = gitlab.gitlab(url, token, api_version=4)
    gl.projects.import_github(ACCESS_TOKEN, 123456, "root", timeout=120.0)
+
+Typing
+------
+
+Generally, ``python-gitlab`` is a fully typed package. However, currently you may still
+need to do some
+`type narrowing <https://mypy.readthedocs.io/en/stable/type_narrowing.html#type-narrowing>`_
+on your own, such as for nested API responses and ``Union`` return types. For example:
+
+.. code-block:: python
+
+   from typing import TYPE_CHECKING
+
+   import gitlab
+
+   gl = gitlab.gitlab(url, token, api_version=4)
+   license = gl.get_license()
+
+   if TYPE_CHECKING:
+      assert isinstance(license["plan"], str)

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -439,7 +439,7 @@ class Gitlab:
         return data["html"]
 
     @gitlab.exceptions.on_http_error(gitlab.exceptions.GitlabLicenseError)
-    def get_license(self, **kwargs: Any) -> Dict[str, Any]:
+    def get_license(self, **kwargs: Any) -> Dict[str, Union[str, Dict[str, str]]]:
         """Retrieve information about the current license.
 
         Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,13 +14,15 @@ module = [
     "docs.ext.*",
     "tests.functional.*",
     "tests.functional.api.*",
-    "tests.meta.*",
     "tests.unit.*",
 ]
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = "tests.smoke.*"
+module = [
+    "tests.meta.*",
+    "tests.smoke.*",
+]
 disable_error_code = ["no-untyped-def"]
 
 [tool.semantic_release]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,11 @@ files = "."
 exclude = "build/.*"
 strict = true
 
-[[tool.mypy.overrides]] # Overrides for currently untyped modules
+# Overrides for currently untyped modules
+[[tool.mypy.overrides]]
 module = [
     "docs.*",
     "docs.ext.*",
-    "tests.functional.api.*",
     "tests.unit.*",
 ]
 ignore_errors = true
@@ -20,6 +20,7 @@ ignore_errors = true
 [[tool.mypy.overrides]]
 module = [
     "tests.functional.*",
+    "tests.functional.api.*",
     "tests.meta.*",
     "tests.smoke.*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ strict = true
 module = [
     "docs.*",
     "docs.ext.*",
-    "tests.functional.*",
     "tests.functional.api.*",
     "tests.unit.*",
 ]
@@ -20,6 +19,7 @@ ignore_errors = true
 
 [[tool.mypy.overrides]]
 module = [
+    "tests.functional.*",
     "tests.meta.*",
     "tests.smoke.*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,9 @@ warn_unused_ignores = true
 module = [
     "docs.*",
     "docs.ext.*",
-    "tests.*",
     "tests.functional.*",
     "tests.functional.api.*",
+    "tests.meta.*",
     "tests.unit.*",
     "tests.smoke.*"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,24 +6,7 @@ order_by_type = false
 [tool.mypy]
 files = "."
 exclude = "build/.*"
-
-# 'strict = true' is equivalent to the following:
-check_untyped_defs = true
-disallow_any_generics = true
-disallow_incomplete_defs = true
-disallow_subclassing_any = true
-disallow_untyped_decorators = true
-disallow_untyped_defs = true
-no_implicit_optional = true
-no_implicit_reexport = true
-strict_equality = true
-warn_redundant_casts = true
-warn_return_any = true
-warn_unused_configs = true
-warn_unused_ignores = true
-
-# The following need to have changes made to be able to enable them:
-# disallow_untyped_calls = true
+strict = true
 
 [[tool.mypy.overrides]] # Overrides for currently untyped modules
 module = [
@@ -33,9 +16,12 @@ module = [
     "tests.functional.api.*",
     "tests.meta.*",
     "tests.unit.*",
-    "tests.smoke.*"
 ]
 ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "tests.smoke.*"
+disable_error_code = ["no-untyped-def"]
 
 [tool.semantic_release]
 branch = "main"

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -6,6 +6,7 @@ isort==5.10.1
 mypy==0.981
 pylint==2.15.3
 pytest==7.1.3
+responses==0.21.0
 types-PyYAML==6.0.12
 types-requests==2.28.11.2
 types-setuptools==65.5.0.1

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -8,4 +8,4 @@ pylint==2.15.3
 pytest==7.1.3
 types-PyYAML==6.0.12
 types-requests==2.28.11.2
-types-setuptools==64.0.1
+types-setuptools==65.5.0.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,18 @@
+import pathlib
+
+import _pytest.config
 import pytest
 
 import gitlab
 
 
 @pytest.fixture(scope="session")
-def test_dir(pytestconfig):
-    return pytestconfig.rootdir / "tests"
+def test_dir(pytestconfig: _pytest.config.Config) -> pathlib.Path:
+    return pytestconfig.rootdir / "tests"  # type: ignore
 
 
 @pytest.fixture(autouse=True)
-def mock_clean_config(monkeypatch):
+def mock_clean_config(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensures user-defined environment variables do not interfere with tests."""
     monkeypatch.delenv("PYTHON_GITLAB_CFG", raising=False)
     monkeypatch.delenv("GITLAB_PRIVATE_TOKEN", raising=False)
@@ -19,13 +22,13 @@ def mock_clean_config(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def default_files(monkeypatch):
+def default_files(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensures user configuration files do not interfere with tests."""
     monkeypatch.setattr(gitlab.config, "_DEFAULT_FILES", [])
 
 
 @pytest.fixture
-def valid_gitlab_ci_yml():
+def valid_gitlab_ci_yml() -> str:
     return """---
 :test_job:
   :script: echo 1
@@ -33,5 +36,5 @@ def valid_gitlab_ci_yml():
 
 
 @pytest.fixture
-def invalid_gitlab_ci_yml():
+def invalid_gitlab_ci_yml() -> str:
     return "invalid"

--- a/tests/functional/api/test_import_export.py
+++ b/tests/functional/api/test_import_export.py
@@ -45,7 +45,7 @@ def test_project_import_export(gl, project, temp_dir):
             raise Exception("Project export taking too much time")
 
     with open(temp_dir / "gitlab-export.tgz", "wb") as f:
-        export.download(streamed=True, action=f.write)
+        export.download(streamed=True, action=f.write)  # type: ignore[arg-type]
 
     output = gl.projects.import_project(
         open(temp_dir / "gitlab-export.tgz", "rb"),

--- a/tests/functional/api/test_keys.py
+++ b/tests/functional/api/test_keys.py
@@ -6,7 +6,7 @@ import base64
 import hashlib
 
 
-def key_fingerprint(key):
+def key_fingerprint(key: str) -> str:
     key_part = key.split()[1]
     decoded = base64.b64decode(key_part.encode("ascii"))
     digest = hashlib.sha256(decoded).digest()

--- a/tests/functional/api/test_merge_requests.py
+++ b/tests/functional/api/test_merge_requests.py
@@ -177,7 +177,7 @@ def test_merge_request_reset_approvals(gitlab_url, project, wait_for_sidekiq):
     bot_project = bot_gitlab.projects.get(project.id, lazy=True)
 
     wait_for_sidekiq(timeout=60)
-    mr = bot_project.mergerequests.list()[0]
+    mr = bot_project.mergerequests.list()[0]  # type: ignore[index]
     assert mr.reset_approvals()
 
 

--- a/tests/functional/api/test_projects.py
+++ b/tests/functional/api/test_projects.py
@@ -142,7 +142,7 @@ def test_project_forks(gl, project, user):
     assert fork_project.forked_from_project["id"] == project.id
 
     forks = project.forks.list()
-    assert fork.id in map(lambda fork_project: fork_project.id, forks)
+    assert fork.id in [fork_project.id for fork_project in forks]
 
 
 def test_project_hooks(project):

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -37,7 +37,7 @@ def gitlab_version(gl) -> GitlabVersion:
 
 
 @pytest.fixture(scope="session")
-def fixture_dir(test_dir) -> pathlib.Path:
+def fixture_dir(test_dir: pathlib.Path) -> pathlib.Path:
     return test_dir / "functional" / "fixtures"
 
 
@@ -56,7 +56,8 @@ def gitlab_container_name() -> str:
 
 @pytest.fixture(scope="session")
 def gitlab_docker_port(docker_services, gitlab_service_name: str) -> int:
-    return docker_services.port_for(service=gitlab_service_name, container_port=80)
+    port: int = docker_services.port_for(gitlab_service_name, container_port=80)
+    return port
 
 
 @pytest.fixture(scope="session")
@@ -114,7 +115,7 @@ def reset_gitlab(gl: gitlab.Gitlab) -> None:
             helpers.safe_delete(user, hard_delete=True)
 
 
-def set_token(container, fixture_dir):
+def set_token(container: str, fixture_dir: pathlib.Path) -> str:
     logging.info("Creating API token.")
     set_token_rb = fixture_dir / "set_token.rb"
 

--- a/tests/functional/helpers.py
+++ b/tests/functional/helpers.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 import pytest
 
@@ -19,8 +19,10 @@ def get_gitlab_plan(gl: gitlab.Gitlab) -> Optional[str]:
         license = gl.get_license()
     except gitlab.exceptions.GitlabLicenseError:
         # Without a license we assume only Free features are available
-        return
+        return None
 
+    if TYPE_CHECKING:
+        assert isinstance(license["plan"], str)
     return license["plan"]
 
 
@@ -34,7 +36,7 @@ def safe_delete(
     manager = object.manager
     for index in range(MAX_ITERATIONS):
         try:
-            object = manager.get(object.get_id())
+            object = manager.get(object.get_id())  # type: ignore[attr-defined]
         except gitlab.exceptions.GitlabGetError:
             return
 

--- a/tests/meta/test_ensure_type_hints.py
+++ b/tests/meta/test_ensure_type_hints.py
@@ -9,7 +9,7 @@ import functools
 import inspect
 from typing import Optional, Type
 
-import _pytest
+import pytest
 
 import gitlab.mixins
 import gitlab.v4.objects
@@ -19,7 +19,7 @@ import gitlab.v4.objects
 @dataclasses.dataclass(frozen=True)
 class ClassInfo:
     name: str
-    type: Type
+    type: Type  # type: ignore[type-arg]
 
     def __lt__(self, other: object) -> bool:
         if not isinstance(other, ClassInfo):
@@ -32,7 +32,7 @@ class ClassInfo:
         return (self.type.__module__, self.name) == (other.type.__module__, other.name)
 
 
-def pytest_generate_tests(metafunc: _pytest.python.Metafunc) -> None:
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     """Find all of the classes in gitlab.v4.objects and pass them to our test
     function"""
 
@@ -106,7 +106,7 @@ class TestTypeHints:
     def get_check_helper(
         self,
         *,
-        base_type: Type,
+        base_type: Type,  # type: ignore[type-arg]
         class_info: ClassInfo,
         method_template: str,
         optional_return: bool,

--- a/tests/smoke/test_dists.py
+++ b/tests/smoke/test_dists.py
@@ -18,9 +18,9 @@ WHEEL_FILE = (
 
 
 @pytest.fixture(scope="function")
-def build():
-    sandbox.run_setup("setup.py", ["--quiet", "clean", "--all"])
-    return sandbox.run_setup("setup.py", ["--quiet", "sdist", "bdist_wheel"])
+def build() -> None:
+    sandbox.run_setup("setup.py", ["--quiet", "clean", "--all"])  # type: ignore[no-untyped-call]
+    sandbox.run_setup("setup.py", ["--quiet", "sdist", "bdist_wheel"])  # type: ignore[no-untyped-call]
 
 
 def test_sdist_includes_tests(build):


### PR DESCRIPTION
Related to https://github.com/python-gitlab/python-gitlab/issues/2338.

This was going to be the start of adding a bit of pragmatic/non-pedantic typing to tests, not so much to type the test code itself, but to catch typing issues in our own package before it gets to users, and then gradually removing suppressions with fixes.

In the end I think it might do more damage than good to readability and productivity because of the amount of additional boilerplate for `test_*` functions needed for no gain (as some maintainers suggested in https://github.com/pytest-dev/pytest/issues/5981). Maybe with some kind of plugin this can be avoided in an elegant way. It might make sense to at least type fixtures when explicitly used in tests eventually.

But since I started something might as well open a PR (folders done in separate commits). I added some docs instead on narrowing in user code.