### PR TITLE
feat: usernames support for MR approvals

### DIFF
--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -63,7 +63,7 @@ class ProjectApprovalRuleManager(
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(
         required=("name", "approvals_required"),
-        optional=("user_ids", "group_ids", "protected_branch_ids"),
+        optional=("user_ids", "group_ids", "protected_branch_ids", "usernames"),
     )
 
 


### PR DESCRIPTION
This can be used instead of 'user_ids'

See: https://docs.gitlab.com/ee/api/merge_request_approvals.html#create-project-level-rule
