### PR TITLE
feat(api): add support for getting a project's pull mirror details

### DIFF
--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -250,6 +250,10 @@ Start the pull mirroring process (EE edition)::
 
     project.mirror_pull()
 
+Get a project’s pull mirror details (EE edition)::
+
+    mirror_pull_details = project.mirror_pull_details()
+
 Import / Export
 ===============
 

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -579,6 +579,29 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
         path = f"/projects/{self.encoded_id}/mirror/pull"
         self.manager.gitlab.http_post(path, **kwargs)
 
+    @cli.register_custom_action("Project")
+    @exc.on_http_error(exc.GitlabGetError)
+    def mirror_pull_details(self, **kwargs: Any) -> Dict[str, Any]:
+        """Get a project's pull mirror details.
+
+        Introduced in GitLab 15.5.
+
+        Args:
+            **kwargs: Extra options to send to the server (e.g. sudo)
+
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabGetError: If the server failed to perform the request
+
+        Returns:
+            dict of the parsed json returned by the server
+        """
+        path = f"/projects/{self.encoded_id}/mirror/pull"
+        result = self.manager.gitlab.http_get(path, **kwargs)
+        if TYPE_CHECKING:
+            assert isinstance(result, dict)
+        return result
+
     @cli.register_custom_action("Project", ("to_namespace",))
     @exc.on_http_error(exc.GitlabTransferProjectError)
     def transfer(self, to_namespace: Union[int, str], **kwargs: Any) -> None:

--- a/tests/unit/objects/test_projects.py
+++ b/tests/unit/objects/test_projects.py
@@ -531,6 +531,27 @@ def resp_start_pull_mirroring_project():
 
 
 @pytest.fixture
+def resp_pull_mirror_details_project():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.GET,
+            url="http://localhost/api/v4/projects/1/mirror/pull",
+            json={
+                "id": 101486,
+                "last_error": None,
+                "last_successful_update_at": "2020-01-06T17:32:02.823Z",
+                "last_update_at": "2020-01-06T17:32:02.823Z",
+                "last_update_started_at": "2020-01-06T17:31:55.864Z",
+                "update_status": "finished",
+                "url": "https://*****:*****@gitlab.com/gitlab-org/security/gitlab.git",
+            },
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
+@pytest.fixture
 def resp_snapshot_project():
     with responses.RequestsMock() as rsps:
         rsps.add(
@@ -764,6 +785,12 @@ def test_transfer_project_deprecated_warns(project, resp_transfer_project):
 
 def test_project_pull_mirror(project, resp_start_pull_mirroring_project):
     project.mirror_pull()
+
+
+def test_project_pull_mirror_details(project, resp_pull_mirror_details_project):
+    details = project.mirror_pull_details()
+    assert details["last_error"] is None
+    assert details["update_status"] == "finished"
 
 
 def test_project_restore(project, resp_restore_project):


### PR DESCRIPTION
Add the ability to get a project's pull mirror details. This was added in GitLab 15.5 and is a PREMIUM feature.

https://docs.gitlab.com/ee/api/projects.html#get-a-projects-pull-mirror-details