### PR TITLE
test(api): fix flaky test `test_cancel_merge_when_pipeline_succeeds`

### DIFF
--- a/tests/functional/api/test_merge_requests.py
+++ b/tests/functional/api/test_merge_requests.py
@@ -183,6 +183,7 @@ def test_merge_request_reset_approvals(gitlab_url, project, wait_for_sidekiq):
 
 def test_cancel_merge_when_pipeline_succeeds(project, merge_request, wait_for_sidekiq):
     mr = merge_request(source_branch="test_merge_request_merge", create_pipeline=True)
+    wait_for_sidekiq(timeout=60)
     # Set to merge when the pipeline succeeds, which should never happen
     mr.merge(merge_when_pipeline_succeeds=True)
     wait_for_sidekiq(timeout=60)


### PR DESCRIPTION
This is an attempt to fix the flaky test
`test_cancel_merge_when_pipeline_succeeds`.
Were seeing a: 405 Method Not Allowed error when setting the MR to
merge_when_pipeline_succeeds.

Closes: #2383