### PR TITLE
fix: Use the ProjectIterationManager within the Project object

### DIFF
--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -57,7 +57,7 @@ from .hooks import ProjectHookManager  # noqa: F401
 from .integrations import ProjectIntegrationManager, ProjectServiceManager  # noqa: F401
 from .invitations import ProjectInvitationManager  # noqa: F401
 from .issues import ProjectIssueManager  # noqa: F401
-from .iterations import GroupIterationManager  # noqa: F401
+from .iterations import ProjectIterationManager  # noqa: F401
 from .jobs import ProjectJobManager  # noqa: F401
 from .labels import ProjectLabelManager  # noqa: F401
 from .members import ProjectMemberAllManager, ProjectMemberManager  # noqa: F401
@@ -187,7 +187,7 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
     invitations: ProjectInvitationManager
     issues: ProjectIssueManager
     issues_statistics: ProjectIssuesStatisticsManager
-    iterations: GroupIterationManager
+    iterations: ProjectIterationManager
     jobs: ProjectJobManager
     keys: ProjectKeyManager
     labels: ProjectLabelManager


### PR DESCRIPTION
The Project object was previously using the GroupIterationManager resulting in the incorrect API endpoint being used. Utilize the correct ProjectIterationManager instead.

Resolves #2403