### PR TITLE
chore: bump version of GitLab to 15.4.6-ee.0

### DIFF
--- a/tests/functional/fixtures/.env
+++ b/tests/functional/fixtures/.env
@@ -1,2 +1,2 @@
 GITLAB_IMAGE=gitlab/gitlab-ee
-GITLAB_TAG=15.4.0-ee.0
+GITLAB_TAG=15.5.9-ee.0

--- a/tests/functional/fixtures/.env
+++ b/tests/functional/fixtures/.env
@@ -1,2 +1,3 @@
 GITLAB_IMAGE=gitlab/gitlab-ee
-GITLAB_TAG=15.5.9-ee.0
+# GITLAB_TAG=15.6.8-ee.0
+GITLAB_TAG=15.6.0-ee.0


### PR DESCRIPTION
Increase version of GitLab to latest major version that works without
changing tests.
