### PR TITLE
feat: Allow uploading packages from files and bytes

### DIFF
--- a/gitlab/_backends/requests_backend.py
+++ b/gitlab/_backends/requests_backend.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, Dict, Optional, TYPE_CHECKING, Union
+from typing import Any, BinaryIO, Dict, Optional, TYPE_CHECKING, Union
 
 import requests
 from requests import PreparedRequest
@@ -94,7 +94,7 @@ class RequestsBackend(protocol.Backend):
     @staticmethod
     def prepare_send_data(
         files: Optional[Dict[str, Any]] = None,
-        post_data: Optional[Union[Dict[str, Any], bytes]] = None,
+        post_data: Optional[Union[Dict[str, Any], bytes, BinaryIO]] = None,
         raw: bool = False,
     ) -> SendData:
         if files:
@@ -120,6 +120,9 @@ class RequestsBackend(protocol.Backend):
 
         if raw and post_data:
             return SendData(data=post_data, content_type="application/octet-stream")
+
+        if TYPE_CHECKING:
+            assert not isinstance(post_data, BinaryIO)
 
         return SendData(json=post_data, content_type="application/json")
 

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -3,7 +3,18 @@
 import os
 import re
 import time
-from typing import Any, cast, Dict, List, Optional, Tuple, Type, TYPE_CHECKING, Union
+from typing import (
+    Any,
+    BinaryIO,
+    cast,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TYPE_CHECKING,
+    Union,
+)
 from urllib import parse
 
 import requests
@@ -612,7 +623,7 @@ class Gitlab:
         verb: str,
         path: str,
         query_data: Optional[Dict[str, Any]] = None,
-        post_data: Optional[Union[Dict[str, Any], bytes]] = None,
+        post_data: Optional[Union[Dict[str, Any], bytes, BinaryIO]] = None,
         raw: bool = False,
         streamed: bool = False,
         files: Optional[Dict[str, Any]] = None,
@@ -993,7 +1004,7 @@ class Gitlab:
         self,
         path: str,
         query_data: Optional[Dict[str, Any]] = None,
-        post_data: Optional[Union[Dict[str, Any], bytes]] = None,
+        post_data: Optional[Union[Dict[str, Any], bytes, BinaryIO]] = None,
         raw: bool = False,
         files: Optional[Dict[str, Any]] = None,
         **kwargs: Any,

--- a/tests/functional/api/test_packages.py
+++ b/tests/functional/api/test_packages.py
@@ -38,7 +38,7 @@ def test_upload_generic_package(tmp_path, project):
     assert package.message == "201 Created"
 
 
-def test_download_generic_package_bytes(tmp_path, project):
+def test_upload_generic_package_as_bytes(tmp_path, project):
     path = tmp_path / file_name
 
     path.write_text(file_content)
@@ -54,7 +54,7 @@ def test_download_generic_package_bytes(tmp_path, project):
     assert package.message == "201 Created"
 
 
-def test_download_generic_package_file(tmp_path, project):
+def test_upload_generic_package_as_file(tmp_path, project):
     path = tmp_path / file_name
 
     path.write_text(file_content)

--- a/tests/functional/api/test_packages.py
+++ b/tests/functional/api/test_packages.py
@@ -38,6 +38,38 @@ def test_upload_generic_package(tmp_path, project):
     assert package.message == "201 Created"
 
 
+def test_download_generic_package_bytes(tmp_path, project):
+    path = tmp_path / file_name
+
+    path.write_text(file_content)
+
+    package = project.generic_packages.upload(
+        package_name=package_name,
+        package_version=package_version,
+        file_name=file_name,
+        data=path.read_bytes(),
+    )
+
+    assert isinstance(package, GenericPackage)
+    assert package.message == "201 Created"
+
+
+def test_download_generic_package_file(tmp_path, project):
+    path = tmp_path / file_name
+
+    path.write_text(file_content)
+
+    package = project.generic_packages.upload(
+        package_name=package_name,
+        package_version=package_version,
+        file_name=file_name,
+        data=path.open(mode="rb"),
+    )
+
+    assert isinstance(package, GenericPackage)
+    assert package.message == "201 Created"
+
+
 def test_upload_generic_package_select(tmp_path, project):
     path = tmp_path / file_name2
     path.write_text(file_content)

--- a/tests/unit/objects/test_packages.py
+++ b/tests/unit/objects/test_packages.py
@@ -6,6 +6,7 @@ import re
 import pytest
 import responses
 
+from gitlab import exceptions as exc
 from gitlab.v4.objects import (
     GenericPackage,
     GroupPackage,
@@ -276,6 +277,74 @@ def test_upload_generic_package(tmp_path, project, resp_upload_generic_package):
         package_version=package_version,
         file_name=file_name,
         path=path,
+    )
+
+    assert isinstance(package, GenericPackage)
+
+
+def test_upload_generic_package_nonexistent_path(tmp_path, project):
+    with pytest.raises(exc.GitlabUploadError):
+        project.generic_packages.upload(
+            package_name=package_name,
+            package_version=package_version,
+            file_name=file_name,
+            path="bad",
+        )
+
+
+def test_upload_generic_package_no_file_and_no_data(tmp_path, project):
+    path = tmp_path / file_name
+
+    path.write_text(file_content, encoding="utf-8")
+
+    with pytest.raises(exc.GitlabUploadError):
+        project.generic_packages.upload(
+            package_name=package_name,
+            package_version=package_version,
+            file_name=file_name,
+        )
+
+
+def test_upload_generic_package_file_and_data(tmp_path, project):
+    path = tmp_path / file_name
+
+    path.write_text(file_content, encoding="utf-8")
+
+    with pytest.raises(exc.GitlabUploadError):
+        project.generic_packages.upload(
+            package_name=package_name,
+            package_version=package_version,
+            file_name=file_name,
+            path=path,
+            data=path.read_bytes(),
+        )
+
+
+def test_upload_generic_package_bytes(tmp_path, project, resp_upload_generic_package):
+    path = tmp_path / file_name
+
+    path.write_text(file_content, encoding="utf-8")
+
+    package = project.generic_packages.upload(
+        package_name=package_name,
+        package_version=package_version,
+        file_name=file_name,
+        data=path.read_bytes(),
+    )
+
+    assert isinstance(package, GenericPackage)
+
+
+def test_upload_generic_package_file(tmp_path, project, resp_upload_generic_package):
+    path = tmp_path / file_name
+
+    path.write_text(file_content, encoding="utf-8")
+
+    package = project.generic_packages.upload(
+        package_name=package_name,
+        package_version=package_version,
+        file_name=file_name,
+        data=path.open(mode="rb"),
     )
 
     assert isinstance(package, GenericPackage)


### PR DESCRIPTION
<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

This commit adds a keyword argument to GenericPackageManager.upload() to allow uploading bytes and file-like objects to the generic package registry. That necessitates changing file path to be a keyword argument as well, which then cascades into a whole slew of checks to not allow passing both and to not allow uploading file-like objects as JSON data.

Closes https://github.com/python-gitlab/python-gitlab/issues/1815

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
