### PR TITLE
feat: remove support for Python 3.7, require 3.8 or higher

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python:
-          - version: "3.7"
-            toxenv: py37,smoke
           - version: "3.8"
             toxenv: py38,smoke
           - version: "3.9"

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -38,11 +38,6 @@
       "enabled": false
     },
     {
-      "description": "Pin pytest-console-scripts until we drop 3.7 support",
-      "packageName": "pytest-console-scripts",
-      "allowedVersions": "<1.4.1"
-    },
-    {
       "packagePatterns": [
         "^gitlab\/gitlab-.+$"
       ],

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Features
 Installation
 ------------
 
-As of 3.0.0, ``python-gitlab`` is compatible with Python 3.7+.
+As of 4.0.0, ``python-gitlab`` is compatible with Python 3.8+.
 
 Use ``pip`` to install the latest stable version of ``python-gitlab``:
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     package_data={
         "gitlab": ["py.typed"],
     },
-    python_requires=">=3.7.0",
+    python_requires=">=3.8.0",
     entry_points={"console_scripts": ["gitlab = gitlab.cli:main"]},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -48,7 +48,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 1.6
 skipsdist = True
 skip_missing_interpreters = True
-envlist = py310,py39,py38,py37,flake8,black,twine-check,mypy,isort,cz,pylint
+envlist = py311,py310,py39,py38,flake8,black,twine-check,mypy,isort,cz,pylint
 
 [testenv]
 passenv =


### PR DESCRIPTION
Python 3.8 is End-of-Life (EOL) as of 2023-06-27 as stated in https://devguide.python.org/versions/ and
https://peps.python.org/pep-0537/

By dropping support for Python 3.7 and requiring Python 3.8 or higher it allows python-gitlab to take advantage of new features in Python 3.8, which are documented at:
https://docs.python.org/3/whatsnew/3.8.html

BREAKING CHANGE: As of python-gitlab 4.0.0, Python 3.7 is no longer
supported. Python 3.8 or higher is required.

<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

<!-- Remove this comment and describe your changes here. -->

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
