### PR TITLE
fix: support int for `parent_id` in `import_group`

### DIFF
--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -716,10 +716,8 @@ class Gitlab:
             retry_transient_errors = self.retry_transient_errors
 
         # We need to deal with json vs. data when uploading files
-        json, data, content_type = self._backend.prepare_send_data(
-            files, post_data, raw
-        )
-        opts["headers"]["Content-type"] = content_type
+        send_data = self._backend.prepare_send_data(files, post_data, raw)
+        opts["headers"]["Content-type"] = send_data.content_type
 
         cur_retries = 0
         while True:
@@ -727,8 +725,8 @@ class Gitlab:
                 result = self._backend.http_request(
                     method=verb,
                     url=url,
-                    json=json,
-                    data=data,
+                    json=send_data.json,
+                    data=send_data.data,
                     params=params,
                     timeout=timeout,
                     verify=verify,

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -378,7 +378,7 @@ class GroupManager(CRUDMixin, RESTManager):
         file: BinaryIO,
         path: str,
         name: str,
-        parent_id: Optional[str] = None,
+        parent_id: Optional[Union[int, str]] = None,
         **kwargs: Any,
     ) -> Union[Dict[str, Any], requests.Response]:
         """Import a group from an archive file.
@@ -399,7 +399,7 @@ class GroupManager(CRUDMixin, RESTManager):
             A representation of the import status.
         """
         files = {"file": ("file.tar.gz", file, "application/octet-stream")}
-        data = {"path": path, "name": name}
+        data: Dict[str, Any] = {"path": path, "name": name}
         if parent_id is not None:
             data["parent_id"] = parent_id
 

--- a/tests/unit/_backends/test_requests_backend.py
+++ b/tests/unit/_backends/test_requests_backend.py
@@ -25,10 +25,21 @@ class TestSendData:
 
 
 class TestRequestsBackend:
-    def test_prepare_send_data_str_parentid(self) -> None:
-        file = "12345"
-        files = {"file": ("file.tar.gz", file, "application/octet-stream")}
-        post_data = {"parent_id": "12"}
+    @pytest.mark.parametrize(
+        "test_data,expected",
+        [
+            (False, "0"),
+            (True, "1"),
+            ("12", "12"),
+            (12, "12"),
+            (12.0, "12.0"),
+            (complex(-2, 7), "(-2+7j)"),
+        ],
+    )
+    def test_prepare_send_data_non_strings(self, test_data, expected) -> None:
+        assert isinstance(expected, str)
+        files = {"file": ("file.tar.gz", "12345", "application/octet-stream")}
+        post_data = {"test_data": test_data}
 
         result = requests_backend.RequestsBackend.prepare_send_data(
             files=files, post_data=post_data, raw=False
@@ -36,3 +47,5 @@ class TestRequestsBackend:
         assert result.json is None
         assert result.content_type.startswith("multipart/form-data")
         assert isinstance(result.data, MultipartEncoder)
+        assert isinstance(result.data.fields["test_data"], str)
+        assert result.data.fields["test_data"] == expected

--- a/tests/unit/_backends/test_requests_backend.py
+++ b/tests/unit/_backends/test_requests_backend.py
@@ -1,0 +1,38 @@
+import pytest
+from requests_toolbelt.multipart.encoder import MultipartEncoder  # type: ignore
+
+from gitlab._backends import requests_backend
+
+
+class TestSendData:
+    def test_senddata_json(self) -> None:
+        result = requests_backend.SendData(
+            json={"a": 1}, content_type="application/json"
+        )
+        assert result.data is None
+
+    def test_senddata_data(self) -> None:
+        result = requests_backend.SendData(
+            data={"b": 2}, content_type="application/octet-stream"
+        )
+        assert result.json is None
+
+    def test_senddata_json_and_data(self) -> None:
+        with pytest.raises(ValueError, match=r"json={'a': 1}  data={'b': 2}"):
+            requests_backend.SendData(
+                json={"a": 1}, data={"b": 2}, content_type="application/json"
+            )
+
+
+class TestRequestsBackend:
+    def test_prepare_send_data_str_parentid(self) -> None:
+        file = "12345"
+        files = {"file": ("file.tar.gz", file, "application/octet-stream")}
+        post_data = {"parent_id": "12"}
+
+        result = requests_backend.RequestsBackend.prepare_send_data(
+            files=files, post_data=post_data, raw=False
+        )
+        assert result.json is None
+        assert result.content_type.startswith("multipart/form-data")
+        assert isinstance(result.data, MultipartEncoder)


### PR DESCRIPTION
This will also fix other use cases where an integer is passed in to
MultipartEncoder.

Added unit tests to show it works.

Closes: #2506
