### PR TITLE
feat(client): replace basic auth with OAuth ROPC flow

### DIFF
--- a/docs/api-usage.rst
+++ b/docs/api-usage.rst
@@ -84,14 +84,32 @@ Note on password authentication
 
 GitLab has long removed password-based basic authentication. You can currently still use the
 `resource owner password credentials <https://docs.gitlab.com/ee/api/oauth2.html#resource-owner-password-credentials-flow>`_
-flow to obtain an OAuth token.
+flow and python-gitlab will obtain an OAuth token for you when instantiated.
 
 However, we do not recommend this as it will not work with 2FA enabled, and GitLab is removing
-ROPC-based flows without client IDs in a future release. We recommend you obtain tokens for
-automated workflows as linked above or obtain a session cookie from your browser.
+ROPC-based flows without client credentials in a future release. We recommend you obtain tokens for
+automated workflows.
 
-For a python example of password authentication using the ROPC-based OAuth2
-flow, see `this Ansible snippet <https://github.com/ansible-collections/community.general/blob/1c06e237c8100ac30d3941d5a3869a4428ba2974/plugins/module_utils/gitlab.py#L86-L92>`_.
+.. code-block:: python
+
+   import gitlab
+   from gitlab.oauth import PasswordCredentials
+
+   oauth_credentials = PasswordCredentials("username", "password")
+   gl = gitlab.Gitlab(oauth_credentials=oauth_credentials)
+
+   # Define a specific OAuth scope
+   oauth_credentials = PasswordCredentials("username", "password", scope="read_api")
+   gl = gitlab.Gitlab(oauth_credentials=oauth_credentials)
+
+   # Use with client credentials
+   oauth_credentials = PasswordCredentials(
+      "username",
+      "password",
+      client_id="your-client-id",
+      client_secret="your-client-secret",
+   )
+   gl = gitlab.Gitlab(oauth_credentials=oauth_credentials)
 
 Managers
 ========

--- a/docs/cli-usage.rst
+++ b/docs/cli-usage.rst
@@ -168,8 +168,7 @@ We recommend that you use `Credential helpers`_ to securely store your tokens.
        <https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html>`__
        to learn how to obtain a token.
    * - ``oauth_token``
-     - An Oauth token for authentication. The Gitlab server must be configured
-       to support this authentication method.
+     - An Oauth token for authentication.
    * - ``job_token``
      - Your job token. See `the official documentation
        <https://docs.gitlab.com/ce/api/jobs.html#get-job-artifacts>`__

--- a/gitlab/oauth.py
+++ b/gitlab/oauth.py
@@ -1,0 +1,33 @@
+import dataclasses
+from typing import Optional
+
+
+@dataclasses.dataclass
+class PasswordCredentials:
+    """
+    Resource owner password credentials modelled according to
+    https://docs.gitlab.com/ee/api/oauth2.html#resource-owner-password-credentials-flow
+    https://datatracker.ietf.org/doc/html/rfc6749#section-4-3.
+
+    If the GitLab server has disabled the ROPC flow without client credentials,
+    client_id and client_secret must be provided.
+    """
+
+    username: str
+    password: str
+    grant_type: str = "password"
+    scope: str = "api"
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        basic_auth = (self.client_id, self.client_secret)
+
+        if not any(basic_auth):
+            self.basic_auth = None
+            return
+
+        if not all(basic_auth):
+            raise TypeError("Both client_id and client_secret must be defined")
+
+        self.basic_auth = basic_auth

--- a/tests/functional/api/test_gitlab.py
+++ b/tests/functional/api/test_gitlab.py
@@ -2,6 +2,7 @@ import pytest
 import requests
 
 import gitlab
+from gitlab.oauth import PasswordCredentials
 
 
 @pytest.fixture(
@@ -18,6 +19,13 @@ def get_all_kwargs(request):
 def test_auth_from_config(gl, gitlab_config, temp_dir):
     """Test token authentication from config file"""
     test_gitlab = gitlab.Gitlab.from_config(config_files=[gitlab_config])
+    test_gitlab.auth()
+    assert isinstance(test_gitlab.user, gitlab.v4.objects.CurrentUser)
+
+
+def test_auth_with_ropc_flow(gl, temp_dir):
+    oauth_credentials = PasswordCredentials("root", "5iveL!fe")
+    test_gitlab = gitlab.Gitlab(gl.url, oauth_credentials=oauth_credentials)
     test_gitlab.auth()
     assert isinstance(test_gitlab.user, gitlab.v4.objects.CurrentUser)
 

--- a/tests/unit/test_oauth.py
+++ b/tests/unit/test_oauth.py
@@ -1,0 +1,27 @@
+import pytest
+
+from gitlab.oauth import PasswordCredentials
+
+
+def test_password_credentials_without_password_raises():
+    with pytest.raises(TypeError, match="missing 1 required positional argument"):
+        PasswordCredentials("username")
+
+
+def test_password_credentials_with_client_id_without_client_secret_raises():
+    with pytest.raises(TypeError, match="client_id and client_secret must be defined"):
+        PasswordCredentials(
+            "username",
+            "password",
+            client_id="abcdef123456",
+        )
+
+
+def test_password_credentials_with_client_credentials_sets_basic_auth():
+    credentials = PasswordCredentials(
+        "username",
+        "password",
+        client_id="abcdef123456",
+        client_secret="123456abcdef",
+    )
+    assert credentials.basic_auth == ("abcdef123456", "123456abcdef")


### PR DESCRIPTION
Small step towards https://github.com/python-gitlab/python-gitlab/issues/1195, and also to get rid of the old username/password auth.

Also gets rid of the requests-specific `HTTPBasicAuth`.