### PR TITLE
chore(ci): wait for all coverage reports in CI status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,6 @@
 codecov:
+  notify:
+    after_n_builds: 3
   require_ci_to_pass: yes
 
 coverage:


### PR DESCRIPTION
This has been annoying me - with the new integration, we get annotations and status checks, but they seem to get notified early, so CI looks like it's failing until all coverage reports are fully uploaded.

https://docs.codecov.com/docs/codecovyml-reference