### PR TITLE
feat(api): support access token rotate API

### DIFF
--- a/docs/gl_objects/group_access_tokens.rst
+++ b/docs/gl_objects/group_access_tokens.rst
@@ -37,3 +37,12 @@ Revoke a group access token::
     gl.groups.get(1).access_tokens.delete(42)
     # or
     access_token.delete()
+
+Rotate a group access token and retrieve its new value::
+
+    token = group.access_tokens.get(42, lazy=True)
+    token.rotate()
+    print(token.token)
+    # or directly using a token ID
+    new_token = group.access_tokens.rotate(42)
+    print(new_token.token)

--- a/docs/gl_objects/personal_access_tokens.rst
+++ b/docs/gl_objects/personal_access_tokens.rst
@@ -52,6 +52,15 @@ Revoke the personal access token currently used::
 
     gl.personal_access_tokens.delete("self")
 
+Rotate a personal access token and retrieve its new value::
+
+    token = gl.personal_access_tokens.get(42, lazy=True)
+    token.rotate()
+    print(token.token)
+    # or directly using a token ID
+    new_token = gl.personal_access_tokens.rotate(42)
+    print(new_token.token)
+
 Create a personal access token for a user (admin only)::
 
     user = gl.users.get(25, lazy=True)

--- a/docs/gl_objects/project_access_tokens.rst
+++ b/docs/gl_objects/project_access_tokens.rst
@@ -32,8 +32,17 @@ Create project access token::
 
     access_token = gl.projects.get(1).access_tokens.create({"name": "test", "scopes": ["api"], "expires_at": "2023-06-06"})
 
-Revoke a project access tokens::
+Revoke a project access token::
 
     gl.projects.get(1).access_tokens.delete(42)
     # or
     access_token.delete()
+
+Rotate a project access token and retrieve its new value::
+
+    token = project.access_tokens.get(42, lazy=True)
+    token.rotate()
+    print(token.token)
+    # or directly using a token ID
+    new_token = project.access_tokens.rotate(42)
+    print(new_token.token)

--- a/gitlab/exceptions.py
+++ b/gitlab/exceptions.py
@@ -288,6 +288,10 @@ class GitlabRevertError(GitlabOperationError):
     pass
 
 
+class GitlabRotateError(GitlabOperationError):
+    pass
+
+
 class GitlabLicenseError(GitlabOperationError):
     pass
 
@@ -397,6 +401,7 @@ __all__ = [
     "GitlabRestoreError",
     "GitlabRetryError",
     "GitlabRevertError",
+    "GitlabRotateError",
     "GitlabSearchError",
     "GitlabSetError",
     "GitlabStopError",

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -653,6 +653,65 @@ class DownloadMixin(_RestObjectBase):
         )
 
 
+class RotateMixin(_RestManagerBase):
+    _computed_path: Optional[str]
+    _from_parent_attrs: Dict[str, Any]
+    _obj_cls: Optional[Type[base.RESTObject]]
+    _parent: Optional[base.RESTObject]
+    _parent_attrs: Dict[str, Any]
+    _path: Optional[str]
+    gitlab: gitlab.Gitlab
+
+    @exc.on_http_error(exc.GitlabRotateError)
+    def rotate(
+        self, id: Union[str, int], expires_at: Optional[str] = None, **kwargs: Any
+    ) -> Dict[str, Any]:
+        """Rotate an access token.
+
+        Args:
+            id: ID of the token to rotate
+            **kwargs: Extra options to send to the server (e.g. sudo)
+
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabRotateError: If the server cannot perform the request
+        """
+        path = f"{self.path}/{utils.EncodedId(id)}/rotate"
+        data: Dict[str, Any] = {}
+        if expires_at is not None:
+            data = {"expires_at": expires_at}
+
+        server_data = self.gitlab.http_post(path, post_data=data, **kwargs)
+        if TYPE_CHECKING:
+            assert not isinstance(server_data, requests.Response)
+        return server_data
+
+
+class ObjectRotateMixin(_RestObjectBase):
+    _id_attr: Optional[str]
+    _attrs: Dict[str, Any]
+    _module: ModuleType
+    _parent_attrs: Dict[str, Any]
+    _updated_attrs: Dict[str, Any]
+    manager: base.RESTManager
+
+    def rotate(self, **kwargs: Any) -> None:
+        """Rotate the current access token object.
+
+        Args:
+            **kwargs: Extra options to send to the server (e.g. sudo)
+
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabRotateError: If the server cannot perform the request
+        """
+        if TYPE_CHECKING:
+            assert isinstance(self.manager, RotateMixin)
+            assert self.encoded_id is not None
+        server_data = self.manager.rotate(self.encoded_id, **kwargs)
+        self._update_attrs(server_data)
+
+
 class SubscribableMixin(_RestObjectBase):
     _id_attr: Optional[str]
     _attrs: Dict[str, Any]

--- a/gitlab/v4/objects/group_access_tokens.py
+++ b/gitlab/v4/objects/group_access_tokens.py
@@ -1,7 +1,14 @@
 from typing import Any, cast, Union
 
 from gitlab.base import RESTManager, RESTObject
