### PR TITLE
fix(cli): remove deprecated `--all` option in favor of `--get-all`

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -42,7 +42,7 @@ Example::
 Not all items are returned from the API
 """""""""""""""""""""""""""""""""""""""
 
-If you've passed ``all=True`` (or ``--all`` via the CLI) to the API and still cannot see all items returned,
+If you've passed ``all=True`` to the API and still cannot see all items returned,
 use ``get_all=True`` (or ``--get-all`` via the CLI) instead. See :ref:`pagination` for more details.
 
 Common errors

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -236,12 +236,6 @@ def _populate_sub_parser_by_class(
                 action="store_true",
                 help="Return all items from the server, without pagination.",
             )
-            sub_parser_action.add_argument(
-                "--all",
-                required=False,
-                action="store_true",
-                help="Deprecated. Use --get-all instead.",
-            )
 
         if action_name == "delete":
             if cls._id_attr is not None:

--- a/gitlab/v4/objects/commits.py
+++ b/gitlab/v4/objects/commits.py
@@ -155,6 +155,7 @@ class ProjectCommitManager(RetrieveMixin, CreateMixin, RESTManager):
         optional=("author_email", "author_name"),
     )
     _list_filters = (
+        "all",
         "ref_name",
         "since",
         "until",

--- a/tests/functional/cli/test_cli_repository.py
+++ b/tests/functional/cli/test_cli_repository.py
@@ -43,7 +43,15 @@ def test_list_all_commits(gitlab_cli, project):
     assert commit.id not in ret.stdout
 
     # Listing commits on other branches requires `all` parameter passed to the API
-    cmd = ["project-commit", "list", "--project-id", project.id, "--get-all", "--all"]
+    cmd = [
+        "project-commit",
+        "list",
+        "--project-id",
+        project.id,
+        "--get-all",
+        "--all",
+        "true",
+    ]
     ret_all = gitlab_cli(cmd)
     assert commit.id in ret_all.stdout
     assert len(ret_all.stdout) > len(ret.stdout)


### PR DESCRIPTION
BREAKING CHANGE: The `--all` option is no longer available in the CLI. Use `--get-all` instead.

Closes https://github.com/python-gitlab/python-gitlab/issues/2535



