### PR TITLE
feat(job_token_scope): support Groups in job token allowlist API 

### DIFF
--- a/docs/gl_objects/job_token_scope.rst
+++ b/docs/gl_objects/job_token_scope.rst
@@ -67,8 +67,17 @@ Remove a project from the project's inbound allowlist::
 .. warning::
 
    Similar to above, the ID attributes you receive from the create and list
-   APIs are not consistent. To safely retrieve the ID of the allowlisted project
+   APIs are not consistent (in create() the id is returned as ``source_project_id`` whereas list() returns as ``id``). To safely retrieve the ID of the allowlisted project
    regardless of how the object was created, always use its ``.get_id()`` method.
+
+Using ``.get_id()``::
+
+    resp = allowlist.create({"target_project_id": 2})
+    allowlist_id = resp.get_id()
+
+    allowlists = project.allowlist.list()
+    for allowlist in allowlists:
+      allowlist_id == allowlist.get_id()
 
 Get a project's CI/CD job token inbound groups allowlist::
 

--- a/docs/gl_objects/job_token_scope.rst
+++ b/docs/gl_objects/job_token_scope.rst
@@ -49,3 +49,23 @@ Refresh the current state of job token scope::
     scope.refresh()
     print(scope.inbound_enabled)
     # False
+
+Get a project's CI/CD job token inbound allowlist::
+
+    allowlist = scope.allowlist.list()
+
+Add a project to the project's inbound allowlist::
+
+    allowed_project = scope.allowlist.create({"target_project_id": 42})
+
+Remove a project from the project's inbound allowlist::
+
+    allowed_project.delete()
+    # or directly using a project ID
+    scope.allowlist.delete(42)
+
+.. warning::
+
+   Similar to above, the ID attributes you receive from the create and list
+   APIs are not consistent. To safely retrieve the ID of the allowlisted project
+   regardless of how the object was created, always use its ``.get_id()`` method.

--- a/docs/gl_objects/job_token_scope.rst
+++ b/docs/gl_objects/job_token_scope.rst
@@ -69,3 +69,24 @@ Remove a project from the project's inbound allowlist::
    Similar to above, the ID attributes you receive from the create and list
    APIs are not consistent. To safely retrieve the ID of the allowlisted project
    regardless of how the object was created, always use its ``.get_id()`` method.
+
+Get a project's CI/CD job token inbound groups allowlist::
+
+    allowlist = scope.groups_allowlist.list()
+
+Add a project to the project's inbound groups allowlist::
+
+    allowed_project = scope.groups_allowlist.create({"target_project_id": 42})
+
+Remove a project from the project's inbound agroups llowlist::
+
+    allowed_project.delete()
+    # or directly using a Group ID
+    scope.groups_allowlist.delete(42)
+
+.. warning::
+
+   Similar to above, the ID attributes you receive from the create and list
+   APIs are not consistent. To safely retrieve the ID of the allowlisted group
+   regardless of how the object was created, always use its ``.get_id()`` method.
+

--- a/gitlab/v4/objects/job_token_scope.py
+++ b/gitlab/v4/objects/job_token_scope.py
@@ -44,10 +44,10 @@ class AllowlistProject(ObjectDeleteMixin, RESTObject):
         """Returns the id of the resource. This override deals with
         the fact that either an `id` or a `target_project_id` attribute
         is returned by the server depending on the endpoint called."""
-        try:
-            return cast(int, getattr(self, self._id_attr))
-        except AttributeError:
-            return cast(int, self.id)
+        project_id = cast(int, super().get_id())
+        if project_id is not None:
+            return project_id
+        return cast(int, self.id)
 
 
 class AllowlistProjectManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
@@ -64,10 +64,10 @@ class AllowlistGroup(ObjectDeleteMixin, RESTObject):
         """Returns the id of the resource. This override deals with
         the fact that either an `id` or a `target_group_id` attribute
         is returned by the server depending on the endpoint called."""
-        try:
-            return cast(int, getattr(self, self._id_attr))
-        except AttributeError:
-            return cast(int, self.id)
+        group_id = cast(int, super().get_id())
+        if group_id is not None:
+            return group_id
+        return cast(int, self.id)
 
 
 class AllowlistGroupManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):

--- a/gitlab/v4/objects/job_token_scope.py
+++ b/gitlab/v4/objects/job_token_scope.py
@@ -62,7 +62,7 @@ class AllowlistedGroup(ObjectDeleteMixin, RESTObject):
 
     def get_id(self) -> int:
         """Returns the id of the resource. This override deals with
-        the fact that either an `id` or a `target_project_id` attribute
+        the fact that either an `id` or a `target_group_id` attribute
         is returned by the server depending on the endpoint called."""
         try:
             return cast(int, getattr(self, self._id_attr))

