### PR TITLE
chore: remove tox `envdir` values

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,42 +28,36 @@ commands =
 
 [testenv:black]
 basepython = python3
-envdir={toxworkdir}/lint
 deps = -r{toxinidir}/requirements-lint.txt
 commands =
   black {posargs} .
 
 [testenv:isort]
 basepython = python3
-envdir={toxworkdir}/lint
 deps = -r{toxinidir}/requirements-lint.txt
 commands =
   isort {posargs} {toxinidir}
 
 [testenv:mypy]
 basepython = python3
-envdir={toxworkdir}/lint
 deps = -r{toxinidir}/requirements-lint.txt
 commands =
   mypy {posargs}
 
 [testenv:flake8]
 basepython = python3
-envdir={toxworkdir}/lint
 deps = -r{toxinidir}/requirements-lint.txt
 commands =
   flake8 {posargs} .
 
 [testenv:pylint]
 basepython = python3
-envdir={toxworkdir}/lint
 deps = -r{toxinidir}/requirements-lint.txt
 commands =
   pylint {posargs} gitlab/
 
 [testenv:cz]
 basepython = python3
-envdir={toxworkdir}/lint
 deps = -r{toxinidir}/requirements-lint.txt
 commands =
   cz check --rev-range 65ecadc..HEAD  # cz is fast, check from first valid commit


### PR DESCRIPTION
tox > 4 no longer will re-use the tox directory :(  What this means is that with the previous config if you ran:
    $ tox -e mypy; tox -e isort; tox -e mypy
It would recreate the tox environment each time :(

By removing the `envdir` values it will have the tox environments in separate directories and not recreate them.

The have an FAQ entry about this:
https://tox.wiki/en/latest/upgrading.html#re-use-of-environments