### PR TITLE
docs: correct error with back-ticks

### DIFF
--- a/docs/gl_objects/runners.rst
+++ b/docs/gl_objects/runners.rst
@@ -77,7 +77,8 @@ Register a new runner::
    workflow comes with a new API endpoint to create runners, which does not use
    registration tokens.
 
-   The new endpoint can be called using ``gl.user.runners.create() after authenticating with `gl.auth()```.
+   The new endpoint can be called using ``gl.user.runners.create()`` after
+   authenticating with ``gl.auth()``.
 
 Update a runner::
 


### PR DESCRIPTION
New linting package update detected the issue.

<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

<!-- Remove this comment and describe your changes here. -->

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