--- a/gitlab/v4/objects/job_token_scope.py
+++ b/gitlab/v4/objects/job_token_scope.py
@@ -23,8 +23,8 @@ __all__ = [
 class ProjectJobTokenScope(RefreshMixin, SaveMixin, RESTObject):
     _id_attr = None
 
-    allowlist: "AllowlistedProjectManager"
-    groups_allowlist: "AllowlistedGroupManager"
+    allowlist: "AllowlistProjectManager"
+    groups_allowlist: "AllowlistGroupManager"
 
 
 class ProjectJobTokenScopeManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
@@ -37,7 +37,7 @@ class ProjectJobTokenScopeManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
         return cast(ProjectJobTokenScope, super().get(**kwargs))
 
 
-class AllowlistedProject(ObjectDeleteMixin, RESTObject):
+class AllowlistProject(ObjectDeleteMixin, RESTObject):
     _id_attr = "target_project_id"  # note: only true for create endpoint
 
     def get_id(self) -> int:
@@ -47,17 +47,17 @@ class AllowlistedProject(ObjectDeleteMixin, RESTObject):
         try:
             return cast(int, getattr(self, self._id_attr))
         except AttributeError:
-            return cast(int, getattr(self, "id"))
+            return cast(int, self.id)
 
 
-class AllowlistedProjectManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
+class AllowlistProjectManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
     _path = "/projects/{project_id}/job_token_scope/allowlist"
-    _obj_cls = AllowlistedProject
+    _obj_cls = AllowlistProject
     _from_parent_attrs = {"project_id": "project_id"}
     _create_attrs = RequiredOptional(required=("target_project_id",))
 
 
-class AllowlistedGroup(ObjectDeleteMixin, RESTObject):
+class AllowlistGroup(ObjectDeleteMixin, RESTObject):
     _id_attr = "target_group_id"  # note: only true for create endpoint
 
     def get_id(self) -> int:
@@ -67,11 +67,11 @@ class AllowlistedGroup(ObjectDeleteMixin, RESTObject):
         try:
             return cast(int, getattr(self, self._id_attr))
         except AttributeError:
-            return cast(int, getattr(self, "id"))
+            return cast(int, self.id)
 
 
-class AllowlistedGroupManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
+class AllowlistGroupManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
     _path = "/projects/{project_id}/job_token_scope/groups_allowlist"
-    _obj_cls = AllowlistedGroup
+    _obj_cls = AllowlistGroup
     _from_parent_attrs = {"project_id": "project_id"}
     _create_attrs = RequiredOptional(required=("target_group_id",))

--- a/gitlab/v4/objects/job_token_scope.py
+++ b/gitlab/v4/objects/job_token_scope.py
@@ -44,9 +44,9 @@ class AllowlistProject(ObjectDeleteMixin, RESTObject):
         """Returns the id of the resource. This override deals with
         the fact that either an `id` or a `target_project_id` attribute
         is returned by the server depending on the endpoint called."""
-        project_id = cast(int, super().get_id())
-        if project_id is not None:
-            return project_id
+        target_project_id = cast(int, super().get_id())
+        if target_project_id is not None:
+            return target_project_id
         return cast(int, self.id)
 
 
@@ -64,9 +64,9 @@ class AllowlistGroup(ObjectDeleteMixin, RESTObject):
         """Returns the id of the resource. This override deals with
         the fact that either an `id` or a `target_group_id` attribute
         is returned by the server depending on the endpoint called."""
-        group_id = cast(int, super().get_id())
-        if group_id is not None:
-            return group_id
+        target_group_id = cast(int, super().get_id())
+        if target_group_id is not None:
+            return target_group_id
         return cast(int, self.id)
 
 

--- a/gitlab/v4/objects/job_token_scope.py
+++ b/gitlab/v4/objects/job_token_scope.py
@@ -24,6 +24,7 @@ class ProjectJobTokenScope(RefreshMixin, SaveMixin, RESTObject):
     _id_attr = None
 
     allowlist: "AllowlistedProjectManager"
+    groups_allowlist: "AllowlistedGroupManager"
 
 
 class ProjectJobTokenScopeManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
@@ -54,3 +55,23 @@ class AllowlistedProjectManager(ListMixin, CreateMixin, DeleteMixin, RESTManager
     _obj_cls = AllowlistedProject
     _from_parent_attrs = {"project_id": "project_id"}
     _create_attrs = RequiredOptional(required=("target_project_id",))
+
+
+class AllowlistedGroup(ObjectDeleteMixin, RESTObject):
+    _id_attr = "target_group_id"  # note: only true for create endpoint
+
+    def get_id(self) -> int:
+        """Returns the id of the resource. This override deals with
+        the fact that either an `id` or a `target_project_id` attribute
+        is returned by the server depending on the endpoint called."""
+        try:
+            return cast(int, getattr(self, self._id_attr))
+        except AttributeError:
+            return cast(int, getattr(self, "id"))
+
+
+class AllowlistedGroupManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
+    _path = "/projects/{project_id}/job_token_scope/groups_allowlist"
+    _obj_cls = AllowlistedProject
+    _from_parent_attrs = {"project_id": "project_id"}
+    _create_attrs = RequiredOptional(required=("target_group_id",))

--- a/gitlab/v4/objects/job_token_scope.py
+++ b/gitlab/v4/objects/job_token_scope.py
@@ -72,6 +72,6 @@ class AllowlistedGroup(ObjectDeleteMixin, RESTObject):
 
 class AllowlistedGroupManager(ListMixin, CreateMixin, DeleteMixin, RESTManager):
     _path = "/projects/{project_id}/job_token_scope/groups_allowlist"
-    _obj_cls = AllowlistedProject
+    _obj_cls = AllowlistedGroup
     _from_parent_attrs = {"project_id": "project_id"}
     _create_attrs = RequiredOptional(required=("target_group_id",))

--- a/gitlab/v4/objects/job_token_scope.py
+++ b/gitlab/v4/objects/job_token_scope.py
@@ -14,7 +14,6 @@ from gitlab.mixins import (
 )
 from gitlab.types import RequiredOptional
 
-
 __all__ = [
     "ProjectJobTokenScope",
     "ProjectJobTokenScopeManager",

--- a/tests/functional/api/test_project_job_token_scope.py
+++ b/tests/functional/api/test_project_job_token_scope.py
@@ -1,3 +1,26 @@
+# https://docs.gitlab.com/ee/ci/jobs/ci_job_token.html#allow-any-project-to-access-your-project
+def test_enable_limit_access_to_this_project(gl, project):
+    scope = project.job_token_scope.get()
+
+    scope.enabled = True
+    scope.save()
+
+    scope.refresh()
+
+    assert scope.inbound_enabled
+
+
+def test_disable_limit_access_to_this_project(gl, project):
+    scope = project.job_token_scope.get()
+
+    scope.enabled = False
+    scope.save()
+
+    scope.refresh()
+
+    assert not scope.inbound_enabled
+
+
 def test_add_project_to_job_token_scope_allowlist(gl, project):
     project_to_add = gl.projects.create({"name": "Ci_Cd_token_add_proj"})
 
@@ -12,8 +35,6 @@ def test_add_project_to_job_token_scope_allowlist(gl, project):
 
 def test_projects_job_token_scope_allowlist_contains_added_project_name(gl, project):
     scope = project.job_token_scope.get()
-    assert len(scope.allowlist.list()) == 0
-
     project_name = "Ci_Cd_token_named_proj"
     project_to_add = gl.projects.create({"name": project_name})
     scope.allowlist.create({"target_project_id": project_to_add.id})
@@ -26,18 +47,70 @@ def test_projects_job_token_scope_allowlist_contains_added_project_name(gl, proj
 
 def test_remove_project_by_id_from_projects_job_token_scope_allowlist(gl, project):
     scope = project.job_token_scope.get()
-    assert len(scope.allowlist.list()) == 0
 
     project_to_add = gl.projects.create({"name": "Ci_Cd_token_remove_proj"})
 
     scope.allowlist.create({"target_project_id": project_to_add.id})
 
     scope.refresh()
-    assert len(scope.allowlist.list()) != 0
 
-    scope.allowlist.remove(project_to_add.id)
+    scope.allowlist.delete(project_to_add.id)
 
     scope.refresh()
-    assert len(scope.allowlist.list()) == 0
+    assert not any(
+        allowed.id == project_to_add.id for allowed in scope.allowlist.list()
+    )
 
     project_to_add.delete()
+
+
+def test_add_group_to_job_token_scope_allowlist(gl, project):
+    group_to_add = gl.groups.create(
+        {"name": "add_group", "path": "allowlisted-add-test"}
+    )
+
+    scope = project.job_token_scope.get()
+    resp = scope.groups_allowlist.create({"target_group_id": group_to_add.id})
+
+    assert resp.source_project_id == project.id
+    assert resp.target_group_id == group_to_add.id
+
+    group_to_add.delete()
+
+
+def test_projects_job_token_scope_groups_allowlist_contains_added_group_name(
+    gl, project
+):
+    scope = project.job_token_scope.get()
+    group_name = "list_group"
+    group_to_add = gl.groups.create(
+        {"name": group_name, "path": "allowlisted-add-and-list-test"}
+    )
+
+    scope.groups_allowlist.create({"target_group_id": group_to_add.id})
+
+    scope.refresh()
+    assert any(allowed.name == group_name for allowed in scope.groups_allowlist.list())
+
+    group_to_add.delete()
+
+
+def test_remove_group_by_id_from_projects_job_token_scope_groups_allowlist(gl, project):
+    scope = project.job_token_scope.get()
+
+    group_to_add = gl.groups.create(
+        {"name": "delete_group", "path": "allowlisted-delete-test"}
+    )
+
+    scope.groups_allowlist.create({"target_group_id": group_to_add.id})
+
+    scope.refresh()
+
+    scope.groups_allowlist.delete(group_to_add.id)
+
+    scope.refresh()
+    assert not any(
+        allowed.name == group_to_add.name for allowed in scope.groups_allowlist.list()
+    )
+
+    group_to_add.delete()

--- a/tests/functional/api/test_project_job_token_scope.py
+++ b/tests/functional/api/test_project_job_token_scope.py
@@ -1,0 +1,43 @@
+def test_add_project_to_job_token_scope_allowlist(gl, project):
+    project_to_add = gl.projects.create({"name": "Ci_Cd_token_add_proj"})
+
+    scope = project.job_token_scope.get()
+    resp = scope.allowlist.create({"target_project_id": project_to_add.id})
+
+    assert resp.source_project_id == project.id
+    assert resp.target_project_id == project_to_add.id
+
+    project_to_add.delete()
+
+
+def test_projects_job_token_scope_allowlist_contains_added_project_name(gl, project):
+    scope = project.job_token_scope.get()
+    assert len(scope.allowlist.list()) == 0
+
+    project_name = "Ci_Cd_token_named_proj"
+    project_to_add = gl.projects.create({"name": project_name})
+    scope.allowlist.create({"target_project_id": project_to_add.id})
+
+    scope.refresh()
+    assert any(allowed.name == project_name for allowed in scope.allowlist.list())
+
+    project_to_add.delete()
+
+
+def test_remove_project_by_id_from_projects_job_token_scope_allowlist(gl, project):
+    scope = project.job_token_scope.get()
+    assert len(scope.allowlist.list()) == 0
+
+    project_to_add = gl.projects.create({"name": "Ci_Cd_token_remove_proj"})
+
+    scope.allowlist.create({"target_project_id": project_to_add.id})
+
+    scope.refresh()
+    assert len(scope.allowlist.list()) != 0
+
+    scope.allowlist.remove(project_to_add.id)
+
+    scope.refresh()
+    assert len(scope.allowlist.list()) == 0
+
+    project_to_add.delete()

--- a/tests/unit/objects/test_job_token_scope.py
+++ b/tests/unit/objects/test_job_token_scope.py
@@ -174,6 +174,7 @@ def test_get_projects_allowlist(job_token_scope, resp_get_allowlist):
 
     allowlist_content = allowlist.list()
     assert isinstance(allowlist_content, list)
+    assert allowlist_content[0].get_id() == 4
 
 
 def test_add_project_to_allowlist(job_token_scope, resp_add_to_allowlist):
@@ -190,6 +191,7 @@ def test_get_groups_allowlist(job_token_scope, resp_get_groups_allowlist):
 
     allowlist_content = allowlist.list()
     assert isinstance(allowlist_content, list)
+    assert allowlist_content[0].get_id() == 4
 
 
 def test_add_group_to_allowlist(job_token_scope, resp_add_to_groups_allowlist):

--- a/tests/unit/objects/test_job_token_scope.py
+++ b/tests/unit/objects/test_job_token_scope.py
@@ -47,6 +47,11 @@ project_allowlist_content = [
     }
 ]
 
+project_allowlist_created_content = {
+    "target_project_id": 2,
+    "project_id": 1,
+}
+
 groups_allowlist_content = [
     {
         "id": 4,
@@ -54,6 +59,11 @@ groups_allowlist_content = [
         "name": "namegroup",
     }
 ]
+
+group_allowlist_created_content = {
+    "target_group_id": 4,
+    "project_id": 1,
+}
 
 
 @pytest.fixture
@@ -83,12 +93,38 @@ def resp_get_allowlist():
 
 
 @pytest.fixture
+def resp_add_to_allowlist():
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(
+            method=responses.POST,
+            url="http://localhost/api/v4/projects/1/job_token_scope/allowlist",
+            json=project_allowlist_created_content,
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
+@pytest.fixture
 def resp_get_groups_allowlist():
     with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
         rsps.add(
             method=responses.GET,
             url="http://localhost/api/v4/projects/1/job_token_scope/groups_allowlist",
             json=groups_allowlist_content,
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
+@pytest.fixture
+def resp_add_to_groups_allowlist():
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(
+            method=responses.POST,
+            url="http://localhost/api/v4/projects/1/job_token_scope/groups_allowlist",
+            json=group_allowlist_created_content,
             content_type="application/json",
             status=200,
         )
@@ -140,9 +176,25 @@ def test_get_projects_allowlist(job_token_scope, resp_get_allowlist):
     assert isinstance(allowlist_content, list)
 
 
+def test_add_project_to_allowlist(job_token_scope, resp_add_to_allowlist):
+    allowlist = job_token_scope.allowlist
+    assert isinstance(allowlist, AllowlistedProjectManager)
+
+    resp = allowlist.create({"target_project_id": 2})
+    assert resp.get_id() == 2
+
+
 def test_get_groups_allowlist(job_token_scope, resp_get_groups_allowlist):
     allowlist = job_token_scope.groups_allowlist
     assert isinstance(allowlist, AllowlistedGroupManager)
 
     allowlist_content = allowlist.list()
     assert isinstance(allowlist_content, list)
+
+
+def test_add_group_to_allowlist(job_token_scope, resp_add_to_groups_allowlist):
+    allowlist = job_token_scope.groups_allowlist
+    assert isinstance(allowlist, AllowlistedGroupManager)
+
+    resp = allowlist.create({"target_group_id": 4})
+    assert resp.get_id() == 4

--- a/tests/unit/objects/test_job_token_scope.py
+++ b/tests/unit/objects/test_job_token_scope.py
@@ -7,8 +7,8 @@ import responses
 
 from gitlab.v4.objects import ProjectJobTokenScope
 from gitlab.v4.objects.job_token_scope import (
-    AllowlistedGroupManager,
-    AllowlistedProjectManager,
+    AllowlistGroupManager,
+    AllowlistProjectManager,
 )
 
 job_token_scope_content = {
@@ -170,7 +170,7 @@ def test_update_job_token_scope(project, resp_patch_job_token_scope):
 
 def test_get_projects_allowlist(job_token_scope, resp_get_allowlist):
     allowlist = job_token_scope.allowlist
-    assert isinstance(allowlist, AllowlistedProjectManager)
+    assert isinstance(allowlist, AllowlistProjectManager)
 
     allowlist_content = allowlist.list()
     assert isinstance(allowlist_content, list)
@@ -178,7 +178,7 @@ def test_get_projects_allowlist(job_token_scope, resp_get_allowlist):
 
 def test_add_project_to_allowlist(job_token_scope, resp_add_to_allowlist):
     allowlist = job_token_scope.allowlist
-    assert isinstance(allowlist, AllowlistedProjectManager)
+    assert isinstance(allowlist, AllowlistProjectManager)
 
     resp = allowlist.create({"target_project_id": 2})
     assert resp.get_id() == 2
@@ -186,7 +186,7 @@ def test_add_project_to_allowlist(job_token_scope, resp_add_to_allowlist):
 
 def test_get_groups_allowlist(job_token_scope, resp_get_groups_allowlist):
     allowlist = job_token_scope.groups_allowlist
-    assert isinstance(allowlist, AllowlistedGroupManager)
+    assert isinstance(allowlist, AllowlistGroupManager)
 
     allowlist_content = allowlist.list()
     assert isinstance(allowlist_content, list)
@@ -194,7 +194,7 @@ def test_get_groups_allowlist(job_token_scope, resp_get_groups_allowlist):
 
 def test_add_group_to_allowlist(job_token_scope, resp_add_to_groups_allowlist):
     allowlist = job_token_scope.groups_allowlist
-    assert isinstance(allowlist, AllowlistedGroupManager)
+    assert isinstance(allowlist, AllowlistGroupManager)
 
     resp = allowlist.create({"target_group_id": 4})
     assert resp.get_id() == 4


### PR DESCRIPTION
Builds ontop of: https://github.com/python-gitlab/python-gitlab/pull/2767 and https://github.com/python-gitlab/python-gitlab/pull/2790

Closes #2762 

Adds support for adding Group to job_token_allowlist: https://docs.gitlab.com/ee/api/project_job_token_scopes.html#add-a-group-to-a-cicd-job-token-allowlist