### PR TITLE
chore(renovate): do not ignore tests dir

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -5,10 +5,14 @@
     "group:allNonMajor",
     "schedule:weekly"
   ],
+  "ignorePaths": [
+    "**/.venv/**",
+    "**/node_modules/**"
+  ],
   "regexManagers": [
     {
       "fileMatch": [
-        "^tests\\/functional\\/fixtures\\/.env$"
+        "(^|/)tests\\/functional\\/fixtures\\/\\.env$"
       ],
       "matchStrings": [
         "GITLAB_TAG=(?<currentValue>.*?)\n"


### PR DESCRIPTION
Seems like renovate at some point added default ignore paths which included `tests/` so this explicitly sets a narrower array. Also aligns the regex to be more like other renovate paths upstream.