### PR TITLE
feat: add keep_base_url when getting configuration from file

### DIFF
--- a/gitlab/config.py
+++ b/gitlab/config.py
@@ -108,6 +108,7 @@ class GitlabConfigParser:
         self.timeout: int = 60
         self.url: Optional[str] = None
         self.user_agent: str = USER_AGENT
+        self.keep_base_url: bool = False
 
         self._files = _get_config_files(config_files)
         if self._files:
@@ -232,6 +233,15 @@ class GitlabConfigParser:
             pass
         try:
             self.user_agent = _config.get(self.gitlab_id, "user_agent")
+        except _CONFIG_PARSER_ERRORS:
+            pass
+
+        try:
+            self.keep_base_url = _config.getboolean("global", "keep_base_url")
+        except _CONFIG_PARSER_ERRORS:
+            pass
+        try:
+            self.keep_base_url = _config.getboolean(self.gitlab_id, "keep_base_url")
         except _CONFIG_PARSER_ERRORS:
             pass
 


### PR DESCRIPTION
Hello,

## Context and problem

For the context, I'm creating myself a little tool to automate some things with our Gitlab instance. This instance has some "misconfiguration": it advertise a different domain name than the one we use to access it.

When developing my tool I used a gitlab token exposed as environment variable to authenticate to gitlab with the [gitlab.Gitlab class](https://python-gitlab.readthedocs.io/en/stable/api-usage.html#gitlab-gitlab-class) like this:

```python
gitlab.Gitlab(os.environ["GITLAB_URL"], os.environ["GITLAB_TOKEN"], keep_base_url=True)
```

As I said in the context section, our gitlab instance has some "misconfiguration" and I kept being warned about this by python-gitlab. I wanted to remove this so I used the `keep_base_url` flag as suggested by the warning.

When installing my tool system-wide I wanted to have a configuration file in my home directory. I did this by using the `gitlab.Gitlab.from_config` method. In my configuration file I added the keep_base_url but it was not working (the warning was here again).

## Solution

I saw that the from_config method did not have the keep_base_url argument, so this MR is here to add it. Tell me if you think of a better solution that I could implement :) 

## Next steps

This MR only add what I needed, but I think some work could be done to unify configuration from environment variable and configuration from file or maybe other sources. I don't know if the code already has this logic somewhere else, what do you think ?