### PR TITLE
feat(releases): Add support for direct_asset_path

### DIFF
--- a/gitlab/v4/objects/releases.py
+++ b/gitlab/v4/objects/releases.py
@@ -50,9 +50,12 @@ class ProjectReleaseLinkManager(CRUDMixin, RESTManager):
     _obj_cls = ProjectReleaseLink
     _from_parent_attrs = {"project_id": "project_id", "tag_name": "tag_name"}
     _create_attrs = RequiredOptional(
-        required=("name", "url"), optional=("filepath", "link_type")
+        required=("name", "url"),
+        optional=("filepath", "direct_asset_path", "link_type"),
     )
-    _update_attrs = RequiredOptional(optional=("name", "url", "filepath", "link_type"))
+    _update_attrs = RequiredOptional(
+        optional=("name", "url", "filepath", "direct_asset_path", "link_type")
+    )
 
     def get(
         self, id: Union[str, int], lazy: bool = False, **kwargs: Any


### PR DESCRIPTION
## Changes

This commit adds support for the “new” alias for `filepath`: `direct_asset_path` (added in 15.10) in release links API.

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
