### PR TITLE
fix(api): Make description optional for releases

### DIFF
--- a/gitlab/v4/objects/releases.py
+++ b/gitlab/v4/objects/releases.py
@@ -23,7 +23,7 @@ class ProjectReleaseManager(CRUDMixin, RESTManager):
     _obj_cls = ProjectRelease
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(
-        required=("tag_name", "description"), optional=("name", "ref", "assets")
+        required=("tag_name",), optional=("name", "description", "ref", "assets")
     )
     _list_filters = (
         "order_by",


### PR DESCRIPTION
For the Release API Endpoint `description` is not a required attribute, see https://docs.gitlab.com/14.10/ee/api/releases/#create-a-release