### PR TITLE
refactor: explicitly use ProjectSecureFile

### DIFF
--- a/docs/gl_objects/secure_files.rst
+++ b/docs/gl_objects/secure_files.rst
@@ -10,8 +10,8 @@ References
 
 * v4 API:
 
-  + :class:`gitlab.v4.objects.SecureFile`
-  + :class:`gitlab.v4.objects.SecureFileManager`
+  + :class:`gitlab.v4.objects.ProjectSecureFile`
+  + :class:`gitlab.v4.objects.ProjectSecureFileManager`
   + :attr:`gitlab.v4.objects.Project.secure_files`
 
 * GitLab API: https://docs.gitlab.com/ee/api/secure_files.html

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -82,7 +82,7 @@ from .push_rules import ProjectPushRulesManager  # noqa: F401
 from .releases import ProjectReleaseManager  # noqa: F401
 from .repositories import RepositoryMixin
 from .runners import ProjectRunnerManager  # noqa: F401
-from .secure_files import SecureFileManager  # noqa: F401
+from .secure_files import ProjectSecureFileManager  # noqa: F401
 from .snippets import ProjectSnippetManager  # noqa: F401
 from .statistics import (  # noqa: F401
     ProjectAdditionalStatisticsManager,
@@ -210,7 +210,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
     remote_mirrors: "ProjectRemoteMirrorManager"
     repositories: ProjectRegistryRepositoryManager
     runners: ProjectRunnerManager
-    secure_files: SecureFileManager
+    secure_files: ProjectSecureFileManager
     services: ProjectServiceManager
     snippets: ProjectSnippetManager
     storage: "ProjectStorageManager"

--- a/gitlab/v4/objects/secure_files.py
+++ b/gitlab/v4/objects/secure_files.py
@@ -13,11 +13,11 @@ from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import NoUpdateMixin, ObjectDeleteMixin
 from gitlab.types import FileAttribute, RequiredOptional
 
-__all__ = ["SecureFile", "SecureFileManager"]
+__all__ = ["ProjectSecureFile", "ProjectSecureFileManager"]
 
 
-class SecureFile(ObjectDeleteMixin, RESTObject):
-    @cli.register_custom_action("SecureFile")
+class ProjectSecureFile(ObjectDeleteMixin, RESTObject):
+    @cli.register_custom_action("ProjectSecureFile")
     @exc.on_http_error(exc.GitlabGetError)
     def download(
         self,
@@ -58,12 +58,14 @@ class SecureFile(ObjectDeleteMixin, RESTObject):
         )
 
 
-class SecureFileManager(NoUpdateMixin, RESTManager):
+class ProjectSecureFileManager(NoUpdateMixin, RESTManager):
     _path = "/projects/{project_id}/secure_files"
-    _obj_cls = SecureFile
+    _obj_cls = ProjectSecureFile
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(required=("name", "file"))
     _types = {"file": FileAttribute}
 
-    def get(self, id: Union[str, int], lazy: bool = False, **kwargs: Any) -> SecureFile:
-        return cast(SecureFile, super().get(id=id, lazy=lazy, **kwargs))
+    def get(
+        self, id: Union[str, int], lazy: bool = False, **kwargs: Any
+    ) -> ProjectSecureFile:
+        return cast(ProjectSecureFile, super().get(id=id, lazy=lazy, **kwargs))

--- a/tests/unit/objects/test_secure_files.py
+++ b/tests/unit/objects/test_secure_files.py
@@ -5,7 +5,7 @@ GitLab API: https://docs.gitlab.com/ee/api/secure_files.html
 import pytest
 import responses
 
-from gitlab.v4.objects import SecureFile
+from gitlab.v4.objects import ProjectSecureFile
 
 secure_file_content = {
     "id": 1,
@@ -93,7 +93,7 @@ def test_create_secure_file(project, resp_create_secure_file):
 def test_download_secure_file(project, binary_content, resp_download_secure_file):
     secure_file = project.secure_files.get(1)
     secure_content = secure_file.download()
-    assert isinstance(secure_file, SecureFile)
+    assert isinstance(secure_file, ProjectSecureFile)
     assert secure_content == binary_content
 
 


### PR DESCRIPTION
This builds on https://github.com/python-gitlab/python-gitlab/pull/2370. During review I suggested `secure_files` instead of `project_secure_files` for the attribute, but I think we maybe went a bit too far, so this is just in case we get `GroupSecureFile` functionality in the future. This way we don't need breaking changes in the future. Using `refactor` as we have no release yet so no need for changelog entry.