### PR TITLE
feat(api): add optional GET attrs for /projects/:id/ci/lint

### DIFF
--- a/gitlab/v4/objects/ci_lint.py
+++ b/gitlab/v4/objects/ci_lint.py
@@ -54,6 +54,7 @@ class ProjectCiLintManager(GetWithoutIdMixin, CreateMixin, RESTManager):
     _path = "/projects/{project_id}/ci/lint"
     _obj_cls = ProjectCiLint
     _from_parent_attrs = {"project_id": "id"}
+    _optional_get_attrs = ("dry_run", "include_jobs", "ref")
     _create_attrs = RequiredOptional(
         required=("content",), optional=("dry_run", "include_jobs", "ref")
     )


### PR DESCRIPTION
This PR adds definition of some optional attributes which where missing for [`GET /projects/:id/ci/lint`](https://docs.gitlab.com/ee/api/lint.html#validate-a-projects-ci-configuration) (in `CiLintManager`).

From a CLI point of view, **BEFORE:**
```
$ gitlab project-ci-lint get --help
usage: gitlab project-ci-lint get [-h] [--sudo SUDO] --project-id PROJECT_ID

options:
  -h, --help            show this help message and exit
  --sudo SUDO
  --project-id PROJECT_ID
```

**AFTER:**
```
$ gitlab project-ci-lint get --help
usage: gitlab project-ci-lint get [-h] [--sudo SUDO] --project-id PROJECT_ID [--dry-run DRY_RUN] [--include-jobs INCLUDE_JOBS] [--ref REF]

options:
  -h, --help            show this help message and exit
  --sudo SUDO
  --project-id PROJECT_ID
  --dry-run DRY_RUN
  --include-jobs INCLUDE_JOBS
  --ref REF
```

My actual use case was listing, from CLI, what would be the jobs of a pipeline; I can now get that with `--include-jobs true`.