### PR TITLE
feat: add pipeline status as Enum

### DIFF
--- a/gitlab/const.py
+++ b/gitlab/const.py
@@ -72,6 +72,21 @@ class DetailedMergeStatus(GitlabEnum):
     POLICIES_DENIED: str = "policies_denied"
 
 
+# https://docs.gitlab.com/ee/api/pipelines.html
+class PipelineStatus(GitlabEnum):
+    CREATED: str = "created"
+    WAITING_FOR_RESOURCE: str = "waiting_for_resource"
+    PREPARING: str = "preparing"
+    PENDING: str = "pending"
+    RUNNING: str = "running"
+    SUCCESS: str = "success"
+    FAILED: str = "failed"
+    CANCELED: str = "canceled"
+    SKIPPED: str = "skipped"
+    MANUAL: str = "manual"
+    SCHEDULED: str = "scheduled"
+
+
 DEFAULT_URL: str = "https://gitlab.com"
 
 NO_ACCESS = AccessLevel.NO_ACCESS.value


### PR DESCRIPTION
https://docs.gitlab.com/ee/api/pipelines.html

Would be nice to extend the [ProjectPipeline object](https://python-gitlab.readthedocs.io/en/stable/api/gitlab.v4.html#gitlab.v4.objects.ProjectPipeline) with an api to get the status that returns this, but 100% how do that.