### PR TITLE
fix(cli): display items when iterator is returned

### DIFF
--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -547,6 +547,8 @@ def run(
         printer.display(data, verbose=True, obj=data)
     elif isinstance(data, list):
         printer.display_list(data, fields, verbose=verbose)
+    elif isinstance(data, gitlab.base.RESTObjectList):
+        printer.display_list(list(data), fields, verbose=verbose)
     elif isinstance(data, gitlab.base.RESTObject):
         printer.display(get_dict(data, fields), verbose=verbose, obj=data)
     elif isinstance(data, str):

--- a/tests/functional/cli/test_cli_repository.py
+++ b/tests/functional/cli/test_cli_repository.py
@@ -49,6 +49,21 @@ def test_list_all_commits(gitlab_cli, project):
     assert len(ret_all.stdout) > len(ret.stdout)
 
 
+def test_list_merge_request_commits(gitlab_cli, merge_request, project):
+    cmd = [
+        "project-merge-request",
+        "commits",
+        "--project-id",
+        project.id,
+        "--iid",
+        merge_request.iid,
+    ]
+
+    ret = gitlab_cli(cmd)
+    assert ret.success
+    assert ret.stdout
+
+
 def test_commit_merge_requests(gitlab_cli, project, merge_request, wait_for_sidekiq):
     """This tests the `project-commit merge-requests` command and also tests
     that we can print the result using the `json` formatter"""

--- a/tests/functional/cli/test_cli_repository.py
+++ b/tests/functional/cli/test_cli_repository.py
@@ -67,17 +67,20 @@ def test_list_merge_request_commits(gitlab_cli, merge_request, project):
 def test_commit_merge_requests(gitlab_cli, project, merge_request, wait_for_sidekiq):
     """This tests the `project-commit merge-requests` command and also tests
     that we can print the result using the `json` formatter"""
-    # create and then merge a merge-request
-    mr = merge_request(source_branch="test_commit_merge_requests")
-    merge_result = mr.merge(should_remove_source_branch=True)
+    # Merge the MR first
+    merge_result = merge_request.merge(should_remove_source_branch=True)
     wait_for_sidekiq(timeout=60)
+
     # Wait until it is merged
-    mr_iid = mr.iid
+    mr = None
+    mr_iid = merge_request.iid
     for _ in range(60):
         mr = project.mergerequests.get(mr_iid)
         if mr.merged_at is not None:
             break
         time.sleep(0.5)
+
+    assert mr is not None
     assert mr.merged_at is not None
     time.sleep(0.5)
     wait_for_sidekiq(timeout=60)


### PR DESCRIPTION
Closes https://github.com/python-gitlab/python-gitlab/issues/2448.

Separately, fce790328df81ac61679f40c0142d70e58049703 renames the fixture factory as is done in https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#factories-as-fixtures and adds a fixture that can be reused directly in tests.