### PR TITLE
refactor(projects): remove deprecated `project.transfer_project()` in favor of `project.transfer()`

### DIFF
--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -625,17 +625,6 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             path, post_data={"namespace": to_namespace}, **kwargs
         )
 
-    @cli.register_custom_action("Project", ("to_namespace",))
-    def transfer_project(self, *args: Any, **kwargs: Any) -> None:
-        utils.warn(
-            message=(
-                "The project.transfer_project() method is deprecated and will be "
-                "removed in a future version. Use project.transfer() instead."
-            ),
-            category=DeprecationWarning,
-        )
-        return self.transfer(*args, **kwargs)
-
     @cli.register_custom_action("Project", ("ref_name", "artifact_path", "job"))
     @exc.on_http_error(exc.GitlabGetError)
     def artifact(

--- a/tests/unit/objects/test_projects.py
+++ b/tests/unit/objects/test_projects.py
@@ -772,11 +772,6 @@ def test_artifact_project(project, resp_artifact):
         project.artifact("ref_name", "artifact_path", "job")
 
 
-def test_transfer_project_deprecated_warns(project, resp_transfer_project):
-    with pytest.warns(DeprecationWarning):
-        project.transfer_project("test-namespace")
-
-
 def test_project_pull_mirror(project, resp_start_pull_mirroring_project):
     project.mirror_pull()
 


### PR DESCRIPTION
BREAKING CHANGE: The deprecated `project.transfer_project()` method is no longer available. Use `project.transfer()` instead.

