### PR TITLE
feat(groups): add LDAP link manager and deprecate old API endpoints

### DIFF
--- a/docs/gl_objects/groups.rst
+++ b/docs/gl_objects/groups.rst
@@ -326,11 +326,22 @@ LDAP group links
 
 Add an LDAP group link to an existing GitLab group::
 
-    group.add_ldap_group_link(ldap_group_cn, gitlab.const.AccessLevel.DEVELOPER, 'ldapmain')
+    ldap_link = group.ldap_group_links.create({
+        'provider': 'ldapmain',
+        'group_access': gitlab.const.AccessLevel.DEVELOPER,
+        'cn: 'ldap_group_cn'
+    })
+
+List a group's LDAP group links:
+
+    group.ldap_group_links.list()
 
 Remove a link::
 
-    group.delete_ldap_group_link(ldap_group_cn, 'ldapmain')
+    ldap_link.delete()
+    # or by explicitly providing the CN or filter
+    group.ldap_group_links.delete(provider='ldapmain', cn='ldap_group_cn')
+    group.ldap_group_links.delete(provider='ldapmain', filter='(cn=Common Name)')
 
 Sync the LDAP groups::
 

--- a/tests/unit/objects/test_groups.py
+++ b/tests/unit/objects/test_groups.py
@@ -8,7 +8,7 @@ import pytest
 import responses
 
 import gitlab
-from gitlab.v4.objects import GroupDescendantGroup, GroupSubgroup
+from gitlab.v4.objects import GroupDescendantGroup, GroupLDAPGroupLink, GroupSubgroup
 from gitlab.v4.objects.projects import GroupProject, SharedProject
 
 content = {"name": "name", "id": 1, "path": "path"}
@@ -283,9 +283,9 @@ def test_list_group_descendant_groups(group, resp_list_subgroups_descendant_grou
 
 
 def test_list_ldap_group_links(group, resp_list_ldap_group_links):
-    ldap_group_links = group.list_ldap_group_links()
-    assert isinstance(ldap_group_links, list)
-    assert ldap_group_links[0]["provider"] == ldap_group_links_content[0]["provider"]
+    ldap_group_links = group.ldap_group_links.list()
+    assert isinstance(ldap_group_links[0], GroupLDAPGroupLink)
+    assert ldap_group_links[0].provider == ldap_group_links_content[0]["provider"]
 
 
 @pytest.mark.skip("GitLab API endpoint not implemented")


### PR DESCRIPTION
This builds on https://github.com/python-gitlab/python-gitlab/pull/2371.

I realized https://github.com/python-gitlab/python-gitlab/pull/1612 already did something similar and the `list()` `create()` `delete()` interface is more intuitive for the user.
Additionally, https://github.com/python-gitlab/python-gitlab/pull/2367 will bring in a similar interface for SAML.
And finally, the delete endpoints used in the current method are actually deprecated upstream, so good to move away from that on our side

https://docs.gitlab.com/ee/api/groups.html#delete-ldap-group-link (deprecated)
https://docs.gitlab.com/ee/api/groups.html#delete-ldap-group-link-with-cn-or-filter (new endpoint)