### PR TITLE
fix(client): support empty 204 responses in http_patch

### DIFF
--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -1083,6 +1083,8 @@ class Gitlab:
             raw=raw,
             **kwargs,
         )
+        if result.status_code in gitlab.const.NO_JSON_RESPONSE_CODES:
+            return result
         try:
             json_result = result.json()
             if TYPE_CHECKING:

--- a/gitlab/const.py
+++ b/gitlab/const.py
@@ -95,6 +95,7 @@ SEARCH_SCOPE_PROJECT_NOTES = SearchScope.PROJECT_NOTES.value
 
 USER_AGENT: str = f"{__title__}/{__version__}"
 
+NO_JSON_RESPONSE_CODES = [204]
 RETRYABLE_TRANSIENT_ERROR_CODES = [500, 502, 503, 504] + list(range(520, 531))
 
 __all__ = [

--- a/tests/unit/test_gitlab_http_methods.py
+++ b/tests/unit/test_gitlab_http_methods.py
@@ -801,6 +801,21 @@ def test_patch_request(gl):
 
 
 @responses.activate
+def test_patch_request_204(gl):
+    url = "http://localhost/api/v4/projects"
+    responses.add(
+        method=responses.PATCH,
+        url=url,
+        status=204,
+        match=helpers.MATCH_EMPTY_QUERY_PARAMS,
+    )
+
+    result = gl.http_patch("/projects")
+    assert isinstance(result, requests.Response)
+    assert responses.assert_call_count(url, 1) is True
+
+
+@responses.activate
 def test_patch_request_404(gl):
     url = "http://localhost/api/v4/not_there"
     responses.add(


### PR DESCRIPTION
Needed for https://docs.gitlab.com/ee/api/project_job_token_scopes.html#patch-a-projects-cicd-job-token-access-settings