### PR TITLE
docs(objects): fix typo in pipeline schedules

### DIFF
--- a/docs/gl_objects/pipelines_and_jobs.rst
+++ b/docs/gl_objects/pipelines_and_jobs.rst
@@ -144,7 +144,7 @@ List pipeline schedules::
 
 Get a single schedule::
 
-    sched = projects.pipelineschedules.get(schedule_id)
+    sched = project.pipelineschedules.get(schedule_id)
 
 Create a new schedule::
 


### PR DESCRIPTION
Closes https://github.com/python-gitlab/python-gitlab/issues/2519