-from gitlab.mixins import CreateMixin, DeleteMixin, ObjectDeleteMixin, RetrieveMixin
+from gitlab.mixins import (
+    CreateMixin,
+    DeleteMixin,
+    ObjectDeleteMixin,
+    ObjectRotateMixin,
+    RetrieveMixin,
+    RotateMixin,
+)
 from gitlab.types import ArrayAttribute, RequiredOptional
 
 __all__ = [
@@ -10,11 +17,13 @@ __all__ = [
 ]
 
 
-class GroupAccessToken(ObjectDeleteMixin, RESTObject):
+class GroupAccessToken(ObjectDeleteMixin, ObjectRotateMixin, RESTObject):
     pass
 
 
-class GroupAccessTokenManager(CreateMixin, DeleteMixin, RetrieveMixin, RESTManager):
+class GroupAccessTokenManager(
+    CreateMixin, DeleteMixin, RetrieveMixin, RotateMixin, RESTManager
+):
     _path = "/groups/{group_id}/access_tokens"
     _obj_cls = GroupAccessToken
     _from_parent_attrs = {"group_id": "id"}

--- a/gitlab/v4/objects/personal_access_tokens.py
+++ b/gitlab/v4/objects/personal_access_tokens.py
@@ -1,7 +1,14 @@
 from typing import Any, cast, Union
 
 from gitlab.base import RESTManager, RESTObject
-from gitlab.mixins import CreateMixin, DeleteMixin, ObjectDeleteMixin, RetrieveMixin
+from gitlab.mixins import (
+    CreateMixin,
+    DeleteMixin,
+    ObjectDeleteMixin,
+    ObjectRotateMixin,
+    RetrieveMixin,
+    RotateMixin,
+)
 from gitlab.types import ArrayAttribute, RequiredOptional
 
 __all__ = [
@@ -12,11 +19,11 @@ __all__ = [
 ]
 
 
-class PersonalAccessToken(ObjectDeleteMixin, RESTObject):
+class PersonalAccessToken(ObjectDeleteMixin, ObjectRotateMixin, RESTObject):
     pass
 
 
-class PersonalAccessTokenManager(DeleteMixin, RetrieveMixin, RESTManager):
+class PersonalAccessTokenManager(DeleteMixin, RetrieveMixin, RotateMixin, RESTManager):
     _path = "/personal_access_tokens"
     _obj_cls = PersonalAccessToken
     _list_filters = ("user_id",)

--- a/gitlab/v4/objects/project_access_tokens.py
+++ b/gitlab/v4/objects/project_access_tokens.py
@@ -1,7 +1,14 @@
 from typing import Any, cast, Union
 
 from gitlab.base import RESTManager, RESTObject
-from gitlab.mixins import CreateMixin, DeleteMixin, ObjectDeleteMixin, RetrieveMixin
+from gitlab.mixins import (
+    CreateMixin,
+    DeleteMixin,
+    ObjectDeleteMixin,
+    ObjectRotateMixin,
+    RetrieveMixin,
+    RotateMixin,
+)
 from gitlab.types import ArrayAttribute, RequiredOptional
 
 __all__ = [
@@ -10,11 +17,13 @@ __all__ = [
 ]
 
 
-class ProjectAccessToken(ObjectDeleteMixin, RESTObject):
+class ProjectAccessToken(ObjectDeleteMixin, ObjectRotateMixin, RESTObject):
     pass
 
 
-class ProjectAccessTokenManager(CreateMixin, DeleteMixin, RetrieveMixin, RESTManager):
+class ProjectAccessTokenManager(
+    CreateMixin, DeleteMixin, RetrieveMixin, RotateMixin, RESTManager
+):
     _path = "/projects/{project_id}/access_tokens"
     _obj_cls = ProjectAccessToken
     _from_parent_attrs = {"project_id": "id"}

--- a/tests/unit/objects/conftest.py
+++ b/tests/unit/objects/conftest.py
@@ -32,6 +32,7 @@ def token_content():
         "active": True,
         "created_at": "2021-01-20T22:11:48.151Z",
         "revoked": False,
+        "token": "s3cr3t",
     }
 
 

--- a/tests/unit/objects/test_group_access_tokens.py
+++ b/tests/unit/objects/test_group_access_tokens.py
@@ -35,23 +35,12 @@ def resp_get_group_access_token(token_content):
 
 
 @pytest.fixture
-def resp_create_group_access_token():
-    content = {
-        "user_id": 141,
-        "scopes": ["api"],
-        "name": "token",
-        "expires_at": "2021-01-31",
-        "id": 42,
-        "active": True,
-        "created_at": "2021-01-20T22:11:48.151Z",
-        "revoked": False,
-    }
-
+def resp_create_group_access_token(token_content):
     with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
         rsps.add(
             method=responses.POST,
             url="http://localhost/api/v4/groups/1/access_tokens",
-            json=content,
+            json=token_content,
             content_type="application/json",
             status=200,
         )
@@ -89,6 +78,19 @@ def resp_revoke_group_access_token():
         yield rsps
 
 
+@pytest.fixture
+def resp_rotate_group_access_token(token_content):
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.POST,
+            url="http://localhost/api/v4/groups/1/access_tokens/1/rotate",
+            json=token_content,
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
 def test_list_group_access_tokens(gl, resp_list_group_access_token):
     access_tokens = gl.groups.get(1, lazy=True).access_tokens.list()
     assert len(access_tokens) == 1
@@ -118,3 +120,10 @@ def test_revoke_group_access_token(
     gl.groups.get(1, lazy=True).access_tokens.delete(42)
     access_token = gl.groups.get(1, lazy=True).access_tokens.list()[0]
     access_token.delete()
+
+
+def test_rotate_group_access_token(group, resp_rotate_group_access_token):
+    access_token = group.access_tokens.get(1, lazy=True)
+    access_token.rotate()
+    assert isinstance(access_token, GroupAccessToken)
+    assert access_token.token == "s3cr3t"


### PR DESCRIPTION
## Changes

Adds a `RotateMixin` and `ObjectRotateMixin` similar to the delete mixins.

Closes https://github.com/python-gitlab/python-gitlab/issues/2589
Closes https://github.com/python-gitlab/python-gitlab/issues/2746

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

