### PR TITLE
fix: Consider scope an ArrayAttribute in PipelineJobManager

### DIFF
--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -17,7 +17,7 @@ from gitlab.mixins import (
     SaveMixin,
     UpdateMixin,
 )
-from gitlab.types import RequiredOptional
+from gitlab.types import ArrayAttribute, RequiredOptional
 
 __all__ = [
     "ProjectMergeRequestPipeline",
@@ -149,6 +149,7 @@ class ProjectPipelineJobManager(ListMixin, RESTManager):
     _obj_cls = ProjectPipelineJob
     _from_parent_attrs = {"project_id": "project_id", "pipeline_id": "id"}
     _list_filters = ("scope", "include_retried")
+    _types = {"scope": ArrayAttribute}
 
 
 class ProjectPipelineBridge(RESTObject):

--- a/tests/unit/objects/test_resource_groups.py
+++ b/tests/unit/objects/test_resource_groups.py
@@ -8,7 +8,7 @@ import responses
 
 from gitlab.v4.objects import ProjectResourceGroup, ProjectResourceGroupUpcomingJob
 
-from .test_jobs import job_content
+from .test_jobs import failed_job_content
 
 resource_group_content = {
     "id": 3,
@@ -51,7 +51,7 @@ def resp_list_upcoming_jobs():
         rsps.add(
             method=responses.GET,
             url="http://localhost/api/v4/projects/1/resource_groups/production/upcoming_jobs",
-            json=[job_content],
+            json=[failed_job_content],
             content_type="application/json",
             status=200,
         )


### PR DESCRIPTION
## Changes

List query params like 'scope' were not being handled correctly. This change ensures multiple values are appended with '[]', resulting in the correct URL structure.



---

Background:
If one queries for pipeline jobs with `scope=["failed", "success"]`

One gets:
```
GET /api/v4/projects/176/pipelines/1113028/jobs?scope=success&scope=failed
```

But it is supposed to get:
```
GET /api/v4/projects/176/pipelines/1113028/jobs?scope[]=success&scope[]=failed
```

The current version only considers the last element of the list argument.

<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->
### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
