### PR TITLE
chore(ci): update release build for python-semantic-release v8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
 
+    - name: Install build dependency
+      run: pip install build
+
     - name: Python Semantic Release
       uses: python-semantic-release/python-semantic-release@v8.1.2
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,11 +88,11 @@ disable_error_code = ["no-untyped-def"]
 
 [tool.semantic_release]
 branch = "main"
+build_command = "python -m build ."
 version_variables = [
     "gitlab/_version.py:__version__",
 ]
-commit_subject = "chore: release v{version}"
-commit_message = ""
+commit_message = "chore: release v{version}"
 
 [tool.pylint.messages_control]
 max-line-length = 88


### PR DESCRIPTION
Fixes failure in https://github.com/python-gitlab/python-gitlab/actions/runs/6530439704/job/17729726207.

python-semantic-release uses a very similar config:
https://github.com/python-semantic-release/python-semantic-release/blob/master/pyproject.toml#L329-L331 