### PR TITLE
feat(api): add support for wiki attachments

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -15,6 +15,6 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v4.0.1
+      - uses: dessant/lock-threads@v5.0.0
         with:
           process-only: 'issues'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.10.1
+    rev: 23.11.0
     hooks:
       - id: black
   - repo: https://github.com/commitizen-tools/commitizen
@@ -30,7 +30,7 @@ repos:
           - requests-toolbelt==1.0.0
         files: 'gitlab/'
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.6.1
+    rev: v1.7.0
     hooks:
       - id: mypy
         args: []
@@ -47,6 +47,6 @@ repos:
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
   - repo: https://github.com/maxbrunet/pre-commit-renovate
-    rev: 37.46.0
+    rev: 37.61.3
     hooks:
       - id: renovate-config-validator

--- a/docs/gl_objects/wikis.rst
+++ b/docs/gl_objects/wikis.rst
@@ -54,3 +54,39 @@ Update a wiki page::
 Delete a wiki page::
 
     page.delete()
+
+
+File uploads
+============
+
+Reference
+---------
+
+* v4 API:
+
+  + :attr:`gitlab.v4.objects.ProjectWiki.upload`
+  + :attr:`gitlab.v4.objects.GrouptWiki.upload`
+
+
+* Gitlab API for Projects: https://docs.gitlab.com/ee/api/wikis.html#upload-an-attachment-to-the-wiki-repository
+* Gitlab API for Groups: https://docs.gitlab.com/ee/api/group_wikis.html#upload-an-attachment-to-the-wiki-repository
+
+Examples
+--------
+
+Upload a file into a project wiki using a filesystem path::
+
+    page.upload("filename.txt", filepath="/some/path/filename.txt")
+
+Upload a file into a project wiki without a filesystem path::
+
+    page.upload("filename.txt", filedata="Raw data")
+
+Upload a file into a project wiki using a filesystem path::
+
+    page.upload("filename.txt", filepath="/some/path/filename.txt")
+
+Upload a file into a project wiki without a filesystem path::
+
+    page.upload("filename.txt", filedata="Raw data")
+

--- a/docs/gl_objects/wikis.rst
+++ b/docs/gl_objects/wikis.rst
@@ -76,17 +76,19 @@ Examples
 
 Upload a file into a project wiki using a filesystem path::
 
+    page = project.wikis.get(page_slug)
     page.upload("filename.txt", filepath="/some/path/filename.txt")
 
-Upload a file into a project wiki without a filesystem path::
+Upload a file into a project wiki with raw data::
 
     page.upload("filename.txt", filedata="Raw data")
 
-Upload a file into a project wiki using a filesystem path::
+Upload a file into a group wiki using a filesystem path::
 
+    page = group.wikis.get(page_slug)
     page.upload("filename.txt", filepath="/some/path/filename.txt")
 
-Upload a file into a project wiki without a filesystem path::
+Upload a file into a group wiki using raw data::
 
     page.upload("filename.txt", filedata="Raw data")
 

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -944,3 +944,74 @@ class PromoteMixin(_RestObjectBase):
         if TYPE_CHECKING:
             assert not isinstance(result, requests.Response)
         return result
