### PR TITLE
refactor(artifacts): remove deprecated `artifact()`in favor of `artifacts.raw()`

### DIFF
--- a/docs/gl_objects/pipelines_and_jobs.rst
+++ b/docs/gl_objects/pipelines_and_jobs.rst
@@ -300,11 +300,6 @@ Get a single artifact file by branch and job::
 
     project.artifacts.raw('branch', 'path/to/file', 'job')
 
-.. attention::
-
-    An older method ``project.artifact()`` is deprecated and will be
-    removed in a future version.
-
 Mark a job artifact as kept when expiration is set::
 
     build_or_job.keep_artifacts()

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -625,26 +625,6 @@ class Project(RefreshMixin, SaveMixin, ObjectDeleteMixin, RepositoryMixin, RESTO
             path, post_data={"namespace": to_namespace}, **kwargs
         )
 
-    @cli.register_custom_action("Project", ("ref_name", "artifact_path", "job"))
-    @exc.on_http_error(exc.GitlabGetError)
-    def artifact(
-        self,
-        *args: Any,
-        **kwargs: Any,
-    ) -> Optional[bytes]:
-        utils.warn(
-            message=(
-                "The project.artifact() method is deprecated and will be "
-                "removed in a future version. Use project.artifacts.raw() instead."
-            ),
-            category=DeprecationWarning,
-        )
-        data = self.artifacts.raw(*args, **kwargs)
-        if TYPE_CHECKING:
-            assert data is not None
-            assert isinstance(data, bytes)
-        return data
-
 
 class ProjectManager(CRUDMixin, RESTManager):
     _path = "/projects"

--- a/tests/functional/cli/test_cli_artifacts.py
+++ b/tests/functional/cli/test_cli_artifacts.py
@@ -97,26 +97,3 @@ def test_cli_project_artifact_raw(gitlab_config, job_with_artifacts):
     artifacts = subprocess.run(cmd, capture_output=True, check=True)
     assert isinstance(artifacts.stdout, bytes)
     assert artifacts.stdout == b"test\n"
-
-
-def test_cli_project_artifact_warns_deprecated(gitlab_config, job_with_artifacts):
-    cmd = [
-        "gitlab",
-        "--config-file",
-        gitlab_config,
-        "project",
-        "artifact",
-        "--id",
-        str(job_with_artifacts.pipeline["project_id"]),
-        "--ref-name",
-        job_with_artifacts.ref,
-        "--job",
-        job_with_artifacts.name,
-        "--artifact-path",
-        "artifact.txt",
-    ]
-
-    artifacts = subprocess.run(cmd, capture_output=True, check=True)
-    assert isinstance(artifacts.stdout, bytes)
-    assert b"DeprecationWarning" in artifacts.stderr
-    assert artifacts.stdout == b"test\n"

--- a/tests/unit/objects/test_projects.py
+++ b/tests/unit/objects/test_projects.py
@@ -767,11 +767,6 @@ def test_transfer_project(project, resp_transfer_project):
     project.transfer("test-namespace")
 
 
-def test_artifact_project(project, resp_artifact):
-    with pytest.warns(DeprecationWarning):
-        project.artifact("ref_name", "artifact_path", "job")
-
-
 def test_project_pull_mirror(project, resp_start_pull_mirroring_project):
     project.mirror_pull()
 


### PR DESCRIPTION
BREAKING CHANGE: The deprecated `project.artifact()` method is no longer available. Use `project.artifacts.raw()` instead.
