### PR TITLE
refactor(list): `as_list` support is removed.

### DIFF
--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -843,7 +843,6 @@ class Gitlab:
         path: str,
         query_data: Optional[Dict[str, Any]] = None,
         *,
-        as_list: Optional[bool] = None,  # Deprecated in favor of `iterator`
         iterator: Optional[bool] = None,
         **kwargs: Any,
     ) -> Union["GitlabList", List[Dict[str, Any]]]:
@@ -870,23 +869,6 @@ class Gitlab:
         """
         query_data = query_data or {}
 
-        # Don't allow both `as_list` and `iterator` to be set.
-        if as_list is not None and iterator is not None:
-            raise ValueError(
-                "Only one of `as_list` or `iterator` can be used. "
-                "Use `iterator` instead of `as_list`. `as_list` is deprecated."
-            )
-
-        if as_list is not None:
-            iterator = not as_list
-            utils.warn(
-                message=(
-                    f"`as_list={as_list}` is deprecated and will be removed in a "
-                    f"future version. Use `iterator={iterator}` instead."
-                ),
-                category=DeprecationWarning,
-            )
-
         # Provide a `get_all`` param to avoid clashes with `all` API attributes.
         get_all = kwargs.pop("get_all", None)
 
@@ -900,8 +882,6 @@ class Gitlab:
 
         if iterator and page is not None:
             arg_used_message = f"iterator={iterator}"
-            if as_list is not None:
-                arg_used_message = f"as_list={as_list}"
             utils.warn(
                 message=(
                     f"`{arg_used_message}` and `page={page}` were both specified. "

--- a/tests/functional/api/test_gitlab.py
+++ b/tests/functional/api/test_gitlab.py
@@ -282,17 +282,3 @@ def test_list_iterator_true_nowarning(gl, recwarn):
     items = gl.gitlabciymls.list(iterator=True)
     assert not recwarn
     assert len(list(items)) > 20
-
-
-def test_list_as_list_false_warnings(gl):
-    """Using `as_list=False` will disable the UserWarning but cause a
-    DeprecationWarning"""
-    with pytest.warns(DeprecationWarning) as record:
-        items = gl.gitlabciymls.list(as_list=False)
-    assert len(record) == 1
-    assert len(list(items)) > 20
-
-
-def test_list_with_as_list_and_iterator_raises(gl):
-    with pytest.raises(ValueError, match="`as_list` or `iterator`"):
-        gl.gitlabciymls.list(as_list=False, iterator=True)

--- a/tests/unit/test_gitlab_http_methods.py
+++ b/tests/unit/test_gitlab_http_methods.py
@@ -556,14 +556,6 @@ def test_list_request_page_and_iterator(gl):
     assert len(result) == 20
     assert len(responses.calls) == 1
 
-    with pytest.warns(
-        UserWarning, match="`as_list=False` and `page=1` were both specified"
-    ):
-        result = gl.http_list("/projects", as_list=False, page=1)
-    assert isinstance(result, list)
-    assert len(result) == 20
-    assert len(responses.calls) == 2
-
 
 large_list_response = {
     "method": responses.GET,
@@ -594,24 +586,6 @@ large_list_response = {
     "status": 200,
     "match": helpers.MATCH_EMPTY_QUERY_PARAMS,
 }
-
-
-@responses.activate
-def test_as_list_deprecation_warning(gl):
-    responses.add(**large_list_response)
-
-    with warnings.catch_warnings(record=True) as caught_warnings:
-        result = gl.http_list("/projects", as_list=False)
-    assert len(caught_warnings) == 1
-    warning = caught_warnings[0]
-    assert isinstance(warning.message, DeprecationWarning)
-    message = str(warning.message)
-    assert "`as_list=False` is deprecated" in message
-    assert "Use `iterator=True` instead" in message
-    assert __file__ == warning.filename
-    assert not isinstance(result, list)
-    assert len(list(result)) == 20
-    assert len(responses.calls) == 1
 
 
 @responses.activate


### PR DESCRIPTION
In `list()` calls support for the `as_list` argument has been removed.
`as_list` was previously deprecated and now the use of `iterator` will
be required if wanting to have same functionality as using `as_list`

BREAKING CHANGE: Support for the deprecated `as_list` argument in
`list()` calls has been removed. Use `iterator` instead.

