### PR TITLE
fix(api): update manual job status when playing it

### DIFF
--- a/gitlab/v4/objects/jobs.py
+++ b/gitlab/v4/objects/jobs.py
@@ -65,7 +65,10 @@ class ProjectJob(RefreshMixin, RESTObject):
             GitlabJobPlayError: If the job could not be triggered
         """
         path = f"{self.manager.path}/{self.encoded_id}/play"
-        self.manager.gitlab.http_post(path, **kwargs)
+        result = self.manager.gitlab.http_post(path, **kwargs)
+        if TYPE_CHECKING:
+            assert isinstance(result, dict)
+        self._update_attrs(result)
 
     @cli.register_custom_action("ProjectJob")
     @exc.on_http_error(exc.GitlabJobEraseError)


### PR DESCRIPTION
## Changes

When `.play()`ing a `ProjectJob`, its status would not be updated from `manual` to `pending`/`running`/etc.

Fix this by updating the object with the data returned by the api.

### Documentation and testing

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs): not needed IMO, this is just a fix to make the behaviour of this method match the others and match the user expectation
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional): not added, it might be good but I wanted to post this first, and I'll add the tests if this change is accepted and tests are requested :)