### PR TITLE
fix: `mr.cancel_merge_when_pipeline_succeeds()`

### DIFF
--- a/docs/gl_objects/merge_requests.rst
+++ b/docs/gl_objects/merge_requests.rst
@@ -122,8 +122,14 @@ Accept a MR::
 
     mr.merge()
 
-Cancel a MR when the build succeeds::
+Schedule a MR to merge after the pipeline(s) succeed::
 
+    mr.merge(merge_when_pipeline_succeeds=True)
+
+Cancel a MR from merging when the pipeline succeeds::
+
+    # Cancel a MR from being merged that had been previously set to
+    # 'merge_when_pipeline_succeeds=True'
     mr.cancel_merge_when_pipeline_succeeds()
 
 List commits of a MR::

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -165,9 +165,7 @@ class ProjectMergeRequest(
 
     @cli.register_custom_action("ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabMROnBuildSuccessError)
-    def cancel_merge_when_pipeline_succeeds(
-        self, **kwargs: Any
-    ) -> "ProjectMergeRequest":
+    def cancel_merge_when_pipeline_succeeds(self, **kwargs: Any) -> Dict[str, str]:
         """Cancel merge when the pipeline succeeds.
 
         Args:
@@ -179,17 +177,20 @@ class ProjectMergeRequest(
                 request
 
         Returns:
-            ProjectMergeRequest
+            dict of the parsed json returned by the server
         """
 
         path = (
             f"{self.manager.path}/{self.encoded_id}/cancel_merge_when_pipeline_succeeds"
         )
-        server_data = self.manager.gitlab.http_put(path, **kwargs)
+        server_data = self.manager.gitlab.http_post(path, **kwargs)
+        # 2022-10-30: The docs at
+        # https://docs.gitlab.com/ee/api/merge_requests.html#cancel-merge-when-pipeline-succeeds
+        # are incorrect in that the return value is actually just:
+        #   {'status': 'success'}  for a successful cancel.
         if TYPE_CHECKING:
             assert isinstance(server_data, dict)
-        self._update_attrs(server_data)
-        return ProjectMergeRequest(self.manager, server_data)
+        return server_data
 
     @cli.register_custom_action("ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabListError)


### PR DESCRIPTION
  * Call was incorrectly using a `PUT` method when should have used a `POST` method.
  * Changed return type to a `dict` as GitLab only returns {'status': 'success'} on success. Since the function didn't work previously, this should not impact anyone.
  * Updated the test fixture `merge_request` to add ability to create a pipeline.
  * Added functional test for `mr.cancel_merge_when_pipeline_succeeds()`

Fixes: #2349