### PR TITLE
docs: correct rotate token example

### DIFF
--- a/docs/gl_objects/personal_access_tokens.rst
+++ b/docs/gl_objects/personal_access_tokens.rst
@@ -58,8 +58,8 @@ Rotate a personal access token and retrieve its new value::
     token.rotate()
     print(token.token)
     # or directly using a token ID
-    new_token = gl.personal_access_tokens.rotate(42)
-    print(new_token.token)
+    new_token_dict = gl.personal_access_tokens.rotate(42)
+    print(new_token_dict)
 
 Create a personal access token for a user (admin only)::
 


### PR DESCRIPTION
Rotate token returns a dict. Change example to print the entire dict.

Closes: #2836

<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

<!-- Remove this comment and describe your changes here. -->

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
