### PR TITLE
refactor: move response_content into backend code

### DIFF
--- a/gitlab/_backends/protocol.py
+++ b/gitlab/_backends/protocol.py
@@ -1,6 +1,6 @@
 import abc
 import sys
-from typing import Any, Dict, Optional, Union
+from typing import Any, Callable, Dict, Iterator, Optional, Union
 
 import requests
 from requests_toolbelt.multipart.encoder import MultipartEncoder  # type: ignore
@@ -17,6 +17,17 @@ class BackendResponse(Protocol):
 
 
 class Backend(Protocol):
+    @staticmethod
+    @abc.abstractmethod
+    def response_content(
+        response: requests.Response,
+        streamed: bool,
+        action: Optional[Callable[[bytes], None]],
+        chunk_size: int,
+        *,
+        iterator: bool,
+    ) -> Optional[Union[bytes, Iterator[Any]]]: ...
+
     @abc.abstractmethod
     def http_request(
         self,

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -649,7 +649,7 @@ class DownloadMixin(_RestObjectBase):
         )
         if TYPE_CHECKING:
             assert isinstance(result, requests.Response)
-        return utils.response_content(
+        return self.manager.gitlab._backend.response_content(
             result, streamed, action, chunk_size, iterator=iterator
         )
 

--- a/gitlab/utils.py
+++ b/gitlab/utils.py
@@ -4,16 +4,9 @@ import pathlib
 import traceback
 import urllib.parse
 import warnings
-from typing import Any, Callable, Dict, Iterator, Literal, Optional, Tuple, Type, Union
+from typing import Any, Dict, Iterator, Literal, Optional, Tuple, Type, Union
 
-import requests
-
-from gitlab import types
-
-
-class _StdoutStream:
-    def __call__(self, chunk: Any) -> None:
-        print(chunk)
+from gitlab import _backends, types
 
 
 def get_content_type(content_type: Optional[str]) -> str:
@@ -50,26 +43,14 @@ class MaskingFormatter(logging.Formatter):
 
 
 def response_content(
-    response: requests.Response,
-    streamed: bool,
-    action: Optional[Callable[[bytes], None]],
-    chunk_size: int,
-    *,
-    iterator: bool,
+    *args: Any, **kwargs: Any
 ) -> Optional[Union[bytes, Iterator[Any]]]:
-    if iterator:
-        return response.iter_content(chunk_size=chunk_size)
-
-    if streamed is False:
-        return response.content
-
-    if action is None:
-        action = _StdoutStream()
-
-    for chunk in response.iter_content(chunk_size=chunk_size):
-        if chunk:
-            action(chunk)
-    return None
+    warn(
+        "`utils.response_content()` is deprecated and will be removed in a future"
+        "version.\nUse the current backend's `response_content()` method instead.",
+        category=DeprecationWarning,
+    )
+    return _backends.DefaultBackend.response_content(*args, **kwargs)
 
 
 def _transform_types(

--- a/gitlab/v4/objects/artifacts.py
+++ b/gitlab/v4/objects/artifacts.py
@@ -9,7 +9,6 @@ import requests
 
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab import utils
 from gitlab.base import RESTManager, RESTObject
 
 __all__ = ["ProjectArtifact", "ProjectArtifactManager"]
@@ -90,7 +89,7 @@ class ProjectArtifactManager(RESTManager):
         )
         if TYPE_CHECKING:
             assert isinstance(result, requests.Response)
-        return utils.response_content(
+        return self.gitlab._backend.response_content(
             result, streamed, action, chunk_size, iterator=iterator
         )
 
@@ -142,6 +141,6 @@ class ProjectArtifactManager(RESTManager):
         )
         if TYPE_CHECKING:
             assert isinstance(result, requests.Response)
-        return utils.response_content(
+        return self.gitlab._backend.response_content(
             result, streamed, action, chunk_size, iterator=iterator
         )

--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -272,7 +272,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         )
         if TYPE_CHECKING:
             assert isinstance(result, requests.Response)
-        return utils.response_content(
+        return self.gitlab._backend.response_content(
             result, streamed, action, chunk_size, iterator=iterator
         )
 

--- a/gitlab/v4/objects/jobs.py
+++ b/gitlab/v4/objects/jobs.py
@@ -4,7 +4,6 @@ import requests
 
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab import utils
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import RefreshMixin, RetrieveMixin
 from gitlab.types import ArrayAttribute
@@ -152,7 +151,7 @@ class ProjectJob(RefreshMixin, RESTObject):
         )
         if TYPE_CHECKING:
             assert isinstance(result, requests.Response)
-        return utils.response_content(
+        return self.manager.gitlab._backend.response_content(
             result, streamed, action, chunk_size, iterator=iterator
         )
 
@@ -195,7 +194,7 @@ class ProjectJob(RefreshMixin, RESTObject):
         )
         if TYPE_CHECKING:
             assert isinstance(result, requests.Response)
-        return utils.response_content(
+        return self.manager.gitlab._backend.response_content(
             result, streamed, action, chunk_size, iterator=iterator
         )
 
@@ -236,7 +235,7 @@ class ProjectJob(RefreshMixin, RESTObject):
         )
         if TYPE_CHECKING:
             assert isinstance(result, requests.Response)
-        return utils.response_content(
+        return self.manager.gitlab._backend.response_content(
             result, streamed, action, chunk_size, iterator=iterator
         )
 

--- a/gitlab/v4/objects/packages.py
+++ b/gitlab/v4/objects/packages.py
@@ -20,7 +20,6 @@ import requests
 
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab import utils
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import DeleteMixin, GetMixin, ListMixin, ObjectDeleteMixin
 
@@ -166,7 +165,7 @@ class GenericPackageManager(RESTManager):
         result = self.gitlab.http_get(path, streamed=streamed, raw=True, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(result, requests.Response)
-        return utils.response_content(
+        return self.gitlab._backend.response_content(
             result, streamed, action, chunk_size, iterator=iterator
         )
 

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -499,7 +499,7 @@ class Project(
         )
         if TYPE_CHECKING:
             assert isinstance(result, requests.Response)
-        return utils.response_content(
+        return self.manager.gitlab._backend.response_content(
             result, streamed, action, chunk_size, iterator=iterator
         )
 

--- a/gitlab/v4/objects/repositories.py
+++ b/gitlab/v4/objects/repositories.py
@@ -145,7 +145,7 @@ class RepositoryMixin(_RestObjectBase):
         )
         if TYPE_CHECKING:
             assert isinstance(result, requests.Response)
-        return utils.response_content(
+        return self.manager.gitlab._backend.response_content(
             result, streamed, action, chunk_size, iterator=iterator
         )
 
@@ -247,7 +247,7 @@ class RepositoryMixin(_RestObjectBase):
         )
         if TYPE_CHECKING:
             assert isinstance(result, requests.Response)
-        return utils.response_content(
+        return self.manager.gitlab._backend.response_content(
             result, streamed, action, chunk_size, iterator=iterator
         )
 

--- a/gitlab/v4/objects/secure_files.py
+++ b/gitlab/v4/objects/secure_files.py
@@ -9,7 +9,6 @@ import requests
 
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab import utils
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import NoUpdateMixin, ObjectDeleteMixin
 from gitlab.types import FileAttribute, RequiredOptional
@@ -54,7 +53,7 @@ class ProjectSecureFile(ObjectDeleteMixin, RESTObject):
         )
         if TYPE_CHECKING:
             assert isinstance(result, requests.Response)
-        return utils.response_content(
+        return self.manager.gitlab._backend.response_content(
             result, streamed, action, chunk_size, iterator=iterator
         )
 

--- a/gitlab/v4/objects/snippets.py
+++ b/gitlab/v4/objects/snippets.py
@@ -4,7 +4,6 @@ import requests
 
 from gitlab import cli
 from gitlab import exceptions as exc
-from gitlab import utils
 from gitlab.base import RESTManager, RESTObject, RESTObjectList
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin, UserAgentDetailMixin
 from gitlab.types import RequiredOptional
@@ -61,7 +60,7 @@ class Snippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
         )
         if TYPE_CHECKING:
             assert isinstance(result, requests.Response)
-        return utils.response_content(
+        return self.manager.gitlab._backend.response_content(
             result, streamed, action, chunk_size, iterator=iterator
         )
 
@@ -154,7 +153,7 @@ class ProjectSnippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObj
         )
         if TYPE_CHECKING:
             assert isinstance(result, requests.Response)
-        return utils.response_content(
+        return self.manager.gitlab._backend.response_content(
             result, streamed, action, chunk_size, iterator=iterator
         )
 

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -1,0 +1,23 @@
+import requests
+import responses
+
+from gitlab import _backends
+
+
+@responses.activate
+def test_streamed_response_content_with_requests(capsys):
+    responses.add(
+        method="GET",
+        url="https://example.com",
+        status=200,
+        body="test",
+        content_type="application/octet-stream",
+    )
+
+    resp = requests.get("https://example.com", stream=True)
+    _backends.RequestsBackend.response_content(
+        resp, streamed=True, action=None, chunk_size=1024, iterator=False
+    )
+
+    captured = capsys.readouterr()
+    assert "test" in captured.out

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,8 +3,6 @@ import logging
 import warnings
 
 import pytest
-import requests
-import responses
 
 from gitlab import types, utils
 
@@ -21,25 +19,6 @@ from gitlab import types, utils
 def test_get_content_type(content_type, expected_type):
     parsed_type = utils.get_content_type(content_type)
     assert parsed_type == expected_type
-
-
-@responses.activate
-def test_response_content(capsys):
-    responses.add(
-        method="GET",
-        url="https://example.com",
-        status=200,
-        body="test",
-        content_type="application/octet-stream",
-    )
-
-    resp = requests.get("https://example.com", stream=True)
-    utils.response_content(
-        resp, streamed=True, action=None, chunk_size=1024, iterator=False
-    )
-
-    captured = capsys.readouterr()
-    assert "test" in captured.out
 
 
 class TestEncodedId:


### PR DESCRIPTION
Needed in order to later add other backends that handle streaming responses differently. Just a first step, later maybe we could get rid of `response_content` completely from individual methods and just handle this in the request code :thinking: 