### PR TITLE
docs(users): add missing comma in v4 API create runner examples

### DIFF
--- a/docs/gl_objects/users.rst
+++ b/docs/gl_objects/users.rst
@@ -483,7 +483,7 @@ Create an instance-wide runner::
         "description": "My brand new runner",
         "paused": True,
         "locked": False,
-        "run_untagged": True
+        "run_untagged": True,
         "tag_list": ["linux", "docker", "testing"],
         "access_level": "not_protected"
     })
@@ -496,7 +496,7 @@ Create a group runner::
         "description": "My brand new runner",
         "paused": True,
         "locked": False,
-        "run_untagged": True
+        "run_untagged": True,
         "tag_list": ["linux", "docker", "testing"],
         "access_level": "not_protected"
     })
@@ -509,7 +509,7 @@ Create a project runner::
         "description": "My brand new runner",
         "paused": True,
         "locked": False,
-        "run_untagged": True
+        "run_untagged": True,
         "tag_list": ["linux", "docker", "testing"],
         "access_level": "not_protected"
     })


### PR DESCRIPTION
The examples which show usage of new runner registration api endpoint are missing commas. This change adds the missing commas.

## Changes

Fix examples in v4 runner registration API docs.