### PR TITLE
build: Add "--no-cache-dir" to pip commands in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.12-${PYTHON_FLAVOR} AS build
 
 WORKDIR /opt/python-gitlab
 COPY . .
-RUN pip install build && python -m build
+RUN pip install --no-cache-dir build && python -m build --wheel
 
 FROM python:3.12-${PYTHON_FLAVOR}
 
@@ -11,8 +11,8 @@ LABEL org.opencontainers.image.source="https://github.com/python-gitlab/python-g
 
 WORKDIR /opt/python-gitlab
 COPY --from=build /opt/python-gitlab/dist dist/
-RUN pip install PyYaml
-RUN pip install $(find dist -name *.whl) && \
+RUN pip install --no-cache-dir PyYaml
+RUN pip install --no-cache-dir $(find dist -name *.whl) && \
     rm -rf dist/
 
 ENTRYPOINT ["gitlab"]


### PR DESCRIPTION
This would not leave cache files in the built docker image.

Additionally, also only build the wheel in the build phase.

On my machine, before this PR, size is 74845395; after this PR, size is
72617713.