### PR TITLE
chore: update `mypy` to 1.9.0 and resolve one issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
           - requests-toolbelt==1.0.0
         files: 'gitlab/'
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: mypy
         args: []

--- a/gitlab/utils.py
+++ b/gitlab/utils.py
@@ -18,7 +18,8 @@ class _StdoutStream:
 
 def get_content_type(content_type: Optional[str]) -> str:
     message = email.message.Message()
-    message["content-type"] = content_type
+    if content_type is not None:
+        message["content-type"] = content_type
 
     return message.get_content_type()
 

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -4,7 +4,7 @@ black==24.3.0
 commitizen==3.16.0
 flake8==7.0.0
 isort==5.13.2
-mypy==1.8.0
+mypy==1.9.0
 pylint==3.1.0
 pytest==8.0.2
 responses==0.25.0


### PR DESCRIPTION
mypy 1.9.0 flagged one issue in the code. Resolve the issue. Current unit tests already check that a `None` value returns `text/plain`. So function is still working as expected.

<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

<!-- Remove this comment and describe your changes here. -->

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
