### PR TITLE
fix(cli): support binary files with `@` notation

### DIFF
--- a/tests/functional/cli/test_cli_v4.py
+++ b/tests/functional/cli/test_cli_v4.py
@@ -540,12 +540,15 @@ def test_update_application_settings(gitlab_cli):
     assert ret.success
 
 
-def test_create_project_with_values_from_file(gitlab_cli, tmpdir):
+def test_create_project_with_values_from_file(gitlab_cli, fixture_dir, tmpdir):
     name = "gitlab-project-from-file"
     description = "Multiline\n\nData\n"
     from_file = tmpdir.join(name)
     from_file.write(description)
     from_file_path = f"@{str(from_file)}"
+    avatar_file = fixture_dir / "avatar.png"
+    assert avatar_file.exists()
+    avatar_file_path = f"@{avatar_file}"
 
     cmd = [
         "-v",
@@ -555,6 +558,8 @@ def test_create_project_with_values_from_file(gitlab_cli, tmpdir):
         name,
         "--description",
         from_file_path,
+        "--avatar",
+        avatar_file_path,
     ]
     ret = gitlab_cli(cmd)
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,9 +1,9 @@
 import argparse
+import contextlib
 import io
 import os
 import sys
 import tempfile
-from contextlib import redirect_stderr  # noqa: H302
 from unittest import mock
 
 import pytest
@@ -62,7 +62,7 @@ def test_cls_to_gitlab_resource(class_name, expected_gitlab_resource):
 )
 def test_die(message, error, expected):
     fl = io.StringIO()
-    with redirect_stderr(fl):
+    with contextlib.redirect_stderr(fl):
         with pytest.raises(SystemExit) as test:
             cli.die(message, error)
     assert fl.getvalue() == expected
@@ -90,12 +90,11 @@ def test_parse_value():
     os.unlink(temp_path)
 
     fl = io.StringIO()
-    with redirect_stderr(fl):
+    with contextlib.redirect_stderr(fl):
         with pytest.raises(SystemExit) as exc:
             cli._parse_value("@/thisfileprobablydoesntexist")
-        assert (
-            fl.getvalue() == "[Errno 2] No such file or directory:"
-            " '/thisfileprobablydoesntexist'\n"
+        assert fl.getvalue().startswith(
+            "FileNotFoundError: [Errno 2] No such file or directory:"
         )
         assert exc.value.code == 1
 


### PR DESCRIPTION
Support binary files being used in the CLI with arguments using the
`@` notation. For example `--avatar @/path/to/avatar.png`

Also explicitly catch the common FileNotFoundError and PermissionError
exceptions.

Remove the bare exception handling. We would rather have the full
traceback of any exceptions that we don't know about and add them
later if needed.

Closes: #2752
