### PR TITLE
refactor: migrating timeout from client to http_backend

### DIFF
--- a/gitlab/http_backends/requests_backend.py
+++ b/gitlab/http_backends/requests_backend.py
@@ -4,9 +4,18 @@ import requests
 
 
 class RequestsBackend:
-    def __init__(self, session: Optional[requests.Session] = None) -> None:
+    def __init__(
+        self,
+        session: Optional[requests.Session] = None,
+        timeout: Optional[float] = None,
+    ) -> None:
         self._client: requests.Session = session or requests.Session()
+        self._timeout: Optional[float] = timeout
 
     @property
     def client(self) -> requests.Session:
         return self._client
+
+    @property
+    def timeout(self) -> Optional[float]:
+        return self._timeout

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -1061,8 +1061,8 @@ class ProjectManager(CRUDMixin, RESTManager):
             data["target_namespace"] = target_namespace
         if (
             "timeout" not in kwargs
-            or self.gitlab.timeout is None
-            or self.gitlab.timeout < 60.0
+            or self.gitlab.http_backend.timeout is None
+            or self.gitlab.http_backend.timeout < 60.0
         ):
             # Ensure that this HTTP request has a longer-than-usual default timeout
             # The base gitlab object tends to have a default that is <10 seconds,
@@ -1135,8 +1135,8 @@ class ProjectManager(CRUDMixin, RESTManager):
             data["new_name"] = new_name
         if (
             "timeout" not in kwargs
-            or self.gitlab.timeout is None
-            or self.gitlab.timeout < 60.0
+            or self.gitlab.http_backend.timeout is None
+            or self.gitlab.http_backend.timeout < 60.0
         ):
             # Ensure that this HTTP request has a longer-than-usual default timeout
             # The base gitlab object tends to have a default that is <10 seconds,

--- a/tests/unit/test_gitlab.py
+++ b/tests/unit/test_gitlab.py
@@ -435,3 +435,22 @@ def test_custom_session(default_config):
     )
 
     assert test_gitlab.session == custom_session
+
+
+def test_no_custom_timeout(default_config):
+    """Test no custom session"""
+
+    config_path = default_config
+    test_gitlab = gitlab.Gitlab.from_config("one", [config_path])
+
+    assert test_gitlab.http_backend.timeout is None
+
+
+@pytest.mark.parametrize("timeout", [(10.0), (60.0), (100.0)])
+def test_custom_timeout(default_config, timeout):
+    """Test custom session"""
+
+    config_path = default_config
+    test_gitlab = gitlab.Gitlab.from_config("one", [config_path], timeout=timeout)
+
+    assert test_gitlab.http_backend.timeout == timeout


### PR DESCRIPTION
@nejch The PR is ready for review but I'm not sure the functional tests cover this change. LMK if you think that adding functional tests might be of help.