### PR TITLE
feat(api): support project remote mirror deletion

### DIFF
--- a/docs/gl_objects/remote_mirrors.rst
+++ b/docs/gl_objects/remote_mirrors.rst
@@ -32,3 +32,7 @@ Update an existing remote mirror's attributes::
     mirror.enabled = False
     mirror.only_protected_branches = True
     mirror.save()
+
+Delete an existing remote mirror::
+
+  mirror.delete()

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -23,6 +23,7 @@ from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,
     CRUDMixin,
+    DeleteMixin,
     GetWithoutIdMixin,
     ListMixin,
     ObjectDeleteMixin,
@@ -1199,11 +1200,13 @@ class ProjectForkManager(CreateMixin, ListMixin, RESTManager):
         return cast(ProjectFork, CreateMixin.create(self, data, path=path, **kwargs))
 
 
-class ProjectRemoteMirror(SaveMixin, RESTObject):
+class ProjectRemoteMirror(ObjectDeleteMixin, SaveMixin, RESTObject):
     pass
 
 
-class ProjectRemoteMirrorManager(ListMixin, CreateMixin, UpdateMixin, RESTManager):
+class ProjectRemoteMirrorManager(
+    ListMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
+):
     _path = "/projects/{project_id}/remote_mirrors"
     _obj_cls = ProjectRemoteMirror
     _from_parent_attrs = {"project_id": "id"}

--- a/tests/functional/api/test_projects.py
+++ b/tests/functional/api/test_projects.py
@@ -282,6 +282,8 @@ def test_project_remote_mirrors(project):
     assert mirror.url == mirror_url
     assert mirror.enabled is True
 
+    mirror.delete()
+
 
 def test_project_services(project):
     # Use 'update' to create a service as we don't have a 'create' method and

--- a/tests/unit/objects/test_remote_mirrors.py
+++ b/tests/unit/objects/test_remote_mirrors.py
@@ -48,6 +48,12 @@ def resp_remote_mirrors():
             content_type="application/json",
             status=200,
         )
+
+        rsps.add(
+            method=responses.DELETE,
+            url="http://localhost/api/v4/projects/1/remote_mirrors/1",
+            status=204,
+        )
         yield rsps
 
 
@@ -70,3 +76,8 @@ def test_update_project_remote_mirror(project, resp_remote_mirrors):
     mirror.save()
     assert mirror.update_status == "finished"
     assert mirror.only_protected_branches
+
+
+def test_delete_project_remote_mirror(project, resp_remote_mirrors):
+    mirror = project.remote_mirrors.create({"url": "https://example.com"})
+    mirror.delete()


### PR DESCRIPTION
<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

Adding support for project remote mirror deletion

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [X] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [X] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
