### PR TITLE
fix(cli): allow exclusive arguments as optional

### DIFF
--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -284,9 +284,9 @@ def _populate_sub_parser_by_class(
                         f"--{x.replace('_', '-')}", required=False
                     )
 
-            if mgr_cls._create_attrs.exclusive:
+            if mgr_cls._update_attrs.exclusive:
                 group = sub_parser_action.add_mutually_exclusive_group()
-                for x in mgr_cls._create_attrs.exclusive:
+                for x in mgr_cls._update_attrs.exclusive:
                     group.add_argument(f"--{x.replace('_', '-')}")
 
     if cls.__name__ in cli.custom_actions:

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -258,10 +258,14 @@ def _populate_sub_parser_by_class(
                 sub_parser_action.add_argument(
                     f"--{x.replace('_', '-')}", required=True
                 )
-            for x in mgr_cls._create_attrs.optional + mgr_cls._create_attrs.exclusive:
+            for x in mgr_cls._create_attrs.optional:
                 sub_parser_action.add_argument(
                     f"--{x.replace('_', '-')}", required=False
                 )
+            if mgr_cls._create_attrs.exclusive:
+                group = sub_parser_action.add_mutually_exclusive_group()
+                for x in mgr_cls._create_attrs.exclusive:
+                    group.add_argument(f"--{x.replace('_', '-')}")
 
         if action_name == "update":
             if cls._id_attr is not None:
@@ -274,11 +278,16 @@ def _populate_sub_parser_by_class(
                         f"--{x.replace('_', '-')}", required=True
                     )
 
-            for x in mgr_cls._update_attrs.optional + mgr_cls._update_attrs.exclusive:
+            for x in mgr_cls._update_attrs.optional:
                 if x != cls._id_attr:
                     sub_parser_action.add_argument(
                         f"--{x.replace('_', '-')}", required=False
                     )
+
+            if mgr_cls._create_attrs.exclusive:
+                group = sub_parser_action.add_mutually_exclusive_group()
+                for x in mgr_cls._create_attrs.exclusive:
+                    group.add_argument(f"--{x.replace('_', '-')}")
 
     if cls.__name__ in cli.custom_actions:
         name = cls.__name__

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -258,7 +258,7 @@ def _populate_sub_parser_by_class(
                 sub_parser_action.add_argument(
                     f"--{x.replace('_', '-')}", required=True
                 )
-            for x in mgr_cls._create_attrs.optional:
+            for x in mgr_cls._create_attrs.optional + mgr_cls._create_attrs.exclusive:
                 sub_parser_action.add_argument(
                     f"--{x.replace('_', '-')}", required=False
                 )
@@ -274,7 +274,7 @@ def _populate_sub_parser_by_class(
                         f"--{x.replace('_', '-')}", required=True
                     )
 
-            for x in mgr_cls._update_attrs.optional:
+            for x in mgr_cls._update_attrs.optional + mgr_cls._update_attrs.exclusive:
                 if x != cls._id_attr:
                     sub_parser_action.add_argument(
                         f"--{x.replace('_', '-')}", required=False


### PR DESCRIPTION
The CLI takes its arguments from the RequiredOptional, which has three fields: required, optional, and exclusive. In practice, the exclusive options are not defined as either required or optional, and would not be allowed in the CLI. This changes that, so that exclusive options are also added to the argument parser.

Closes #2769

<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

<!-- Remove this comment and describe your changes here. -->

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
