### PR TITLE
Draft: Add ProjectPackagePipeline

### DIFF
--- a/docs/gl_objects/packages.rst
+++ b/docs/gl_objects/packages.rst
@@ -107,11 +107,7 @@ Reference
   + :class:`gitlab.v4.objects.ProjectPackagePipelineManager`
   + :attr:`gitlab.v4.objects.ProjectPackage.pipelines`
 
-..
-  TODO: Not yet published (see https://gitlab.com/gitlab-org/gitlab/-/merge_requests/117539).
-  Add anchor/fragment once available.
-
-* GitLab API: https://docs.gitlab.com/ee/api/packages.html
+* GitLab API: https://docs.gitlab.com/ee/api/packages.html#list-package-pipelines
 
 Examples
 --------

--- a/docs/gl_objects/packages.rst
+++ b/docs/gl_objects/packages.rst
@@ -95,6 +95,31 @@ Delete a package file in a project::
     file = package.package_files.list()[0]
     file.delete()
 
+Project Package Pipelines
+=========================
+
+Reference
+---------
+
+* v4 API:
+
+  + :class:`gitlab.v4.objects.ProjectPackagePipeline`
+  + :class:`gitlab.v4.objects.ProjectPackagePipelineManager`
+  + :attr:`gitlab.v4.objects.ProjectPackage.pipelines`
+
+..
+  TODO: Not yet published (see https://gitlab.com/gitlab-org/gitlab/-/merge_requests/117539).
+  Add anchor/fragment once available.
+
+* GitLab API: https://docs.gitlab.com/ee/api/packages.html
+
+Examples
+--------
+
+List package pipelines for package in project::
+
+    package = project.packages.get(1)
+    package_pipelines = package.pipelines.list()
 
 Generic Packages
 ================

--- a/gitlab/v4/objects/packages.py
+++ b/gitlab/v4/objects/packages.py
@@ -33,6 +33,8 @@ __all__ = [
     "ProjectPackageManager",
     "ProjectPackageFile",
     "ProjectPackageFileManager",
+    "ProjectPackagePipeline",
+    "ProjectPackagePipelineManager",
 ]
 
 
@@ -188,6 +190,7 @@ class GroupPackageManager(ListMixin, RESTManager):
 
 class ProjectPackage(ObjectDeleteMixin, RESTObject):
     package_files: "ProjectPackageFileManager"
+    pipelines: "ProjectPackagePipelineManager"
 
 
 class ProjectPackageManager(ListMixin, GetMixin, DeleteMixin, RESTManager):
@@ -214,4 +217,14 @@ class ProjectPackageFile(ObjectDeleteMixin, RESTObject):
 class ProjectPackageFileManager(DeleteMixin, ListMixin, RESTManager):
     _path = "/projects/{project_id}/packages/{package_id}/package_files"
     _obj_cls = ProjectPackageFile
+    _from_parent_attrs = {"project_id": "project_id", "package_id": "id"}
+
+
+class ProjectPackagePipeline(RESTObject):
+    pass
+
+
+class ProjectPackagePipelineManager(ListMixin, RESTManager):
+    _path = "/projects/{project_id}/packages/{package_id}/pipelines"
+    _obj_cls = ProjectPackagePipeline
     _from_parent_attrs = {"project_id": "project_id", "package_id": "id"}


### PR DESCRIPTION
**Warning: This PR is in Draft status, and is pending [the inclusion of ProjectPackagePipelines](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/117539) in GitLab 16.0.** Tests and documentation modifications are required before merging.

## Changes

Add ProjectPackagePipeline, a new API endpoint which is [expected to be included](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/117539) in GitLab 16.0.

### Documentation and testing

- [X] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs) - **needs revision once GitLab publishes upstream docs**
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)
