### PR TITLE
feat(client): Use requests AuthBase classes

### DIFF
--- a/docs/api-usage-advanced.rst
+++ b/docs/api-usage-advanced.rst
@@ -44,11 +44,11 @@ properly closed when you exit a ``with`` block:
 netrc authentication
 --------------------
 
-python-gitlab reads credentials from ``.netrc`` files via the ``requests`` backend by default,
-which may override authentication headers you set on your client.
+python-gitlab reads credentials from ``.netrc`` files via the ``requests`` backend
+only if you do not provide any other type of authentication yourself.
 
-For more granular control, you can disable this `Using a custom session`_
-and explicitly setting ``trust_env=False`` as described in the ``requests`` documentation.
+If you'd like to disable reading netrc files altogether, you can follow `Using a custom session`_
+and explicitly set ``trust_env=False`` as described in the ``requests`` documentation.
 
 .. code-block:: python
 

--- a/gitlab/_backends/__init__.py
+++ b/gitlab/_backends/__init__.py
@@ -2,7 +2,21 @@
 Defines http backends for processing http requests
 """
 
-from .requests_backend import RequestsBackend, RequestsResponse
+from .requests_backend import (
+    JobTokenAuth,
+    OAuthTokenAuth,
+    PrivateTokenAuth,
+    RequestsBackend,
+    RequestsResponse,
+)
 
 DefaultBackend = RequestsBackend
 DefaultResponse = RequestsResponse
+
+__all__ = [
+    "DefaultBackend",
+    "DefaultResponse",
+    "JobTokenAuth",
+    "OAuthTokenAuth",
+    "PrivateTokenAuth",
+]


### PR DESCRIPTION
<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

Use Private / Job / OAuth token auth classes based on requests' `AuthBase` class to provide an encapsulated mechanism for passing authentication credentials.

Additionally this helps with #2425 since we always pass the `auth` argument, so unless hitting redirects requests should always prefer the passed token over netrc credentials.

This does however break the behavior when credentials are set using environment variables and a user wants to set `netrc` to override that (username / password should be discouraged, but users have better ideas...), for example, running in the CI the `CI_JOB_TOKEN` is set it will prevent the netrc creds from being loaded, instead of the old API logic (as can seen in the tests changes)

### Documentation and testing

This changes internal implementation by leveraging standard `requests` mechanisms, if the tests cover this part, they should succeed or fail the same way they did before.

Update: I misunderstood the logic re. token precedence and assumed, after rewriting the tests I got the logic