### PR TITLE
chore: add source label to container image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,6 @@ deploy-images:
     name: gcr.io/kaniko-project/executor:debug
     entrypoint: [""]
   script:
-    - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
     - executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile --destination $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG-alpine
     - executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile --destination $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG-slim-bullseye --build-arg PYTHON_FLAVOR=slim-bullseye
   rules:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN pip install build && python -m build
 
 FROM python:3.12-${PYTHON_FLAVOR}
 
+LABEL org.opencontainers.image.source="https://github.com/python-gitlab/python-gitlab"
+
 WORKDIR /opt/python-gitlab
 COPY --from=build /opt/python-gitlab/dist dist/
 RUN pip install PyYaml


### PR DESCRIPTION
## Changes

Adds the [OCI source label](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys) to the container image so that downstream tools know where the image comes from. This is for example used by Renovate Bot to fetch the changelog.

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)
