### PR TITLE
fix(cli): add _from_parent_attrs to user-project manager (#2558)

### DIFF
--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -46,7 +46,7 @@ class GitlabCLI:
 
         self.mgr_cls._path = self.mgr_cls._path.format(**self.parent_args)
         self.mgr = self.mgr_cls(gl)
-
+        self.mgr._from_parent_attrs = self.parent_args
         if self.mgr_cls._types:
             for attr_name, type_cls in self.mgr_cls._types.items():
                 if attr_name in self.args.keys():

--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -638,7 +638,7 @@ class UserProjectManager(ListMixin, CreateMixin, RESTManager):
         if self._parent:
             path = f"/users/{self._parent.id}/projects"
         else:
-            path = f"/users/{kwargs['user_id']}/projects"
+            path = f"/users/{self._from_parent_attrs['user_id']}/projects"
         return ListMixin.list(self, path=path, **kwargs)
 
 


### PR DESCRIPTION
## Changes

setting `_from_parent_attrs` on `UserProjectManager` and using it in its `list` method resolves #2558 and allows specific user's projects to be returned successfully. 

The inspiration for the fix came from `_from_parent_attrs = {"user_id": "id"}` line of `UserProjectManager`.

Tested by running below script with arguments: `user-project list --user-id [user_id]`

```
import gitlab
gl = gitlab.GitLab(...)
gl.auth()
import gitlab.cli as cli
cli.main()
```