+
+
+class UploadMixin(_RestObjectBase):
+    _id_attr: Optional[str]
+    _attrs: Dict[str, Any]
+    _module: ModuleType
+    _parent_attrs: Dict[str, Any]
+    _updated_attrs: Dict[str, Any]
+    _upload_path: str
+    manager: base.RESTManager
+
+    def _get_upload_path(self) -> str:
+        """Formats _upload_path with object attributes.
+
+        Returns:
+            The upload path
+        """
+        if TYPE_CHECKING:
+            assert isinstance(self._upload_path, str)
+        data = self.attributes
+        return self._upload_path.format(**data)
+
+    @cli.register_custom_action(("Project", "ProjectWiki"), ("filename", "filepath"))
+    @exc.on_http_error(exc.GitlabUploadError)
+    def upload(
+        self,
+        filename: str,
+        filedata: Optional[bytes] = None,
+        filepath: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Upload the specified file.
+
+        .. note::
+
+            Either ``filedata`` or ``filepath`` *MUST* be specified.
+
+        Args:
+            path: api endpoint where file is to be posted
+            filename: The name of the file being uploaded
+            filedata: The raw data of the file being uploaded
+            filepath: The path to a local file to upload (optional)
+
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabUploadError: If the file upload fails
+            GitlabUploadError: If ``filedata`` and ``filepath`` are not
+                specified
+            GitlabUploadError: If both ``filedata`` and ``filepath`` are
+                specified
+
+        Returns:
+            A ``dict`` with info on the uploaded file
+        """
+        if filepath is None and filedata is None:
+            raise exc.GitlabUploadError("No file contents or path specified")
+
+        if filedata is not None and filepath is not None:
+            raise exc.GitlabUploadError("File contents and file path specified")
+
+        if filepath is not None:
+            with open(filepath, "rb") as f:
+                filedata = f.read()
+
+        file_info = {"file": (filename, filedata)}
+        path = self._get_upload_path()
+        server_data = self.manager.gitlab.http_post(path, files=file_info, **kwargs)
+
+        if TYPE_CHECKING:
+            assert isinstance(server_data, dict)
+        return server_data

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -982,7 +982,6 @@ class UploadMixin(_RestObjectBase):
             Either ``filedata`` or ``filepath`` *MUST* be specified.
 
         Args:
-            path: api endpoint where file is to be posted
             filename: The name of the file being uploaded
             filedata: The raw data of the file being uploaded
             filepath: The path to a local file to upload (optional)

--- a/gitlab/v4/objects/wikis.py
+++ b/gitlab/v4/objects/wikis.py
@@ -1,7 +1,7 @@
 from typing import Any, cast, Union
 
 from gitlab.base import RESTManager, RESTObject
-from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
+from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin, UploadMixin
 from gitlab.types import RequiredOptional
 
 __all__ = [
@@ -12,9 +12,10 @@ __all__ = [
 ]
 
 
-class ProjectWiki(SaveMixin, ObjectDeleteMixin, RESTObject):
+class ProjectWiki(SaveMixin, ObjectDeleteMixin, UploadMixin, RESTObject):
     _id_attr = "slug"
     _repr_attr = "slug"
+    _upload_path = "/projects/{project_id}/wikis/attachments"
 
 
 class ProjectWikiManager(CRUDMixin, RESTManager):
@@ -33,9 +34,10 @@ class ProjectWikiManager(CRUDMixin, RESTManager):
         return cast(ProjectWiki, super().get(id=id, lazy=lazy, **kwargs))
 
 
-class GroupWiki(SaveMixin, ObjectDeleteMixin, RESTObject):
+class GroupWiki(SaveMixin, ObjectDeleteMixin, UploadMixin, RESTObject):
     _id_attr = "slug"
     _repr_attr = "slug"
+    _upload_path = "/groups/{group_id}/wikis/attachments"
 
 
 class GroupWikiManager(CRUDMixin, RESTManager):

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,13 +1,13 @@
 -r requirements.txt
 argcomplete==2.0.0
-black==23.10.1
+black==23.11.0
 commitizen==3.12.0
 flake8==6.1.0
 isort==5.12.0
-mypy==1.6.1
+mypy==1.7.0
 pylint==3.0.2
 pytest==7.4.3
-responses==0.24.0
+responses==0.24.1
 types-PyYAML==6.0.12.12
 types-requests==2.31.0.10
-types-setuptools==68.2.0.0
+types-setuptools==68.2.0.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,5 +6,5 @@ pytest-cov==4.1.0
 pytest-github-actions-annotate-failures==0.2.0
 pytest==7.4.3
 PyYaml==6.0.1
-responses==0.24.0
+responses==0.24.1
 wheel==0.41.3

--- a/tests/functional/api/test_wikis.py
+++ b/tests/functional/api/test_wikis.py
@@ -4,7 +4,7 @@ https://docs.gitlab.com/ee/api/wikis.html
 """
 
 
-def test_wikis(project):
+def test_project_wikis(project):
     page = project.wikis.create({"title": "title/subtitle", "content": "test content"})
     page.content = "update content"
     page.title = "subtitle"
@@ -12,3 +12,51 @@ def test_wikis(project):
     page.save()
 
     page.delete()
+
+
+def test_project_wiki_file_upload(project):
+    page = project.wikis.create(
+        {"title": "title/subtitle", "content": "test page content"}
+    )
+    filename = "test.txt"
+    file_contents = "testing contents"
+
+    uploaded_file = page.upload(filename, file_contents)
+
+    link = uploaded_file["link"]
+    file_name = uploaded_file["file_name"]
+    file_path = uploaded_file["file_path"]
+    assert file_name == filename
+    assert file_path.startswith("uploads/")
+    assert file_path.endswith(f"/{filename}")
+    assert link["url"] == file_path
+    assert link["markdown"] == f"[{file_name}]({file_path})"
+
+
+def test_group_wikis(group):
+    page = group.wikis.create({"title": "title/subtitle", "content": "test content"})
+    page.content = "update content"
+    page.title = "subtitle"
+
+    page.save()
+
+    page.delete()
+
+
+def test_group_wiki_file_upload(group):
+    page = group.wikis.create(
+        {"title": "title/subtitle", "content": "test page content"}
+    )
+    filename = "test.txt"
+    file_contents = "testing contents"
+
+    uploaded_file = page.upload(filename, file_contents)
+
+    link = uploaded_file["link"]
+    file_name = uploaded_file["file_name"]
+    file_path = uploaded_file["file_path"]
+    assert file_name == filename
+    assert file_path.startswith("uploads/")
+    assert file_path.endswith(f"/{filename}")
+    assert link["url"] == file_path
+    assert link["markdown"] == f"[{file_name}]({file_path})"

--- a/tests/unit/objects/test_projects.py
+++ b/tests/unit/objects/test_projects.py
@@ -2,9 +2,12 @@
 GitLab API: https://docs.gitlab.com/ce/api/projects.html
 """
 
+from unittest.mock import mock_open, patch
+
 import pytest
 import responses
 
+from gitlab import exceptions
 from gitlab.const import DEVELOPER_ACCESS, SEARCH_SCOPE_ISSUES
 from gitlab.v4.objects import (
     Project,
@@ -49,7 +52,12 @@ project_starrers_content = {
         "name": "name",
     },
 }
-
+upload_file_content = {
+    "alt": "filename",
+    "url": "/uploads/66dbcd21ec5d24ed6ea225176098d52b/filename.png",
+    "full_path": "/namespace/project/uploads/66dbcd21ec5d24ed6ea225176098d52b/filename.png",
+    "markdown": "![dk](/uploads/66dbcd21ec5d24ed6ea225176098d52b/filename.png)",
+}
 share_project_content = {
     "id": 1,
     "project_id": 1,
@@ -322,6 +330,19 @@ def resp_delete_project(accepted_content):
             json=accepted_content,
             content_type="application/json",
             status=202,
+        )
+        yield rsps
+
+
+@pytest.fixture
+def resp_upload_file_project():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.POST,
+            url="http://localhost/api/v4/projects/1/uploads",
+            json=upload_file_content,
+            content_type="application/json",
+            status=201,
         )
         yield rsps
 
@@ -659,6 +680,29 @@ def test_unarchive_project(project, resp_unarchive_project):
 
 def test_delete_project(project, resp_delete_project):
     project.delete()
+
+
+def test_upload_file(project, resp_upload_file_project):
+    project.upload("filename.png", "raw\nfile\ndata")
+
+
+def test_upload_file_with_filepath(project, resp_upload_file_project):
+    with patch("builtins.open", mock_open(read_data="raw\nfile\ndata")):
+        project.upload("filename.png", None, "/filepath")
+
+
+def test_upload_file_without_filepath_nor_filedata(project):
+    with pytest.raises(
+        exceptions.GitlabUploadError, match="No file contents or path specified"
+    ):
+        project.upload("filename.png")
+
+
+def test_upload_file_with_filepath_and_filedata(project):
+    with pytest.raises(
+        exceptions.GitlabUploadError, match="File contents and file path specified"
+    ):
+        project.upload("filename.png", "filedata", "/filepath")
 
 
 def test_share_project(project, group, resp_share_project):


### PR DESCRIPTION

## Changes

UploadMixin added, inherits from RESTObject;
UploadMixin used in projects.py and wikis.py to upload files; 
Test for upload to wiki api added in tests/functional/api/test_wikis.
Documentation and unit tests not yet added - waiting for corrections/objections 

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
