### PR TITLE
feat(api): add get_reviewers call for mergrequest to get reviewers of…

### DIFF
--- a/docs/gl_objects/merge_requests.rst
+++ b/docs/gl_objects/merge_requests.rst
@@ -94,6 +94,10 @@ Get a single MR::
 
     mr = project.mergerequests.get(mr_iid)
 
+Get MR reviewer details::
+    mr = project.mergerequests.get(mr_iid)
+    reviewers = mr.reviewer_details.list()
+
 Create a MR::
 
     mr = project.mergerequests.create({'source_branch': 'cool_feature',

--- a/gitlab/v4/objects/__init__.py
+++ b/gitlab/v4/objects/__init__.py
@@ -56,6 +56,7 @@ from .push_rules import *
 from .releases import *
 from .repositories import *
 from .resource_groups import *
+from .reviewers import *
 from .runners import *
 from .secure_files import *
 from .settings import *

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -42,6 +42,7 @@ from .merge_request_approvals import (  # noqa: F401
 )
 from .notes import ProjectMergeRequestNoteManager  # noqa: F401
 from .pipelines import ProjectMergeRequestPipelineManager  # noqa: F401
+from .reviewers import ProjectMergeRequestReviewerDetailManager
 
 __all__ = [
     "MergeRequest",
@@ -164,6 +165,7 @@ class ProjectMergeRequest(
     resourcelabelevents: ProjectMergeRequestResourceLabelEventManager
     resourcemilestoneevents: ProjectMergeRequestResourceMilestoneEventManager
     resourcestateevents: ProjectMergeRequestResourceStateEventManager
+    reviewer_details: ProjectMergeRequestReviewerDetailManager
 
     @cli.register_custom_action("ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabMROnBuildSuccessError)

--- a/gitlab/v4/objects/reviewers.py
+++ b/gitlab/v4/objects/reviewers.py
@@ -1,0 +1,17 @@
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import ListMixin
+
+__all__ = [
+    "ProjectMergeRequestReviewerDetail",
+    "ProjectMergeRequestReviewerDetailManager",
+]
+
+
+class ProjectMergeRequestReviewerDetail(RESTObject):
+    pass
+
+
+class ProjectMergeRequestReviewerDetailManager(ListMixin, RESTManager):
+    _path = "/projects/{project_id}/merge_requests/{mr_iid}/reviewers"
+    _obj_cls = ProjectMergeRequestReviewerDetail
+    _from_parent_attrs = {"project_id": "project_id", "mr_iid": "iid"}

--- a/tests/unit/objects/test_merge_requests.py
+++ b/tests/unit/objects/test_merge_requests.py
@@ -8,7 +8,11 @@ import re
 import pytest
 import responses
 
-from gitlab.v4.objects import ProjectDeploymentMergeRequest, ProjectMergeRequest
+from gitlab.v4.objects import (
+    ProjectDeploymentMergeRequest,
+    ProjectMergeRequest,
+    ProjectMergeRequestReviewerDetail,
+)
 
 mr_content = {
     "id": 1,
@@ -25,7 +29,32 @@ mr_content = {
         "avatar_url": "https://gitlab.example.com/uploads/-/system/user/avatar/87854/avatar.png",
         "web_url": "https://gitlab.com/DouweM",
     },
+    "reviewers": [
+        {
+            "id": 2,
+            "name": "Sam Bauch",
+            "username": "kenyatta_oconnell",
+            "state": "active",
+            "avatar_url": "https://www.gravatar.com/avatar/956c92487c6f6f7616b536927e22c9a0?s=80&d=identicon",
+            "web_url": "http://gitlab.example.com//kenyatta_oconnell",
+        }
+    ],
 }
+
+reviewers_content = [
+    {
+        "user": {
+            "id": 2,
+            "name": "Sam Bauch",
+            "username": "kenyatta_oconnell",
+            "state": "active",
+            "avatar_url": "https://www.gravatar.com/avatar/956c92487c6f6f7616b536927e22c9a0?s=80&d=identicon",
+            "web_url": "http://gitlab.example.com//kenyatta_oconnell",
+        },
+        "state": "unreviewed",
+        "created_at": "2022-07-27T17:03:27.684Z",
+    }
+]
 
 
 @pytest.fixture
@@ -43,6 +72,26 @@ def resp_list_merge_requests():
         yield rsps
 
 
+@pytest.fixture
+def resp_get_merge_request_reviewers():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.GET,
+            url="http://localhost/api/v4/projects/1/merge_requests/1",
+            json=mr_content,
+            content_type="application/json",
+            status=200,
+        )
+        rsps.add(
+            method=responses.GET,
+            url="http://localhost/api/v4/projects/3/merge_requests/1/reviewers",
+            json=reviewers_content,
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
 def test_list_project_merge_requests(project, resp_list_merge_requests):
     mrs = project.mergerequests.list()
     assert isinstance(mrs[0], ProjectMergeRequest)
@@ -54,3 +103,14 @@ def test_list_deployment_merge_requests(project, resp_list_merge_requests):
     mrs = deployment.mergerequests.list()
     assert isinstance(mrs[0], ProjectDeploymentMergeRequest)
     assert mrs[0].iid == mr_content["iid"]
+
+
+def test_get_merge_request_reviewers(project, resp_get_merge_request_reviewers):
+    mr = project.mergerequests.get(1)
+    reviewers_details = mr.reviewer_details.list()
+    assert isinstance(mr, ProjectMergeRequest)
+    assert isinstance(reviewers_details, list)
+    assert isinstance(reviewers_details[0], ProjectMergeRequestReviewerDetail)
+    assert mr.reviewers[0]["name"] == reviewers_details[0].user["name"]
+    assert reviewers_details[0].state == "unreviewed"
+    assert reviewers_details[0].created_at == "2022-07-27T17:03:27.684Z"


### PR DESCRIPTION
Those changes implements 'GET /projects/:id/merge_requests/:merge_request_iid/reviewers' gitlab API call. Naming for call is not reviewers because reviewers atribute already present in merge request class.
https://docs.gitlab.com/ee/api/merge_requests.html#get-single-merge-request-reviewers

Closes: https://github.com/python-gitlab/python-gitlab/issues/2733

<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

<!-- Remove this comment and describe your changes here. -->

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
