### PR TITLE
fix: Fix 404 not found error for saving approval rules 

### DIFF
--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -132,6 +132,7 @@ class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTMan
 
 class ProjectMergeRequestApprovalRule(SaveMixin, ObjectDeleteMixin, RESTObject):
     _repr_attr = "name"
+    _id_attr = "approval_rule_id"
     id: int
     approval_rule_id: int
     merge_request_iid: int


### PR DESCRIPTION
save() was getting id of the merge request instead of id of the approval_rule, setting _id_attr to approval_rule_id addresses this issue.

