### PR TITLE
feat(files): allow decoding project files directly to string

### DIFF
--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -434,8 +434,11 @@ Get a file::
     # get the base64 encoded content
     print(f.content)
 
-    # get the decoded content
+    # get the decoded content as bytes
     print(f.decode())
+
+    # get the decoded content as a string
+    print(f.decode("utf-8"))
 
 Get file details from headers, without fetching its entire content::
 

--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -7,6 +7,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    overload,
     TYPE_CHECKING,
     Union,
 )
@@ -41,13 +42,30 @@ class ProjectFile(SaveMixin, ObjectDeleteMixin, RESTObject):
     file_path: str
     manager: "ProjectFileManager"
 
+    @overload
     def decode(self) -> bytes:
+        ...
+
+    @overload
+    def decode(self, encoding: None) -> bytes:
+        ...
+
+    @overload
+    def decode(self, encoding: str) -> str:
+        ...
+
+    def decode(self, encoding: Optional[str] = None) -> Union[bytes, str]:
         """Returns the decoded content of the file.
 
         Returns:
-            The decoded content.
+            The decoded content as bytes.
+            The decoded content as string if a valid encoding is provided.
         """
-        return base64.b64decode(self.content)
+        decoded_bytes = base64.b64decode(self.content)
+
+        if encoding is not None:
+            return decoded_bytes.decode(encoding)
+        return decoded_bytes
 
     # NOTE(jlvillal): Signature doesn't match SaveMixin.save() so ignore
     # type error

--- a/tests/functional/api/test_repository.py
+++ b/tests/functional/api/test_repository.py
@@ -36,9 +36,9 @@ def test_repository_files(project):
         }
     )
     readme = project.files.get(file_path="README.rst", ref="main")
-    # The first decode() is the ProjectFile method, the second one is the bytes
-    # object method
-    assert readme.decode().decode() == "Initial content"
+
+    assert readme.decode() == b"Initial content"
+    assert readme.decode("utf-8") == "Initial content"
 
     headers = project.files.head("README.rst", ref="main")
     assert headers["X-Gitlab-File-Path"] == "README.rst"


### PR DESCRIPTION
Provides a slightly less clunky interface so people don't need to do `f.decode.().decode("utf-8")` in user code.