### PR TITLE
feat(api): add support for events scope parameter

### DIFF
--- a/gitlab/v4/objects/events.py
+++ b/gitlab/v4/objects/events.py
@@ -39,7 +39,7 @@ class Event(RESTObject):
 class EventManager(ListMixin, RESTManager):
     _path = "/events"
     _obj_cls = Event
-    _list_filters = ("action", "target_type", "before", "after", "sort")
+    _list_filters = ("action", "target_type", "before", "after", "sort", "scope")
 
 
 class GroupEpicResourceLabelEvent(RESTObject):


### PR DESCRIPTION
## Changes

Add support for the `scope` parameter in api: "/events?scope=all" that is implemented by https://gitlab.com/gitlab-org/gitlab/-/merge_requests/19816

ex: retrieve all dashboard activity for a given user:

```py
i_t = user.impersonationtokens.create({"name": token_name, 'scopes': ["api"]})
user_gl = gitlab.Gitlab(<url>, private_token=i_t.token)
events = user_gl.events.list(scope="all")
i_t.delete()
```

### Documentation and testing

No other params are documented more than the method signature. So automodule should generate it.
