### PR TITLE
fix(cli): expose missing mr_default_target_self project attribute

### DIFF
--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -740,6 +740,7 @@ class ProjectManager(CRUDMixin, RESTManager):
             "mirror_trigger_builds",
             "mirror_user_id",
             "mirror",
+            "mr_default_target_self",
             "name",
             "operations_access_level",
             "only_allow_merge_if_all_discussions_are_resolved",


### PR DESCRIPTION
Expose `mr_default_target_self` to the CLI.

Example::

   gitlab project update --id 616 --mr-default-target-self 1

References:

* https://gitlab.com/gitlab-org/gitlab/-/merge_requests/58093
* https://gitlab.com/gitlab-org/gitlab/-/blob/v13.11.0-ee/doc/user/project/merge_requests/creating_merge_requests.md#new-merge-request-from-a-fork
* https://gitlab.com/gitlab-org/gitlab/-/blob/v14.7.0-ee/doc/api/projects.md#get-single-project

 Closes #2360