### PR TITLE
feat: add support for `select="package_file"` in package upload

### DIFF
--- a/tests/functional/api/test_packages.py
+++ b/tests/functional/api/test_packages.py
@@ -10,6 +10,7 @@ from gitlab.v4.objects import GenericPackage
 package_name = "hello-world"
 package_version = "v1.0.0"
 file_name = "hello.tar.gz"
+file_name2 = "hello2.tar.gz"
 file_content = "package content"
 
 
@@ -35,6 +36,22 @@ def test_upload_generic_package(tmp_path, project):
 
     assert isinstance(package, GenericPackage)
     assert package.message == "201 Created"
+
+
+def test_upload_generic_package_select(tmp_path, project):
+    path = tmp_path / file_name2
+    path.write_text(file_content)
+    package = project.generic_packages.upload(
+        package_name=package_name,
+        package_version=package_version,
+        file_name=file_name2,
+        path=path,
+        select="package_file",
+    )
+
+    assert isinstance(package, GenericPackage)
+    assert package.file_name == file_name2
+    assert package.size == path.stat().st_size
 
 
 def test_download_generic_package(project):


### PR DESCRIPTION
Add ability to use `select="package_file"` when uploading a generic package as described in:
https://docs.gitlab.com/ee/user/packages/generic_packages/index.html

Closes: #2557

<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

<!-- Remove this comment and describe your changes here. -->

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
