### PR TITLE
docs: fix update badge behaviour

### DIFF
--- a/docs/gl_objects/badges.rst
+++ b/docs/gl_objects/badges.rst
@@ -38,7 +38,8 @@ Create a badge::
 
 Update a badge::
 
-    badge.image_link = new_link
+    badge.image_url = new_image_url
+    badge.link_url = new_link_url
     badge.save()
 
 Delete a badge::


### PR DESCRIPTION
docs: fix update badge behaviour

Earlier:
badge.image_link = new_link

Now:
badge.image_url = new_image_url
badge.link_url = new_link_url

Fixes #2485 