### PR TITLE
fix(api): use ID instead of name for GroupLabel & ProjectLabel _id_attr

### DIFF
--- a/gitlab/v4/objects/labels.py
+++ b/gitlab/v4/objects/labels.py
@@ -20,7 +20,8 @@ __all__ = ["GroupLabel", "GroupLabelManager", "ProjectLabel", "ProjectLabelManag
 
 
 class GroupLabel(SubscribableMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
-    _id_attr = "name"
+    _id_attr = "id"
+    _repr_attr = "name"
     manager: GroupLabelManager
 
     # Update without ID, but we need an ID to get from list.
@@ -81,7 +82,8 @@ class GroupLabelManager(
 class ProjectLabel(
     PromoteMixin, SubscribableMixin, SaveMixin, ObjectDeleteMixin, RESTObject
 ):
-    _id_attr = "name"
+    _id_attr = "id"
+    _repr_attr = "name"
     manager: ProjectLabelManager
 
     # Update without ID, but we need an ID to get from list.


### PR DESCRIPTION
## Changes

_id_attr is used when comparing RESTObject objects. Labels will be seen as equal when they have the same name even if they are from different groups or projects.

Instead, use the label's ID as the _id_attr so that comparisions will only be equal if they truly represent the same gitlab label object.

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
