### PR TITLE
chore: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+python-gitlab is a thin wrapper and you should generally mostly ensure your transitive dependencies are kept up-to-date.
+
+However, if you find an issue that may be security relevant, please
+[Report a security vulnerability](https://github.com/python-gitlab/python-gitlab/security/advisories/new)
+on GitHub.
+
+Alternatively, if you cannot report vulnerabilities on GitHub,
+you can email the currently active maintainers listed in [AUTHORS](https://github.com/python-gitlab/python-gitlab/blob/main/AUTHORS).
+
+## Supported Versions
+
+We will typically apply fixes for the current major version. As the package is distributed on
+PyPI and GitLab's container registry, users are encouraged to always update to the latest version.


### PR DESCRIPTION
GitHub likes to have this file for its Community Standards it seems.