### PR TITLE
fix(cli): add ability to disable SSL verification

### DIFF
--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -194,14 +194,25 @@ def _get_base_parser(add_help: bool = True) -> argparse.ArgumentParser:
         required=False,
         default=os.getenv("GITLAB_URL"),
     )
-    parser.add_argument(
+
+    ssl_verify_group = parser.add_mutually_exclusive_group()
+    ssl_verify_group.add_argument(
         "--ssl-verify",
         help=(
-            "Whether SSL certificates should be validated. [env var: GITLAB_SSL_VERIFY]"
+            "Path to a CA_BUNDLE file or directory with certificates of trusted CAs. "
+            "[env var: GITLAB_SSL_VERIFY]"
         ),
         required=False,
         default=os.getenv("GITLAB_SSL_VERIFY"),
     )
+    ssl_verify_group.add_argument(
+        "--no-ssl-verify",
+        help="Disable SSL verification",
+        required=False,
+        dest="ssl_verify",
+        action="store_false",
+    )
+
     parser.add_argument(
         "--timeout",
         help=(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -106,6 +106,13 @@ def test_base_parser():
     assert args.verbose
     assert args.gitlab == "gl_id"
     assert args.config_file == ["foo.cfg", "bar.cfg"]
+    assert args.ssl_verify is None
+
+
+def test_no_ssl_verify():
+    parser = cli._get_base_parser()
+    args = parser.parse_args(["--no-ssl-verify"])
+    assert args.ssl_verify is False
 
 
 def test_v4_parse_args():


### PR DESCRIPTION
Add a `--no-ssl-verify` option to disable SSL verification

Closes: #2714

<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

<!-- Remove this comment and describe your changes here. -->

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
