### PR TITLE
docs(files): fix minor typo in variable declaration

### DIFF
--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -240,7 +240,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
 
         Args:
             ref: ID of the commit
-            filepath: Path of the file to return
+            file_path: Path of the file to return
             streamed: If True the data will be processed by chunks of
                 `chunk_size` and each chunk is passed to `action` for
                 treatment


### PR DESCRIPTION
This should be an instant merge

You can see the documentation creating wrong variables here: https://python-gitlab.readthedocs.io/en/stable/api/gitlab.v4.html#gitlab.v4.objects.ProjectFileManager.raw