### PR TITLE
docs: Use the term "log file" for getting a job log file

### DIFF
--- a/docs/gl_objects/pipelines_and_jobs.rst
+++ b/docs/gl_objects/pipelines_and_jobs.rst
@@ -312,7 +312,7 @@ Delete the artifacts of a job::
 
     build_or_job.delete_artifacts()
 
-Get a job trace::
+Get a job log file / trace::
 
     build_or_job.trace()
 


### PR DESCRIPTION
The GitLab docs refer to it as a log file:
https://docs.gitlab.com/ee/api/jobs.html#get-a-log-file

"trace" is the endpoint name but not a common term people will think of for a "log file"