### PR TITLE
chore: add py312 & py313 to tox environment list

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 1.6
 skipsdist = True
 skip_missing_interpreters = True
-envlist = py311,py310,py39,py38,flake8,black,twine-check,mypy,isort,cz,pylint
+envlist = py313,py312,py311,py310,py39,py38,flake8,black,twine-check,mypy,isort,cz,pylint
 
 [testenv]
 passenv =


### PR DESCRIPTION
Even though there isn't a Python 3.13 at this time, this is done for
the future.  tox is already configured to just warn about missing
Python versions, but not fail if they don't exist.
