### PR TITLE
chore(ci): follow upstream config for release build_command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,6 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
 
-    - name: Install build dependency
-      run: pip install build
-
     - name: Python Semantic Release
       uses: python-semantic-release/python-semantic-release@v8.1.2
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,10 @@ disable_error_code = ["no-untyped-def"]
 
 [tool.semantic_release]
 branch = "main"
-build_command = "python -m build ."
+build_command = """
+    python -m pip install build~=0.10.0
+    python -m build .
+"""
 version_variables = [
     "gitlab/_version.py:__version__",
 ]


### PR DESCRIPTION
I missed that this action runs in a docker container so the earlier install had no effect it seems.