### PR TITLE
chore(ci): use OIDC trusted publishing for pypi.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,27 @@ jobs:
   release:
     if: github.repository == 'python-gitlab/python-gitlab'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment: pypi.org
     steps:
     - uses: actions/checkout@v3.5.0
       with:
         fetch-depth: 0
         token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+    - name: mint API token
+      id: mint-token
+      run: |
+        resp=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=pypi")
+        oidc_token=$(jq '.value' <<< "${resp}")
+
+        resp=$(curl -X POST https://pypi.org/_/oidc/github/mint-token -d "{\"token\":${oidc_token}}")
+        api_token=$(jq '.token' <<< "${resp}" | tr -d '"')
+
+        echo "::add-mask::${api_token}"
+        echo "api-token=${api_token}" >> "${GITHUB_OUTPUT}"
     - name: Python Semantic Release
       uses: relekang/python-semantic-release@v7.33.2
       with:
         github_token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
-        pypi_token: ${{ secrets.PYPI_TOKEN }}
+        pypi_token: ${{ steps.mint-token.outputs.api-token }}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,3 +7,5 @@ pytest-github-actions-annotate-failures==0.1.8
 pytest==7.2.2
 PyYaml==5.4.1
 responses==0.23.1
+setuptools==67.7.2
+wheel==0.40.0


### PR DESCRIPTION
Closes #2554 

Tested on test.pypi.org, I've removed the static PYPI_TOKEN already. We can also remove the deploy token member now IMO