### PR TITLE
ci: Complete all unit tests even if one has failed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
   unit:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python:


### PR DESCRIPTION
There are cases where unit tests are failing for a specific python version but not for all