### PR TITLE
fix(cli): Enable debug before doing auth

### DIFF
--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -366,13 +366,12 @@ def main() -> None:
 
     try:
         gl = gitlab.Gitlab.merge_config(vars(options), gitlab_id, config_files)
+        if debug:
+            gl.enable_debug()
         if gl.private_token or gl.oauth_token:
             gl.auth()
     except Exception as e:
         die(str(e))
-
-    if debug:
-        gl.enable_debug()
 
     gitlab.v4.cli.run(
         gl, gitlab_resource, resource_action, args_dict, verbose, output, fields


### PR DESCRIPTION
Authentication issues are currently hard to debug since `--debug` only has effect after `gl.auth()` has been called.

For example, a 401 error is printed without any details about the actual HTTP request being sent:

    $ gitlab --debug --server-url https://gitlab.com current-user get
    401: 401 Unauthorized

By moving the call to `gl.enable_debug()` the usual debug logs get printed before the final error message.