### PR TITLE
fix(cli): add ability to escape at-prefixed parameter

### DIFF
--- a/docs/cli-usage.rst
+++ b/docs/cli-usage.rst
@@ -305,7 +305,7 @@ command line. This is handy for values containing new lines for instance:
    EOF
    $ gitlab project create --name SuperProject --description @/tmp/description
 
-It you want to explicitly pass argument starting with "@" - double it:
+It you want to explicitly pass an argument starting with ``@``,  you can escape it using ``@@``:
 
 .. code-block:: console
   

--- a/docs/cli-usage.rst
+++ b/docs/cli-usage.rst
@@ -305,6 +305,17 @@ command line. This is handy for values containing new lines for instance:
    EOF
    $ gitlab project create --name SuperProject --description @/tmp/description
 
+It you want to explicitly pass argument starting with "@" - double it:
+
+.. code-block:: console
+  
+   $ gitlab project-tag list --project-id somenamespace/myproject
+   ...
+   name: @at-started-tag
+   ...
+   $ gitlab project-tag delete --project-id somenamespace/myproject --name '@@at-started-tag'
+
+
 Enabling shell autocompletion
 =============================
 

--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -272,6 +272,8 @@ def _get_parser() -> argparse.ArgumentParser:
 
 
 def _parse_value(v: Any) -> Any:
+    if isinstance(v, str) and v.startswith("@@"):
+        return v[1:]
     if isinstance(v, str) and v.startswith("@"):
         # If the user-provided value starts with @, we try to read the file
         # path provided after @ as the real value. Exit on any error.

--- a/tests/functional/cli/test_cli_v4.py
+++ b/tests/functional/cli/test_cli_v4.py
@@ -562,6 +562,26 @@ def test_create_project_with_values_from_file(gitlab_cli, tmpdir):
     assert description in ret.stdout
 
 
+def test_create_project_with_values_at_prefixed(gitlab_cli, tmpdir):
+    name = "gitlab-project-at-prefixed"
+    description = "@at-prefixed"
+    at_prefixed = f"@{description}"
+
+    cmd = [
+        "-v",
+        "project",
+        "create",
+        "--name",
+        name,
+        "--description",
+        at_prefixed,
+    ]
+    ret = gitlab_cli(cmd)
+
+    assert ret.success
+    assert description in ret.stdout
+
+
 def test_create_project_deploy_token(gitlab_cli, project):
     name = "project-token"
     username = "root"


### PR DESCRIPTION
Fixes python-gitlab#2511