### PR TITLE
fix: user.warn() to show correct filename of issue

### DIFF
--- a/gitlab/utils.py
+++ b/gitlab/utils.py
@@ -191,8 +191,7 @@ def warn(
     stacklevel = 1
     warning_from = ""
     for stacklevel, frame in enumerate(reversed(stack), start=1):
-        if stacklevel == 2:
-            warning_from = f" (python-gitlab: {frame.filename}:{frame.lineno})"
+        warning_from = f" (python-gitlab: {frame.filename}:{frame.lineno})"
         frame_dir = str(pathlib.Path(frame.filename).parent.resolve())
         if not frame_dir.startswith(str(pg_dir)):
             break

--- a/tests/functional/api/test_gitlab.py
+++ b/tests/functional/api/test_gitlab.py
@@ -252,6 +252,7 @@ def test_list_default_warning(gl):
     assert len(record) == 1
     warning = record[0]
     assert __file__ == warning.filename
+    assert __file__ in str(warning.message)
 
 
 def test_list_page_nowarning(gl, recwarn):

--- a/tests/unit/test_gitlab_http_methods.py
+++ b/tests/unit/test_gitlab_http_methods.py
@@ -600,6 +600,7 @@ def test_list_request_pagination_warning(gl):
     message = str(warning.message)
     assert "Calling a `list()` method" in message
     assert "python-gitlab.readthedocs.io" in message
+    assert __file__ in message
     assert __file__ == warning.filename
     assert isinstance(result, list)
     assert len(result) == 20


### PR DESCRIPTION
Previously would only go to the 2nd level of the stack for determining the offending filename and line number. When it should be showing the first filename outside of the python-gitlab source code. As we want it to show the warning for the user of the libraries code.

Update test to show it works as expected.

This is sort of related to #2799