### PR TITLE
docs: fix rst link typo in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -42,7 +42,7 @@ This creates a clearer project history, and automates our `Releases`_ and change
 Coding Style
 ------------
 
-We use `black<https://github.com/python/black>`_ and `isort <https://pycqa.github.io/isort/>`_
+We use `black <https://github.com/python/black/>`_ and `isort <https://pycqa.github.io/isort/>`_
 to format our code, so you'll need to make sure you use it when committing.
 
 Pre-commit hooks will validate and format your code, so you can then stage any changes done if the commit failed.


### PR DESCRIPTION
<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

<!-- Remove this comment and describe your changes here. -->

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
