### PR TITLE
feat: allow passing kwargs to Gitlab class when instantiating with `from_config`

### DIFF
--- a/docs/api-usage-advanced.rst
+++ b/docs/api-usage-advanced.rst
@@ -181,3 +181,15 @@ on your own, such as for nested API responses and ``Union`` return types. For ex
 
    if TYPE_CHECKING:
       assert isinstance(license["plan"], str)
+
+Custom session (Bring your own Session) 
+---------------------------------------
+
+You can use configuration files and a custom session to create 
+``gitlab.Gitlab`` objects:
+
+.. code-block:: python
+
+   gl = gitlab.Gitlab.from_config('somewhere', ['/tmp/gl.cfg'], session=custom_session)
+
+

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -232,13 +232,19 @@ class Gitlab:
 
     @classmethod
     def from_config(
-        cls, gitlab_id: Optional[str] = None, config_files: Optional[List[str]] = None
+        cls,
+        gitlab_id: Optional[str] = None,
+        config_files: Optional[List[str]] = None,
+        **kwargs: Any,
     ) -> "Gitlab":
         """Create a Gitlab connection from configuration files.
 
         Args:
             gitlab_id: ID of the configuration section.
             config_files list[str]: List of paths to configuration files.
+
+        kwargs:
+            session requests.Session: Custom requests Session
 
         Returns:
             A Gitlab connection.
@@ -264,6 +270,7 @@ class Gitlab:
             order_by=config.order_by,
             user_agent=config.user_agent,
             retry_transient_errors=config.retry_transient_errors,
+            **kwargs,
         )
 
     @classmethod

--- a/tests/functional/api/test_gitlab.py
+++ b/tests/functional/api/test_gitlab.py
@@ -1,4 +1,5 @@
 import pytest
+import requests
 
 import gitlab
 
@@ -21,6 +22,24 @@ def test_auth_from_config(gl, temp_dir):
     )
     test_gitlab.auth()
     assert isinstance(test_gitlab.user, gitlab.v4.objects.CurrentUser)
+
+
+def test_no_custom_session(gl, temp_dir):
+    """Test no custom session"""
+    custom_session = requests.Session()
+    test_gitlab = gitlab.Gitlab.from_config(
+        config_files=[temp_dir / "python-gitlab.cfg"]
+    )
+    assert test_gitlab.session != custom_session
+
+
+def test_custom_session(gl, temp_dir):
+    """Test custom session"""
+    custom_session = requests.Session()
+    test_gitlab = gitlab.Gitlab.from_config(
+        config_files=[temp_dir / "python-gitlab.cfg"], session=custom_session
+    )
+    assert test_gitlab.session == custom_session
 
 
 def test_broadcast_messages(gl, get_all_kwargs):

--- a/tests/unit/test_gitlab.py
+++ b/tests/unit/test_gitlab.py
@@ -4,6 +4,7 @@ import pickle
 from http.client import HTTPConnection
 
 import pytest
+import requests
 import responses
 
 import gitlab
@@ -412,3 +413,25 @@ def test_gitlab_keep_base_url(kwargs, link_header, expected_next_url, show_warni
     else:
         obj = gl.http_list("/tests", iterator=True)
     assert obj._next_url == expected_next_url
+
+
+def test_no_custom_session(default_config):
+    """Test no custom session"""
+
+    config_path = default_config
+    custom_session = requests.Session()
+    test_gitlab = gitlab.Gitlab.from_config("one", [config_path])
+
+    assert test_gitlab.session != custom_session
+
+
+def test_custom_session(default_config):
+    """Test custom session"""
+
+    config_path = default_config
+    custom_session = requests.Session()
+    test_gitlab = gitlab.Gitlab.from_config(
+        "one", [config_path], session=custom_session
+    )
+
+    assert test_gitlab.session == custom_session


### PR DESCRIPTION
This PR is needed for the validation of #2391