### PR TITLE
fix: change return value to "None" in case getattr returns None

### DIFF
--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -490,7 +490,7 @@ class LegacyPrinter:
                 id = getattr(obj, obj._id_attr)
                 print(f"{obj._id_attr.replace('_', '-')}: {id}")
             if obj._repr_attr:
-                value = getattr(obj, obj._repr_attr, "None")
+                value = getattr(obj, obj._repr_attr, "None") or "None"
                 value = value.replace("\r", "").replace("\n", " ")
                 # If the attribute is a note (ProjectCommitComment) then we do
                 # some modifications to fit everything on one line


### PR DESCRIPTION
It is quite similar to issue #1425 , even though getattr call already provides default value.

It fixed following error:

```
gitlab -c gitlab.cfg user-event list --user-id 292
target_title: iozone

Traceback (most recent call last):
  File "~/miniforge3/bin/gitlab", line 8, in <module>
    sys.exit(main())
  File "~/miniforge3/lib/python3.9/site-packages/gitlab/cli.py", line 376, in main
    gitlab.v4.cli.run(
  File "~/miniforge3/lib/python3.9/site-packages/gitlab/v4/cli.py", line 549, in run
    printer.display_list(data, fields, verbose=verbose)
  File "~/miniforge3/lib/python3.9/site-packages/gitlab/v4/cli.py", line 512, in display_list
    self.display(get_dict(obj, fields), verbose=verbose, obj=obj)
  File "~/miniforge3/lib/python3.9/site-packages/gitlab/v4/cli.py", line 494, in display
    value = value.replace("\r", "").replace("\n", " ")
AttributeError: 'NoneType' object has no attribute 'replace'
```