### PR TITLE
feat(cli): add setting of `allow_force_push` for protected branch

### DIFF
--- a/gitlab/v4/objects/branches.py
+++ b/gitlab/v4/objects/branches.py
@@ -42,6 +42,7 @@ class ProjectProtectedBranchManager(NoUpdateMixin, RESTManager):
             "push_access_level",
             "merge_access_level",
             "unprotect_access_level",
+            "allow_force_push",
             "allowed_to_push",
             "allowed_to_merge",
             "allowed_to_unprotect",


### PR DESCRIPTION
For the CLI: add `allow_force_push` as an optional argument for creating a protected branch.

API reference:
https://docs.gitlab.com/ee/api/protected_branches.html#protect-repository-branches

Closes: #2466