### PR TITLE
chore: add Python 3.12 testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,8 @@ jobs:
             toxenv: py310,smoke
           - version: "3.11"
             toxenv: py311,smoke
+          - version: '3.12.0-alpha - 3.12' # SemVer's version range syntax
+            toxenv: py312,smoke
         include:
           - os: macos-latest
             python:


### PR DESCRIPTION
Add a unit test for Python 3.12. This will use the latest version of Python 3.12 that is available from
https://github.com/actions/python-versions/

At this time it is 3.12.0-alpha.4 but will move forward over time until the final 3.12 release and updates. So 3.12.0, 3.12.1, ... will be matched.