### PR TITLE
fix(client): regression - do not automatically get_next if page=# and iterator=True/as_list=False are used

### DIFF
--- a/docs/api-usage.rst
+++ b/docs/api-usage.rst
@@ -393,6 +393,9 @@ The generator exposes extra listing information as received from the server:
    Prior to python-gitlab 3.6.0 the argument ``as_list`` was used instead of
    ``iterator``.  ``as_list=False`` is the equivalent of ``iterator=True``.
 
+.. note::
+   If ``page`` and ``iterator=True`` are used together, the latter is ignored.
+
 Sudo
 ====
 

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -929,7 +929,7 @@ class Gitlab:
 
         page = kwargs.get("page")
 
-        if iterator:
+        if iterator and page is None:
             # Generator requested
             return GitlabList(self, url, query_data, **kwargs)
 

--- a/tests/unit/test_gitlab_http_methods.py
+++ b/tests/unit/test_gitlab_http_methods.py
@@ -542,6 +542,18 @@ def test_list_request(gl):
     assert responses.assert_call_count(url, 3) is True
 
 
+@responses.activate
+def test_list_request_page_and_iterator(gl):
+    response_dict = copy.deepcopy(large_list_response)
+    response_dict["match"] = [responses.matchers.query_param_matcher({"page": "1"})]
+    responses.add(**response_dict)
+
+    result = gl.http_list("/projects", iterator=True, page=1)
+    assert isinstance(result, list)
+    assert len(result) == 20
+    assert len(responses.calls) == 1
+
+
 large_list_response = {
     "method": responses.GET,
     "url": "http://localhost/api/v4/projects",


### PR DESCRIPTION
This fix a regression introduced on commit
https://github.com/python-gitlab/python-gitlab/commit/1339d645ce58a2e1198b898b9549ba5917b1ff12
(cc @JohnVillalovos)

If page is used, then get_next should be false.

This was found on the mesa ci project, after upgrading the python-gitlab version, the script that monitors the ci was getting killed by consuming too much memory.