### PR TITLE
refactor(artifacts): remove deprecated `artifacts()`in favor of `artifacts.download()`

### DIFF
--- a/docs/gl_objects/pipelines_and_jobs.rst
+++ b/docs/gl_objects/pipelines_and_jobs.rst
@@ -255,11 +255,6 @@ a branch or tag::
 
   project.artifacts.download(ref_name='main', job='build')
 
-.. attention::
-
-    An older method ``project.artifacts()`` is deprecated and will be
-    removed in a future version.
-
 .. warning::
 
    Artifacts are entirely stored in memory in this example.

--- a/gitlab/v4/objects/artifacts.py
+++ b/gitlab/v4/objects/artifacts.py
@@ -25,30 +25,6 @@ class ProjectArtifactManager(RESTManager):
     _path = "/projects/{project_id}/jobs/artifacts"
     _from_parent_attrs = {"project_id": "id"}
 
-    @cli.register_custom_action(
-        "Project", ("ref_name", "job"), ("job_token",), custom_action="artifacts"
-    )
-    def __call__(
-        self,
-        *args: Any,
-        **kwargs: Any,
-    ) -> Optional[bytes]:
-        utils.warn(
-            message=(
-                "The project.artifacts() method is deprecated and will be removed in a "
-                "future version. Use project.artifacts.download() instead.\n"
-            ),
-            category=DeprecationWarning,
-        )
-        data = self.download(
-            *args,
-            **kwargs,
-        )
-        if TYPE_CHECKING:
-            assert data is not None
-            assert isinstance(data, bytes)
-        return data
-
     @exc.on_http_error(exc.GitlabDeleteError)
     def delete(self, **kwargs: Any) -> None:
         """Delete the project's artifacts on the server.

--- a/tests/functional/cli/test_cli_artifacts.py
+++ b/tests/functional/cli/test_cli_artifacts.py
@@ -77,29 +77,6 @@ def test_cli_project_artifact_download(gitlab_config, job_with_artifacts):
     assert is_zipfile(artifacts_zip)
 
 
-def test_cli_project_artifacts_warns_deprecated(gitlab_config, job_with_artifacts):
-    cmd = [
-        "gitlab",
-        "--config-file",
-        gitlab_config,
-        "project",
-        "artifacts",
-        "--id",
-        str(job_with_artifacts.pipeline["project_id"]),
-        "--ref-name",
-        job_with_artifacts.ref,
-        "--job",
-        job_with_artifacts.name,
-    ]
-
-    artifacts = subprocess.run(cmd, capture_output=True, check=True)
-    assert isinstance(artifacts.stdout, bytes)
-    assert b"DeprecationWarning" in artifacts.stderr
-
-    artifacts_zip = BytesIO(artifacts.stdout)
-    assert is_zipfile(artifacts_zip)
-
-
 def test_cli_project_artifact_raw(gitlab_config, job_with_artifacts):
     cmd = [
         "gitlab",

--- a/tests/unit/objects/test_job_artifacts.py
+++ b/tests/unit/objects/test_job_artifacts.py
@@ -46,12 +46,3 @@ def test_project_artifacts_download_by_ref_name(
     project = gl.projects.get(1, lazy=True)
     artifacts = project.artifacts.download(ref_name=ref_name, job=job)
     assert artifacts == binary_content
-
-
-def test_project_artifacts_by_ref_name_warns(
-    gl, binary_content, resp_artifacts_by_ref_name
-):
-    project = gl.projects.get(1, lazy=True)
-    with pytest.warns(DeprecationWarning):
-        artifacts = project.artifacts(ref_name=ref_name, job=job)
-    assert artifacts == binary_content


### PR DESCRIPTION
BREAKING CHANGE: The deprecated `project.artifacts()` method is no longer available. Use `project.artifacts.download()` instead.