### PR TITLE
chore: remove `pre-commit` as a default `tox` environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 1.6
 skipsdist = True
 skip_missing_interpreters = True
-envlist = py310,py39,py38,py37,flake8,black,twine-check,mypy,isort,cz,pylint,pre-commit
+envlist = py310,py39,py38,py37,flake8,black,twine-check,mypy,isort,cz,pylint
 
 [testenv]
 passenv =


### PR DESCRIPTION
For users who use `tox` having `pre-commit` as part of the default
environment list is redundant as it will run the same tests again that
are being run in other environments. For example: black, flake8,
pylint, and more.