### PR TITLE
docs: Note how to use the Docker image from within GitLab CI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,23 @@ You can also mount your own config file:
 
    $ docker run -it --rm -v /path/to/python-gitlab.cfg:/etc/python-gitlab.cfg registry.gitlab.com/python-gitlab/python-gitlab:latest <command> ...
 
+Usage inside GitLab CI
+~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to use the Docker image directly inside your GitLab CI as an `image`, you will need to override
+the `entrypoint`, `as noted in the official GitLab documentation <https://docs.gitlab.com/ee/ci/docker/using_docker_images.html#override-the-entrypoint-of-an-image>`__:
+
+.. code-block:: yaml
+
+   Job Name:
+      image:
+         name: registry.gitlab.com/python-gitlab/python-gitlab:latest
+         entrypoint: [""]
+      before_script:
+         gitlab --version
+      script:
+         gitlab <command>
+
 Building the image
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Ref: #2823

<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

Improves the main `README` to give an example as to how to use the Docker image within GitLab CI..

Discussion: https://github.com/python-gitlab/python-gitlab/discussions/2822
Issue: https://github.com/python-gitlab/python-gitlab/issues/2823

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
