### PR TITLE
chore: add tox `labels` to enable running groups of environments

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -81,6 +81,17 @@ You need to install ``tox`` (``pip3 install tox``) to run tests and lint checks 
    # List all available tox environments
    tox list
 
+   # "label" based tests. These use the '-m' flag to tox
+
+   # run all the linter checks:
+   tox -m lint
+
+   # run only the unit tests:
+   tox -m unit
+
+   # run the functional tests. This is very time consuming:
+   tox -m func
+
 Running integration tests
 -------------------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 1.6
 skipsdist = True
 skip_missing_interpreters = True
-envlist = py311,py310,py39,py38,flake8,black,twine-check,mypy,isort,cz,pylint
+envlist = py313,py312,py311,py310,py39,py38,flake8,black,twine-check,mypy,isort,cz,pylint
 
 [testenv]
 passenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,17 @@
 [tox]
-minversion = 1.6
+minversion = 4.0
 skipsdist = True
 skip_missing_interpreters = True
-envlist = py313,py312,py311,py310,py39,py38,flake8,black,twine-check,mypy,isort,cz,pylint
+envlist = py313,py312,py311,py310,py39,py38,black,isort,flake8,mypy,twine-check,cz,pylint
+
+# NOTE(jlvillal): To use a label use the `-m` flag.
+# For example to run the `func` label group of environments do:
+#   tox -m func
+labels =
+    lint = black,isort,flake8,mypy,pylint,cz
+    unit = py313,py312,py311,py310,py39,py38
+# func is the functional tests. This is very time consuming.
+    func = cli_func_v4,api_func_v4
 
 [testenv]
 passenv =


### PR DESCRIPTION
tox now has a feature of `labels` which allows running groups of
environments using the command `tox -m LABEL_NAME`. For example
`tox -m lint` which has been setup to run the linters.

Bumped the minimum required version of tox to be 4.0, which was
released over a year ago.
