### PR TITLE
fix(cli): don't require `--id` when enabling a deploy key

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Require keyword arguments for register_custom_action
+19251506f734117a564c59e157221f37e5cf97ef

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # Require keyword arguments for register_custom_action
-19251506f734117a564c59e157221f37e5cf97ef
+d74545a309ed02fdc8d32157f8ccb9f7559cd185

--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import dataclasses
 import functools
 import os
 import pathlib
@@ -29,12 +30,20 @@ from gitlab.base import RESTObject
 camel_upperlower_regex = re.compile(r"([A-Z]+)([A-Z][a-z])")
 camel_lowerupper_regex = re.compile(r"([a-z\d])([A-Z])")
 
+
+@dataclasses.dataclass
+class CustomAction:
+    required: Tuple[str, ...]
+    optional: Tuple[str, ...]
+    in_object: bool
+
+
 # custom_actions = {
 #    cls: {
 #        action: (mandatory_args, optional_args, in_obj),
 #    },
 # }
-custom_actions: Dict[str, Dict[str, Tuple[Tuple[str, ...], Tuple[str, ...], bool]]] = {}
+custom_actions: Dict[str, Dict[str, CustomAction]] = {}
 
 
 # For an explanation of how these type-hints work see:
@@ -99,7 +108,9 @@ def register_custom_action(
                 custom_actions[final_name] = {}
 
             action = custom_action or f.__name__.replace("_", "-")
-            custom_actions[final_name][action] = (required, optional, in_obj)
+            custom_actions[final_name][action] = CustomAction(
+                required=required, optional=optional, in_object=in_obj
+            )
 
         return cast(__F, wrapped_f)
 

--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -72,8 +72,9 @@ class VerticalHelpFormatter(argparse.HelpFormatter):
 
 
 def register_custom_action(
+    *,
     cls_names: Union[str, Tuple[str, ...]],
-    mandatory: Tuple[str, ...] = (),
+    required: Tuple[str, ...] = (),
     optional: Tuple[str, ...] = (),
     custom_action: Optional[str] = None,
 ) -> Callable[[__F], __F]:
@@ -98,7 +99,7 @@ def register_custom_action(
                 custom_actions[final_name] = {}
 
             action = custom_action or f.__name__.replace("_", "-")
-            custom_actions[final_name][action] = (mandatory, optional, in_obj)
+            custom_actions[final_name][action] = (required, optional, in_obj)
 
         return cast(__F, wrapped_f)
 

--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -36,6 +36,7 @@ class CustomAction:
     required: Tuple[str, ...]
     optional: Tuple[str, ...]
     in_object: bool
+    requires_id: bool  # if the `_id_attr` value should be a required argument
 
 
 # custom_actions = {
@@ -86,6 +87,7 @@ def register_custom_action(
     required: Tuple[str, ...] = (),
     optional: Tuple[str, ...] = (),
     custom_action: Optional[str] = None,
+    requires_id: bool = True,  # if the `_id_attr` value should be a required argument
 ) -> Callable[[__F], __F]:
     def wrap(f: __F) -> __F:
         @functools.wraps(f)
@@ -109,7 +111,10 @@ def register_custom_action(
 
             action = custom_action or f.__name__.replace("_", "-")
             custom_actions[final_name][action] = CustomAction(
-                required=required, optional=optional, in_object=in_obj
+                required=required,
+                optional=optional,
+                in_object=in_obj,
+                requires_id=requires_id,
             )
 
         return cast(__F, wrapped_f)

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -550,7 +550,7 @@ class UserAgentDetailMixin(_RestObjectBase):
     _updated_attrs: Dict[str, Any]
     manager: base.RESTManager
 
-    @cli.register_custom_action(("Snippet", "ProjectSnippet", "ProjectIssue"))
+    @cli.register_custom_action(cls_names=("Snippet", "ProjectSnippet", "ProjectIssue"))
     @exc.on_http_error(exc.GitlabGetError)
     def user_agent_detail(self, **kwargs: Any) -> Dict[str, Any]:
         """Get the user agent detail.
@@ -578,7 +578,8 @@ class AccessRequestMixin(_RestObjectBase):
     manager: base.RESTManager
 
     @cli.register_custom_action(
-        ("ProjectAccessRequest", "GroupAccessRequest"), (), ("access_level",)
+        cls_names=("ProjectAccessRequest", "GroupAccessRequest"),
+        optional=("access_level",),
     )
     @exc.on_http_error(exc.GitlabUpdateError)
     def approve(
@@ -611,7 +612,7 @@ class DownloadMixin(_RestObjectBase):
     _updated_attrs: Dict[str, Any]
     manager: base.RESTManager
 
-    @cli.register_custom_action(("GroupExport", "ProjectExport"))
+    @cli.register_custom_action(cls_names=("GroupExport", "ProjectExport"))
     @exc.on_http_error(exc.GitlabGetError)
     def download(
         self,
@@ -721,7 +722,7 @@ class SubscribableMixin(_RestObjectBase):
     manager: base.RESTManager
 
     @cli.register_custom_action(
-        ("ProjectIssue", "ProjectMergeRequest", "ProjectLabel", "GroupLabel")
+        cls_names=("ProjectIssue", "ProjectMergeRequest", "ProjectLabel", "GroupLabel")
     )
     @exc.on_http_error(exc.GitlabSubscribeError)
     def subscribe(self, **kwargs: Any) -> None:
@@ -741,7 +742,7 @@ class SubscribableMixin(_RestObjectBase):
         self._update_attrs(server_data)
 
     @cli.register_custom_action(
-        ("ProjectIssue", "ProjectMergeRequest", "ProjectLabel", "GroupLabel")
+        cls_names=("ProjectIssue", "ProjectMergeRequest", "ProjectLabel", "GroupLabel")
     )
     @exc.on_http_error(exc.GitlabUnsubscribeError)
     def unsubscribe(self, **kwargs: Any) -> None:
@@ -769,7 +770,7 @@ class TodoMixin(_RestObjectBase):
     _updated_attrs: Dict[str, Any]
     manager: base.RESTManager
 
-    @cli.register_custom_action(("ProjectIssue", "ProjectMergeRequest"))
+    @cli.register_custom_action(cls_names=("ProjectIssue", "ProjectMergeRequest"))
     @exc.on_http_error(exc.GitlabTodoError)
     def todo(self, **kwargs: Any) -> None:
         """Create a todo associated to the object.
@@ -793,7 +794,7 @@ class TimeTrackingMixin(_RestObjectBase):
     _updated_attrs: Dict[str, Any]
     manager: base.RESTManager
 
-    @cli.register_custom_action(("ProjectIssue", "ProjectMergeRequest"))
+    @cli.register_custom_action(cls_names=("ProjectIssue", "ProjectMergeRequest"))
     @exc.on_http_error(exc.GitlabTimeTrackingError)
     def time_stats(self, **kwargs: Any) -> Dict[str, Any]:
         """Get time stats for the object.
@@ -819,7 +820,9 @@ class TimeTrackingMixin(_RestObjectBase):
             assert not isinstance(result, requests.Response)
         return result
 
-    @cli.register_custom_action(("ProjectIssue", "ProjectMergeRequest"), ("duration",))
+    @cli.register_custom_action(
+        cls_names=("ProjectIssue", "ProjectMergeRequest"), required=("duration",)
+    )
     @exc.on_http_error(exc.GitlabTimeTrackingError)
     def time_estimate(self, duration: str, **kwargs: Any) -> Dict[str, Any]:
         """Set an estimated time of work for the object.
@@ -839,7 +842,7 @@ class TimeTrackingMixin(_RestObjectBase):
             assert not isinstance(result, requests.Response)
         return result
 
-    @cli.register_custom_action(("ProjectIssue", "ProjectMergeRequest"))
+    @cli.register_custom_action(cls_names=("ProjectIssue", "ProjectMergeRequest"))
     @exc.on_http_error(exc.GitlabTimeTrackingError)
     def reset_time_estimate(self, **kwargs: Any) -> Dict[str, Any]:
         """Resets estimated time for the object to 0 seconds.
@@ -857,7 +860,9 @@ class TimeTrackingMixin(_RestObjectBase):
             assert not isinstance(result, requests.Response)
         return result
 
-    @cli.register_custom_action(("ProjectIssue", "ProjectMergeRequest"), ("duration",))
+    @cli.register_custom_action(
+        cls_names=("ProjectIssue", "ProjectMergeRequest"), required=("duration",)
+    )
     @exc.on_http_error(exc.GitlabTimeTrackingError)
     def add_spent_time(self, duration: str, **kwargs: Any) -> Dict[str, Any]:
         """Add time spent working on the object.
@@ -877,7 +882,7 @@ class TimeTrackingMixin(_RestObjectBase):
             assert not isinstance(result, requests.Response)
         return result
 
-    @cli.register_custom_action(("ProjectIssue", "ProjectMergeRequest"))
+    @cli.register_custom_action(cls_names=("ProjectIssue", "ProjectMergeRequest"))
     @exc.on_http_error(exc.GitlabTimeTrackingError)
     def reset_spent_time(self, **kwargs: Any) -> Dict[str, Any]:
         """Resets the time spent working on the object.
@@ -904,7 +909,7 @@ class ParticipantsMixin(_RestObjectBase):
     _updated_attrs: Dict[str, Any]
     manager: base.RESTManager
 
-    @cli.register_custom_action(("ProjectMergeRequest", "ProjectIssue"))
+    @cli.register_custom_action(cls_names=("ProjectMergeRequest", "ProjectIssue"))
     @exc.on_http_error(exc.GitlabListError)
     def participants(self, **kwargs: Any) -> Dict[str, Any]:
         """List the participants.
@@ -932,7 +937,8 @@ class ParticipantsMixin(_RestObjectBase):
 
 class BadgeRenderMixin(_RestManagerBase):
     @cli.register_custom_action(
-        ("GroupBadgeManager", "ProjectBadgeManager"), ("link_url", "image_url")
+        cls_names=("GroupBadgeManager", "ProjectBadgeManager"),
+        required=("link_url", "image_url"),
     )
     @exc.on_http_error(exc.GitlabRenderError)
     def render(self, link_url: str, image_url: str, **kwargs: Any) -> Dict[str, Any]:
@@ -1025,7 +1031,9 @@ class UploadMixin(_RestObjectBase):
         data = self.attributes
         return self._upload_path.format(**data)
 
-    @cli.register_custom_action(("Project", "ProjectWiki"), ("filename", "filepath"))
+    @cli.register_custom_action(
+        cls_names=("Project", "ProjectWiki"), required=("filename", "filepath")
+    )
     @exc.on_http_error(exc.GitlabUploadError)
     def upload(
         self,

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -82,7 +82,7 @@ class GitlabCLI:
 
     def do_custom(self) -> Any:
         class_instance: Union[gitlab.base.RESTManager, gitlab.base.RESTObject]
-        in_obj = cli.custom_actions[self.cls_name][self.resource_action][2]
+        in_obj = cli.custom_actions[self.cls_name][self.resource_action].in_object
 
         # Get the object (lazy), then act
         if in_obj:
@@ -321,13 +321,13 @@ def _populate_sub_parser_by_class(
                     id_attr = cls._id_attr.replace("_", "-")
                     sub_parser_action.add_argument(f"--{id_attr}", required=True)
 
-            required, optional, dummy = cli.custom_actions[name][action_name]
-            for x in required:
+            custom_action = cli.custom_actions[name][action_name]
+            for x in custom_action.required:
                 if x != cls._id_attr:
                     sub_parser_action.add_argument(
                         f"--{x.replace('_', '-')}", required=True
                     )
-            for x in optional:
+            for x in custom_action.optional:
                 if x != cls._id_attr:
                     sub_parser_action.add_argument(
                         f"--{x.replace('_', '-')}", required=False
@@ -350,13 +350,13 @@ def _populate_sub_parser_by_class(
                     )
                 sub_parser_action.add_argument("--sudo", required=False)
 
-            required, optional, dummy = cli.custom_actions[name][action_name]
-            for x in required:
+            custom_action = cli.custom_actions[name][action_name]
+            for x in custom_action.required:
                 if x != cls._id_attr:
                     sub_parser_action.add_argument(
                         f"--{x.replace('_', '-')}", required=True
                     )
-            for x in optional:
+            for x in custom_action.optional:
                 if x != cls._id_attr:
                     sub_parser_action.add_argument(
                         f"--{x.replace('_', '-')}", required=False

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -315,13 +315,13 @@ def _populate_sub_parser_by_class(
                     )
                 sub_parser_action.add_argument("--sudo", required=False)
 
+            custom_action = cli.custom_actions[name][action_name]
             # We need to get the object somehow
             if not issubclass(cls, gitlab.mixins.GetWithoutIdMixin):
-                if cls._id_attr is not None:
+                if cls._id_attr is not None and custom_action.requires_id:
                     id_attr = cls._id_attr.replace("_", "-")
                     sub_parser_action.add_argument(f"--{id_attr}", required=True)
 
-            custom_action = cli.custom_actions[name][action_name]
             for x in custom_action.required:
                 if x != cls._id_attr:
                     sub_parser_action.add_argument(

--- a/gitlab/v4/objects/artifacts.py
+++ b/gitlab/v4/objects/artifacts.py
@@ -44,7 +44,9 @@ class ProjectArtifactManager(RESTManager):
         self.gitlab.http_delete(path, **kwargs)
 
     @cli.register_custom_action(
-        "ProjectArtifactManager", ("ref_name", "job"), ("job_token",)
+        cls_names="ProjectArtifactManager",
+        required=("ref_name", "job"),
+        optional=("job_token",),
     )
     @exc.on_http_error(exc.GitlabGetError)
     def download(
@@ -93,7 +95,8 @@ class ProjectArtifactManager(RESTManager):
         )
 
     @cli.register_custom_action(
-        "ProjectArtifactManager", ("ref_name", "artifact_path", "job")
+        cls_names="ProjectArtifactManager",
+        required=("ref_name", "artifact_path", "job"),
     )
     @exc.on_http_error(exc.GitlabGetError)
     def raw(

--- a/gitlab/v4/objects/ci_lint.py
+++ b/gitlab/v4/objects/ci_lint.py
@@ -31,8 +31,8 @@ class CiLintManager(CreateMixin, RESTManager):
     )
 
     @register_custom_action(
-        "CiLintManager",
-        ("content",),
+        cls_names="CiLintManager",
+        required=("content",),
         optional=("include_merged_yaml", "include_jobs"),
     )
     def validate(self, *args: Any, **kwargs: Any) -> None:
@@ -63,8 +63,8 @@ class ProjectCiLintManager(GetWithoutIdMixin, CreateMixin, RESTManager):
         return cast(ProjectCiLint, super().get(**kwargs))
 
     @register_custom_action(
-        "ProjectCiLintManager",
-        ("content",),
+        cls_names="ProjectCiLintManager",
+        required=("content",),
         optional=("dry_run", "include_jobs", "ref"),
     )
     def validate(self, *args: Any, **kwargs: Any) -> None:

--- a/gitlab/v4/objects/commits.py
+++ b/gitlab/v4/objects/commits.py
@@ -28,7 +28,7 @@ class ProjectCommit(RESTObject):
     discussions: ProjectCommitDiscussionManager
     statuses: "ProjectCommitStatusManager"
 
-    @cli.register_custom_action("ProjectCommit")
+    @cli.register_custom_action(cls_names="ProjectCommit")
     @exc.on_http_error(exc.GitlabGetError)
     def diff(self, **kwargs: Any) -> Union[gitlab.GitlabList, List[Dict[str, Any]]]:
         """Generate the commit diff.
@@ -46,7 +46,7 @@ class ProjectCommit(RESTObject):
         path = f"{self.manager.path}/{self.encoded_id}/diff"
         return self.manager.gitlab.http_list(path, **kwargs)
 
-    @cli.register_custom_action("ProjectCommit", ("branch",))
+    @cli.register_custom_action(cls_names="ProjectCommit", required=("branch",))
     @exc.on_http_error(exc.GitlabCherryPickError)
     def cherry_pick(self, branch: str, **kwargs: Any) -> None:
         """Cherry-pick a commit into a branch.
@@ -63,7 +63,7 @@ class ProjectCommit(RESTObject):
         post_data = {"branch": branch}
         self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
 
-    @cli.register_custom_action("ProjectCommit", optional=("type",))
+    @cli.register_custom_action(cls_names="ProjectCommit", optional=("type",))
     @exc.on_http_error(exc.GitlabGetError)
     def refs(
         self, type: str = "all", **kwargs: Any
@@ -85,7 +85,7 @@ class ProjectCommit(RESTObject):
         query_data = {"type": type}
         return self.manager.gitlab.http_list(path, query_data=query_data, **kwargs)
 
-    @cli.register_custom_action("ProjectCommit")
+    @cli.register_custom_action(cls_names="ProjectCommit")
     @exc.on_http_error(exc.GitlabGetError)
     def merge_requests(
         self, **kwargs: Any
@@ -105,7 +105,7 @@ class ProjectCommit(RESTObject):
         path = f"{self.manager.path}/{self.encoded_id}/merge_requests"
         return self.manager.gitlab.http_list(path, **kwargs)
 
-    @cli.register_custom_action("ProjectCommit", ("branch",))
+    @cli.register_custom_action(cls_names="ProjectCommit", required=("branch",))
     @exc.on_http_error(exc.GitlabRevertError)
     def revert(
         self, branch: str, **kwargs: Any
@@ -127,7 +127,7 @@ class ProjectCommit(RESTObject):
         post_data = {"branch": branch}
         return self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
 
-    @cli.register_custom_action("ProjectCommit")
+    @cli.register_custom_action(cls_names="ProjectCommit")
     @exc.on_http_error(exc.GitlabGetError)
     def signature(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Get the signature of the commit.

--- a/gitlab/v4/objects/container_registry.py
+++ b/gitlab/v4/objects/container_registry.py
@@ -42,8 +42,8 @@ class ProjectRegistryTagManager(DeleteMixin, RetrieveMixin, RESTManager):
     _path = "/projects/{project_id}/registry/repositories/{repository_id}/tags"
 
     @cli.register_custom_action(
-        "ProjectRegistryTagManager",
-        ("name_regex_delete",),
+        cls_names="ProjectRegistryTagManager",
+        required=("name_regex_delete",),
         optional=("keep_n", "name_regex_keep", "older_than"),
     )
     @exc.on_http_error(exc.GitlabDeleteError)

--- a/gitlab/v4/objects/deploy_keys.py
+++ b/gitlab/v4/objects/deploy_keys.py
@@ -36,7 +36,9 @@ class ProjectKeyManager(CRUDMixin, RESTManager):
     _create_attrs = RequiredOptional(required=("title", "key"), optional=("can_push",))
     _update_attrs = RequiredOptional(optional=("title", "can_push"))
 
-    @cli.register_custom_action(cls_names="ProjectKeyManager", required=("key_id",))
+    @cli.register_custom_action(
+        cls_names="ProjectKeyManager", required=("key_id",), requires_id=False
+    )
     @exc.on_http_error(exc.GitlabProjectDeployKeyError)
     def enable(
         self, key_id: int, **kwargs: Any

--- a/gitlab/v4/objects/deploy_keys.py
+++ b/gitlab/v4/objects/deploy_keys.py
@@ -36,7 +36,7 @@ class ProjectKeyManager(CRUDMixin, RESTManager):
     _create_attrs = RequiredOptional(required=("title", "key"), optional=("can_push",))
     _update_attrs = RequiredOptional(optional=("title", "can_push"))
 
-    @cli.register_custom_action("ProjectKeyManager", ("key_id",))
+    @cli.register_custom_action(cls_names="ProjectKeyManager", required=("key_id",))
     @exc.on_http_error(exc.GitlabProjectDeployKeyError)
     def enable(
         self, key_id: int, **kwargs: Any

--- a/gitlab/v4/objects/deployments.py
+++ b/gitlab/v4/objects/deployments.py
@@ -23,8 +23,8 @@ class ProjectDeployment(SaveMixin, RESTObject):
     mergerequests: ProjectDeploymentMergeRequestManager
 
     @cli.register_custom_action(
-        "ProjectDeployment",
-        mandatory=("status",),
+        cls_names="ProjectDeployment",
+        required=("status",),
         optional=("comment", "represented_as"),
     )
     @exc.on_http_error(exc.GitlabDeploymentApprovalError)

--- a/gitlab/v4/objects/environments.py
+++ b/gitlab/v4/objects/environments.py
@@ -24,7 +24,7 @@ __all__ = [
 
 
 class ProjectEnvironment(SaveMixin, ObjectDeleteMixin, RESTObject):
-    @cli.register_custom_action("ProjectEnvironment")
+    @cli.register_custom_action(cls_names="ProjectEnvironment")
     @exc.on_http_error(exc.GitlabStopError)
     def stop(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Stop the environment.

--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -109,7 +109,9 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         optional=("encoding", "author_email", "author_name"),
     )
 
-    @cli.register_custom_action("ProjectFileManager", ("file_path", "ref"))
+    @cli.register_custom_action(
+        cls_names="ProjectFileManager", required=("file_path", "ref")
+    )
     # NOTE(jlvillal): Signature doesn't match UpdateMixin.update() so ignore
     # type error
     def get(  # type: ignore
@@ -132,9 +134,9 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         return cast(ProjectFile, GetMixin.get(self, file_path, ref=ref, **kwargs))
 
     @cli.register_custom_action(
-        "ProjectFileManager",
-        ("file_path", "branch", "content", "commit_message"),
-        ("encoding", "author_email", "author_name"),
+        cls_names="ProjectFileManager",
+        required=("file_path", "branch", "content", "commit_message"),
+        optional=("encoding", "author_email", "author_name"),
     )
     @exc.on_http_error(exc.GitlabCreateError)
     def create(
@@ -199,7 +201,8 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         return result
 
     @cli.register_custom_action(
-        "ProjectFileManager", ("file_path", "branch", "commit_message")
+        cls_names="ProjectFileManager",
+        required=("file_path", "branch", "commit_message"),
     )
     @exc.on_http_error(exc.GitlabDeleteError)
     # NOTE(jlvillal): Signature doesn't match DeleteMixin.delete() so ignore
@@ -224,7 +227,9 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         data = {"branch": branch, "commit_message": commit_message}
         self.gitlab.http_delete(path, query_data=data, **kwargs)
 
-    @cli.register_custom_action("ProjectFileManager", ("file_path", "ref"))
+    @cli.register_custom_action(
+        cls_names="ProjectFileManager", required=("file_path", "ref")
+    )
     @exc.on_http_error(exc.GitlabGetError)
     def raw(
         self,
@@ -271,7 +276,9 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
             result, streamed, action, chunk_size, iterator=iterator
         )
 
-    @cli.register_custom_action("ProjectFileManager", ("file_path", "ref"))
+    @cli.register_custom_action(
+        cls_names="ProjectFileManager", required=("file_path", "ref")
+    )
     @exc.on_http_error(exc.GitlabListError)
     def blame(self, file_path: str, ref: str, **kwargs: Any) -> List[Dict[str, Any]]:
         """Return the content of a file for a commit.

--- a/gitlab/v4/objects/geo_nodes.py
+++ b/gitlab/v4/objects/geo_nodes.py
@@ -19,7 +19,7 @@ __all__ = [
 
 
 class GeoNode(SaveMixin, ObjectDeleteMixin, RESTObject):
-    @cli.register_custom_action("GeoNode")
+    @cli.register_custom_action(cls_names="GeoNode")
     @exc.on_http_error(exc.GitlabRepairError)
     def repair(self, **kwargs: Any) -> None:
         """Repair the OAuth authentication of the geo node.
@@ -37,7 +37,7 @@ class GeoNode(SaveMixin, ObjectDeleteMixin, RESTObject):
             assert isinstance(server_data, dict)
         self._update_attrs(server_data)
 
-    @cli.register_custom_action("GeoNode")
+    @cli.register_custom_action(cls_names="GeoNode")
     @exc.on_http_error(exc.GitlabGetError)
     def status(self, **kwargs: Any) -> Dict[str, Any]:
         """Get the status of the geo node.
@@ -69,7 +69,7 @@ class GeoNodeManager(RetrieveMixin, UpdateMixin, DeleteMixin, RESTManager):
     def get(self, id: Union[str, int], lazy: bool = False, **kwargs: Any) -> GeoNode:
         return cast(GeoNode, super().get(id=id, lazy=lazy, **kwargs))
 
-    @cli.register_custom_action("GeoNodeManager")
+    @cli.register_custom_action(cls_names="GeoNodeManager")
     @exc.on_http_error(exc.GitlabGetError)
     def status(self, **kwargs: Any) -> List[Dict[str, Any]]:
         """Get the status of all the geo nodes.
@@ -89,7 +89,7 @@ class GeoNodeManager(RetrieveMixin, UpdateMixin, DeleteMixin, RESTManager):
             assert isinstance(result, list)
         return result
 
-    @cli.register_custom_action("GeoNodeManager")
+    @cli.register_custom_action(cls_names="GeoNodeManager")
     @exc.on_http_error(exc.GitlabGetError)
     def current_failures(self, **kwargs: Any) -> List[Dict[str, Any]]:
         """Get the list of failures on the current geo node.

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -105,7 +105,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
     saml_group_links: "GroupSAMLGroupLinkManager"
     service_accounts: "GroupServiceAccountManager"
 
-    @cli.register_custom_action("Group", ("project_id",))
+    @cli.register_custom_action(cls_names="Group", required=("project_id",))
     @exc.on_http_error(exc.GitlabTransferProjectError)
     def transfer_project(self, project_id: int, **kwargs: Any) -> None:
         """Transfer a project to this group.
@@ -121,7 +121,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
         path = f"/groups/{self.encoded_id}/projects/{project_id}"
         self.manager.gitlab.http_post(path, **kwargs)
 
-    @cli.register_custom_action("Group", (), ("group_id",))
+    @cli.register_custom_action(cls_names="Group", required=(), optional=("group_id",))
     @exc.on_http_error(exc.GitlabGroupTransferError)
     def transfer(self, group_id: Optional[int] = None, **kwargs: Any) -> None:
         """Transfer the group to a new parent group or make it a top-level group.
@@ -143,7 +143,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
             post_data["group_id"] = group_id
         self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
 
-    @cli.register_custom_action("Group", ("scope", "search"))
+    @cli.register_custom_action(cls_names="Group", required=("scope", "search"))
     @exc.on_http_error(exc.GitlabSearchError)
     def search(
         self, scope: str, search: str, **kwargs: Any
@@ -166,7 +166,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
         path = f"/groups/{self.encoded_id}/search"
         return self.manager.gitlab.http_list(path, query_data=data, **kwargs)
 
-    @cli.register_custom_action("Group")
+    @cli.register_custom_action(cls_names="Group")
     @exc.on_http_error(exc.GitlabCreateError)
     def ldap_sync(self, **kwargs: Any) -> None:
         """Sync LDAP groups.
@@ -181,7 +181,11 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
         path = f"/groups/{self.encoded_id}/ldap_sync"
         self.manager.gitlab.http_post(path, **kwargs)
 
-    @cli.register_custom_action("Group", ("group_id", "group_access"), ("expires_at",))
+    @cli.register_custom_action(
+        cls_names="Group",
+        required=("group_id", "group_access"),
+        optional=("expires_at",),
+    )
     @exc.on_http_error(exc.GitlabCreateError)
     def share(
         self,
@@ -215,7 +219,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
             assert isinstance(server_data, dict)
         self._update_attrs(server_data)
 
-    @cli.register_custom_action("Group", ("group_id",))
+    @cli.register_custom_action(cls_names="Group", required=("group_id",))
     @exc.on_http_error(exc.GitlabDeleteError)
     def unshare(self, group_id: int, **kwargs: Any) -> None:
         """Delete a shared group link within a group.
@@ -231,7 +235,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
         path = f"/groups/{self.encoded_id}/share/{group_id}"
         self.manager.gitlab.http_delete(path, **kwargs)
 
-    @cli.register_custom_action("Group")
+    @cli.register_custom_action(cls_names="Group")
     @exc.on_http_error(exc.GitlabRestoreError)
     def restore(self, **kwargs: Any) -> None:
         """Restore a  group marked for deletion..

--- a/gitlab/v4/objects/integrations.py
+++ b/gitlab/v4/objects/integrations.py
@@ -270,7 +270,9 @@ class ProjectIntegrationManager(
     ) -> ProjectIntegration:
         return cast(ProjectIntegration, super().get(id=id, lazy=lazy, **kwargs))
 
-    @cli.register_custom_action(("ProjectIntegrationManager", "ProjectServiceManager"))
+    @cli.register_custom_action(
+        cls_names=("ProjectIntegrationManager", "ProjectServiceManager")
+    )
     def available(self) -> List[str]:
         """List the services known by python-gitlab.
 

--- a/gitlab/v4/objects/issues.py
+++ b/gitlab/v4/objects/issues.py
@@ -126,7 +126,7 @@ class ProjectIssue(
     resource_iteration_events: ProjectIssueResourceIterationEventManager
     resource_weight_events: ProjectIssueResourceWeightEventManager
 
-    @cli.register_custom_action("ProjectIssue", ("to_project_id",))
+    @cli.register_custom_action(cls_names="ProjectIssue", required=("to_project_id",))
     @exc.on_http_error(exc.GitlabUpdateError)
     def move(self, to_project_id: int, **kwargs: Any) -> None:
         """Move the issue to another project.
@@ -146,7 +146,9 @@ class ProjectIssue(
             assert isinstance(server_data, dict)
         self._update_attrs(server_data)
 
-    @cli.register_custom_action("ProjectIssue", ("move_after_id", "move_before_id"))
+    @cli.register_custom_action(
+        cls_names="ProjectIssue", required=("move_after_id", "move_before_id")
+    )
     @exc.on_http_error(exc.GitlabUpdateError)
     def reorder(
         self,
@@ -178,7 +180,7 @@ class ProjectIssue(
             assert isinstance(server_data, dict)
         self._update_attrs(server_data)
 
-    @cli.register_custom_action("ProjectIssue")
+    @cli.register_custom_action(cls_names="ProjectIssue")
     @exc.on_http_error(exc.GitlabGetError)
     def related_merge_requests(self, **kwargs: Any) -> Dict[str, Any]:
         """List merge requests related to the issue.
@@ -199,7 +201,7 @@ class ProjectIssue(
             assert isinstance(result, dict)
         return result
 
-    @cli.register_custom_action("ProjectIssue")
+    @cli.register_custom_action(cls_names="ProjectIssue")
     @exc.on_http_error(exc.GitlabGetError)
     def closed_by(self, **kwargs: Any) -> Dict[str, Any]:
         """List merge requests that will close the issue when merged.

--- a/gitlab/v4/objects/jobs.py
+++ b/gitlab/v4/objects/jobs.py
@@ -16,7 +16,7 @@ __all__ = [
 
 
 class ProjectJob(RefreshMixin, RESTObject):
-    @cli.register_custom_action("ProjectJob")
+    @cli.register_custom_action(cls_names="ProjectJob")
     @exc.on_http_error(exc.GitlabJobCancelError)
     def cancel(self, **kwargs: Any) -> Dict[str, Any]:
         """Cancel the job.
@@ -34,7 +34,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             assert isinstance(result, dict)
         return result
 
-    @cli.register_custom_action("ProjectJob")
+    @cli.register_custom_action(cls_names="ProjectJob")
     @exc.on_http_error(exc.GitlabJobRetryError)
     def retry(self, **kwargs: Any) -> Dict[str, Any]:
         """Retry the job.
@@ -52,7 +52,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             assert isinstance(result, dict)
         return result
 
-    @cli.register_custom_action("ProjectJob")
+    @cli.register_custom_action(cls_names="ProjectJob")
     @exc.on_http_error(exc.GitlabJobPlayError)
     def play(self, **kwargs: Any) -> None:
         """Trigger a job explicitly.
@@ -70,7 +70,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             assert isinstance(result, dict)
         self._update_attrs(result)
 
-    @cli.register_custom_action("ProjectJob")
+    @cli.register_custom_action(cls_names="ProjectJob")
     @exc.on_http_error(exc.GitlabJobEraseError)
     def erase(self, **kwargs: Any) -> None:
         """Erase the job (remove job artifacts and trace).
@@ -85,7 +85,7 @@ class ProjectJob(RefreshMixin, RESTObject):
         path = f"{self.manager.path}/{self.encoded_id}/erase"
         self.manager.gitlab.http_post(path, **kwargs)
 
-    @cli.register_custom_action("ProjectJob")
+    @cli.register_custom_action(cls_names="ProjectJob")
     @exc.on_http_error(exc.GitlabCreateError)
     def keep_artifacts(self, **kwargs: Any) -> None:
         """Prevent artifacts from being deleted when expiration is set.
@@ -100,7 +100,7 @@ class ProjectJob(RefreshMixin, RESTObject):
         path = f"{self.manager.path}/{self.encoded_id}/artifacts/keep"
         self.manager.gitlab.http_post(path, **kwargs)
 
-    @cli.register_custom_action("ProjectJob")
+    @cli.register_custom_action(cls_names="ProjectJob")
     @exc.on_http_error(exc.GitlabCreateError)
     def delete_artifacts(self, **kwargs: Any) -> None:
         """Delete artifacts of a job.
@@ -115,7 +115,7 @@ class ProjectJob(RefreshMixin, RESTObject):
         path = f"{self.manager.path}/{self.encoded_id}/artifacts"
         self.manager.gitlab.http_delete(path, **kwargs)
 
-    @cli.register_custom_action("ProjectJob")
+    @cli.register_custom_action(cls_names="ProjectJob")
     @exc.on_http_error(exc.GitlabGetError)
     def artifacts(
         self,
@@ -156,7 +156,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             result, streamed, action, chunk_size, iterator=iterator
         )
 
-    @cli.register_custom_action("ProjectJob")
+    @cli.register_custom_action(cls_names="ProjectJob")
     @exc.on_http_error(exc.GitlabGetError)
     def artifact(
         self,
@@ -199,7 +199,7 @@ class ProjectJob(RefreshMixin, RESTObject):
             result, streamed, action, chunk_size, iterator=iterator
         )
 
-    @cli.register_custom_action("ProjectJob")
+    @cli.register_custom_action(cls_names="ProjectJob")
     @exc.on_http_error(exc.GitlabGetError)
     def trace(
         self,

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -168,7 +168,7 @@ class ProjectMergeRequest(
     resourcestateevents: ProjectMergeRequestResourceStateEventManager
     reviewer_details: ProjectMergeRequestReviewerDetailManager
 
-    @cli.register_custom_action("ProjectMergeRequest")
+    @cli.register_custom_action(cls_names="ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabMROnBuildSuccessError)
     def cancel_merge_when_pipeline_succeeds(self, **kwargs: Any) -> Dict[str, str]:
         """Cancel merge when the pipeline succeeds.
@@ -197,7 +197,7 @@ class ProjectMergeRequest(
             assert isinstance(server_data, dict)
         return server_data
 
-    @cli.register_custom_action("ProjectMergeRequest")
+    @cli.register_custom_action(cls_names="ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabListError)
     def closes_issues(self, **kwargs: Any) -> RESTObjectList:
         """List issues that will close on merge."
@@ -222,7 +222,7 @@ class ProjectMergeRequest(
         manager = ProjectIssueManager(self.manager.gitlab, parent=self.manager._parent)
         return RESTObjectList(manager, ProjectIssue, data_list)
 
-    @cli.register_custom_action("ProjectMergeRequest")
+    @cli.register_custom_action(cls_names="ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabListError)
     def commits(self, **kwargs: Any) -> RESTObjectList:
         """List the merge request commits.
@@ -248,7 +248,9 @@ class ProjectMergeRequest(
         manager = ProjectCommitManager(self.manager.gitlab, parent=self.manager._parent)
         return RESTObjectList(manager, ProjectCommit, data_list)
 
-    @cli.register_custom_action("ProjectMergeRequest", optional=("access_raw_diffs",))
+    @cli.register_custom_action(
+        cls_names="ProjectMergeRequest", optional=("access_raw_diffs",)
+    )
     @exc.on_http_error(exc.GitlabListError)
     def changes(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """List the merge request changes.
@@ -266,7 +268,7 @@ class ProjectMergeRequest(
         path = f"{self.manager.path}/{self.encoded_id}/changes"
         return self.manager.gitlab.http_get(path, **kwargs)
 
-    @cli.register_custom_action("ProjectMergeRequest", (), ("sha",))
+    @cli.register_custom_action(cls_names="ProjectMergeRequest", optional=("sha",))
     @exc.on_http_error(exc.GitlabMRApprovalError)
     def approve(self, sha: Optional[str] = None, **kwargs: Any) -> Dict[str, Any]:
         """Approve the merge request.
@@ -295,7 +297,7 @@ class ProjectMergeRequest(
         self._update_attrs(server_data)
         return server_data
 
-    @cli.register_custom_action("ProjectMergeRequest")
+    @cli.register_custom_action(cls_names="ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabMRApprovalError)
     def unapprove(self, **kwargs: Any) -> None:
         """Unapprove the merge request.
@@ -317,7 +319,7 @@ class ProjectMergeRequest(
             assert isinstance(server_data, dict)
         self._update_attrs(server_data)
 
-    @cli.register_custom_action("ProjectMergeRequest")
+    @cli.register_custom_action(cls_names="ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabMRRebaseError)
     def rebase(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Attempt to rebase the source branch onto the target branch
@@ -333,7 +335,7 @@ class ProjectMergeRequest(
         data: Dict[str, Any] = {}
         return self.manager.gitlab.http_put(path, post_data=data, **kwargs)
 
-    @cli.register_custom_action("ProjectMergeRequest")
+    @cli.register_custom_action(cls_names="ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabMRResetApprovalError)
     def reset_approvals(
         self, **kwargs: Any
@@ -351,7 +353,7 @@ class ProjectMergeRequest(
         data: Dict[str, Any] = {}
         return self.manager.gitlab.http_put(path, post_data=data, **kwargs)
 
-    @cli.register_custom_action("ProjectMergeRequest")
+    @cli.register_custom_action(cls_names="ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabGetError)
     def merge_ref(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Attempt to merge changes between source and target branches into
@@ -367,9 +369,8 @@ class ProjectMergeRequest(
         return self.manager.gitlab.http_get(path, **kwargs)
 
     @cli.register_custom_action(
-        "ProjectMergeRequest",
-        (),
-        (
+        cls_names="ProjectMergeRequest",
+        optional=(
             "merge_commit_message",
             "should_remove_source_branch",
             "merge_when_pipeline_succeeds",

--- a/gitlab/v4/objects/milestones.py
+++ b/gitlab/v4/objects/milestones.py
@@ -31,7 +31,7 @@ __all__ = [
 class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
     _repr_attr = "title"
 
-    @cli.register_custom_action("GroupMilestone")
+    @cli.register_custom_action(cls_names="GroupMilestone")
     @exc.on_http_error(exc.GitlabListError)
     def issues(self, **kwargs: Any) -> RESTObjectList:
         """List issues related to this milestone.
@@ -58,7 +58,7 @@ class GroupMilestone(SaveMixin, ObjectDeleteMixin, RESTObject):
         # FIXME(gpocentek): the computed manager path is not correct
         return RESTObjectList(manager, GroupIssue, data_list)
 
-    @cli.register_custom_action("GroupMilestone")
+    @cli.register_custom_action(cls_names="GroupMilestone")
     @exc.on_http_error(exc.GitlabListError)
     def merge_requests(self, **kwargs: Any) -> RESTObjectList:
         """List the merge requests related to this milestone.
@@ -108,7 +108,7 @@ class ProjectMilestone(PromoteMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
     _repr_attr = "title"
     _update_method = UpdateMethod.POST
 
-    @cli.register_custom_action("ProjectMilestone")
+    @cli.register_custom_action(cls_names="ProjectMilestone")
     @exc.on_http_error(exc.GitlabListError)
     def issues(self, **kwargs: Any) -> RESTObjectList:
         """List issues related to this milestone.
@@ -135,7 +135,7 @@ class ProjectMilestone(PromoteMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
         # FIXME(gpocentek): the computed manager path is not correct
         return RESTObjectList(manager, ProjectIssue, data_list)
 
-    @cli.register_custom_action("ProjectMilestone")
+    @cli.register_custom_action(cls_names="ProjectMilestone")
     @exc.on_http_error(exc.GitlabListError)
     def merge_requests(self, **kwargs: Any) -> RESTObjectList:
         """List the merge requests related to this milestone.

--- a/gitlab/v4/objects/namespaces.py
+++ b/gitlab/v4/objects/namespaces.py
@@ -24,7 +24,9 @@ class NamespaceManager(RetrieveMixin, RESTManager):
     def get(self, id: Union[str, int], lazy: bool = False, **kwargs: Any) -> Namespace:
         return cast(Namespace, super().get(id=id, lazy=lazy, **kwargs))
 
-    @cli.register_custom_action("NamespaceManager", ("namespace", "parent_id"))
+    @cli.register_custom_action(
+        cls_names="NamespaceManager", required=("namespace", "parent_id")
+    )
     @exc.on_http_error(exc.GitlabGetError)
     def exists(self, namespace: str, **kwargs: Any) -> Namespace:
         """Get existence of a namespace by path.

--- a/gitlab/v4/objects/packages.py
+++ b/gitlab/v4/objects/packages.py
@@ -48,8 +48,8 @@ class GenericPackageManager(RESTManager):
     _from_parent_attrs = {"project_id": "id"}
 
     @cli.register_custom_action(
-        "GenericPackageManager",
-        ("package_name", "package_version", "file_name", "path"),
+        cls_names="GenericPackageManager",
+        required=("package_name", "package_version", "file_name", "path"),
     )
     @exc.on_http_error(exc.GitlabUploadError)
     def upload(
@@ -123,8 +123,8 @@ class GenericPackageManager(RESTManager):
         return self._obj_cls(self, attrs=attrs)
 
     @cli.register_custom_action(
-        "GenericPackageManager",
-        ("package_name", "package_version", "file_name"),
+        cls_names="GenericPackageManager",
+        required=("package_name", "package_version", "file_name"),
     )
     @exc.on_http_error(exc.GitlabGetError)
     def download(

--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -60,7 +60,7 @@ class ProjectPipeline(RefreshMixin, ObjectDeleteMixin, RESTObject):
     test_report_summary: "ProjectPipelineTestReportSummaryManager"
     variables: "ProjectPipelineVariableManager"
 
-    @cli.register_custom_action("ProjectPipeline")
+    @cli.register_custom_action(cls_names="ProjectPipeline")
     @exc.on_http_error(exc.GitlabPipelineCancelError)
     def cancel(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Cancel the job.
@@ -75,7 +75,7 @@ class ProjectPipeline(RefreshMixin, ObjectDeleteMixin, RESTObject):
         path = f"{self.manager.path}/{self.encoded_id}/cancel"
         return self.manager.gitlab.http_post(path, **kwargs)
 
-    @cli.register_custom_action("ProjectPipeline")
+    @cli.register_custom_action(cls_names="ProjectPipeline")
     @exc.on_http_error(exc.GitlabPipelineRetryError)
     def retry(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Retry the job.
@@ -201,7 +201,7 @@ class ProjectPipelineSchedule(SaveMixin, ObjectDeleteMixin, RESTObject):
     variables: ProjectPipelineScheduleVariableManager
     pipelines: ProjectPipelineSchedulePipelineManager
 
-    @cli.register_custom_action("ProjectPipelineSchedule")
+    @cli.register_custom_action(cls_names="ProjectPipelineSchedule")
     @exc.on_http_error(exc.GitlabOwnershipError)
     def take_ownership(self, **kwargs: Any) -> None:
         """Update the owner of a pipeline schedule.
@@ -219,7 +219,7 @@ class ProjectPipelineSchedule(SaveMixin, ObjectDeleteMixin, RESTObject):
             assert isinstance(server_data, dict)
         self._update_attrs(server_data)
 
-    @cli.register_custom_action("ProjectPipelineSchedule")
+    @cli.register_custom_action(cls_names="ProjectPipelineSchedule")
     @exc.on_http_error(exc.GitlabPipelinePlayError)
     def play(self, **kwargs: Any) -> Dict[str, Any]:
         """Trigger a new scheduled pipeline, which runs immediately.

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -231,7 +231,7 @@ class Project(
     variables: ProjectVariableManager
     wikis: ProjectWikiManager
 
-    @cli.register_custom_action("Project", ("forked_from_id",))
+    @cli.register_custom_action(cls_names="Project", required=("forked_from_id",))
     @exc.on_http_error(exc.GitlabCreateError)
     def create_fork_relation(self, forked_from_id: int, **kwargs: Any) -> None:
         """Create a forked from/to relation between existing projects.
@@ -247,7 +247,7 @@ class Project(
         path = f"/projects/{self.encoded_id}/fork/{forked_from_id}"
         self.manager.gitlab.http_post(path, **kwargs)
 
-    @cli.register_custom_action("Project")
+    @cli.register_custom_action(cls_names="Project")
     @exc.on_http_error(exc.GitlabDeleteError)
     def delete_fork_relation(self, **kwargs: Any) -> None:
         """Delete a forked relation between existing projects.
@@ -262,7 +262,7 @@ class Project(
         path = f"/projects/{self.encoded_id}/fork"
         self.manager.gitlab.http_delete(path, **kwargs)
 
-    @cli.register_custom_action("Project")
+    @cli.register_custom_action(cls_names="Project")
     @exc.on_http_error(exc.GitlabGetError)
     def languages(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Get languages used in the project with percentage value.
@@ -277,7 +277,7 @@ class Project(
         path = f"/projects/{self.encoded_id}/languages"
         return self.manager.gitlab.http_get(path, **kwargs)
 
-    @cli.register_custom_action("Project")
+    @cli.register_custom_action(cls_names="Project")
     @exc.on_http_error(exc.GitlabCreateError)
     def star(self, **kwargs: Any) -> None:
         """Star a project.
@@ -295,7 +295,7 @@ class Project(
             assert isinstance(server_data, dict)
         self._update_attrs(server_data)
 
-    @cli.register_custom_action("Project")
+    @cli.register_custom_action(cls_names="Project")
     @exc.on_http_error(exc.GitlabDeleteError)
     def unstar(self, **kwargs: Any) -> None:
         """Unstar a project.
@@ -313,7 +313,7 @@ class Project(
             assert isinstance(server_data, dict)
         self._update_attrs(server_data)
 
-    @cli.register_custom_action("Project")
+    @cli.register_custom_action(cls_names="Project")
     @exc.on_http_error(exc.GitlabCreateError)
     def archive(self, **kwargs: Any) -> None:
         """Archive a project.
@@ -331,7 +331,7 @@ class Project(
             assert isinstance(server_data, dict)
         self._update_attrs(server_data)
 
-    @cli.register_custom_action("Project")
+    @cli.register_custom_action(cls_names="Project")
     @exc.on_http_error(exc.GitlabDeleteError)
     def unarchive(self, **kwargs: Any) -> None:
         """Unarchive a project.
@@ -350,7 +350,9 @@ class Project(
         self._update_attrs(server_data)
 
     @cli.register_custom_action(
-        "Project", ("group_id", "group_access"), ("expires_at",)
+        cls_names="Project",
+        required=("group_id", "group_access"),
+        optional=("expires_at",),
     )
     @exc.on_http_error(exc.GitlabCreateError)
     def share(
@@ -379,7 +381,7 @@ class Project(
         }
         self.manager.gitlab.http_post(path, post_data=data, **kwargs)
 
-    @cli.register_custom_action("Project", ("group_id",))
+    @cli.register_custom_action(cls_names="Project", required=("group_id",))
     @exc.on_http_error(exc.GitlabDeleteError)
     def unshare(self, group_id: int, **kwargs: Any) -> None:
         """Delete a shared project link within a group.
@@ -396,7 +398,7 @@ class Project(
         self.manager.gitlab.http_delete(path, **kwargs)
 
     # variables not supported in CLI
-    @cli.register_custom_action("Project", ("ref", "token"))
+    @cli.register_custom_action(cls_names="Project", required=("ref", "token"))
     @exc.on_http_error(exc.GitlabCreateError)
     def trigger_pipeline(
         self,
@@ -427,7 +429,7 @@ class Project(
             assert isinstance(attrs, dict)
         return ProjectPipeline(self.pipelines, attrs)
 
-    @cli.register_custom_action("Project")
+    @cli.register_custom_action(cls_names="Project")
     @exc.on_http_error(exc.GitlabHousekeepingError)
     def housekeeping(self, **kwargs: Any) -> None:
         """Start the housekeeping task.
@@ -443,7 +445,7 @@ class Project(
         path = f"/projects/{self.encoded_id}/housekeeping"
         self.manager.gitlab.http_post(path, **kwargs)
 
-    @cli.register_custom_action("Project")
+    @cli.register_custom_action(cls_names="Project")
     @exc.on_http_error(exc.GitlabRestoreError)
     def restore(self, **kwargs: Any) -> None:
         """Restore a project marked for deletion.
@@ -458,7 +460,7 @@ class Project(
         path = f"/projects/{self.encoded_id}/restore"
         self.manager.gitlab.http_post(path, **kwargs)
 
-    @cli.register_custom_action("Project", optional=("wiki",))
+    @cli.register_custom_action(cls_names="Project", optional=("wiki",))
     @exc.on_http_error(exc.GitlabGetError)
     def snapshot(
         self,
@@ -501,7 +503,7 @@ class Project(
             result, streamed, action, chunk_size, iterator=iterator
         )
 
-    @cli.register_custom_action("Project", ("scope", "search"))
+    @cli.register_custom_action(cls_names="Project", required=("scope", "search"))
     @exc.on_http_error(exc.GitlabSearchError)
     def search(
         self, scope: str, search: str, **kwargs: Any
@@ -524,7 +526,7 @@ class Project(
         path = f"/projects/{self.encoded_id}/search"
         return self.manager.gitlab.http_list(path, query_data=data, **kwargs)
 
-    @cli.register_custom_action("Project")
+    @cli.register_custom_action(cls_names="Project")
     @exc.on_http_error(exc.GitlabCreateError)
     def mirror_pull(self, **kwargs: Any) -> None:
         """Start the pull mirroring process for the project.
@@ -539,7 +541,7 @@ class Project(
         path = f"/projects/{self.encoded_id}/mirror/pull"
         self.manager.gitlab.http_post(path, **kwargs)
 
-    @cli.register_custom_action("Project")
+    @cli.register_custom_action(cls_names="Project")
     @exc.on_http_error(exc.GitlabGetError)
     def mirror_pull_details(self, **kwargs: Any) -> Dict[str, Any]:
         """Get a project's pull mirror details.
@@ -562,7 +564,7 @@ class Project(
             assert isinstance(result, dict)
         return result
 
-    @cli.register_custom_action("Project", ("to_namespace",))
+    @cli.register_custom_action(cls_names="Project", required=("to_namespace",))
     @exc.on_http_error(exc.GitlabTransferProjectError)
     def transfer(self, to_namespace: Union[int, str], **kwargs: Any) -> None:
         """Transfer a project to the given namespace ID

--- a/gitlab/v4/objects/repositories.py
+++ b/gitlab/v4/objects/repositories.py
@@ -21,7 +21,9 @@ else:
 
 
 class RepositoryMixin(_RestObjectBase):
-    @cli.register_custom_action("Project", ("submodule", "branch", "commit_sha"))
+    @cli.register_custom_action(
+        cls_names="Project", required=("submodule", "branch", "commit_sha")
+    )
     @exc.on_http_error(exc.GitlabUpdateError)
     def update_submodule(
         self, submodule: str, branch: str, commit_sha: str, **kwargs: Any
@@ -47,7 +49,9 @@ class RepositoryMixin(_RestObjectBase):
             data["commit_message"] = kwargs["commit_message"]
         return self.manager.gitlab.http_put(path, post_data=data)
 
-    @cli.register_custom_action("Project", (), ("path", "ref", "recursive"))
+    @cli.register_custom_action(
+        cls_names="Project", optional=("path", "ref", "recursive")
+    )
     @exc.on_http_error(exc.GitlabGetError)
     def repository_tree(
         self, path: str = "", ref: str = "", recursive: bool = False, **kwargs: Any
@@ -80,7 +84,7 @@ class RepositoryMixin(_RestObjectBase):
             query_data["ref"] = ref
         return self.manager.gitlab.http_list(gl_path, query_data=query_data, **kwargs)
 
-    @cli.register_custom_action("Project", ("sha",))
+    @cli.register_custom_action(cls_names="Project", required=("sha",))
     @exc.on_http_error(exc.GitlabGetError)
     def repository_blob(
         self, sha: str, **kwargs: Any
@@ -102,7 +106,7 @@ class RepositoryMixin(_RestObjectBase):
         path = f"/projects/{self.encoded_id}/repository/blobs/{sha}"
         return self.manager.gitlab.http_get(path, **kwargs)
 
-    @cli.register_custom_action("Project", ("sha",))
+    @cli.register_custom_action(cls_names="Project", required=("sha",))
     @exc.on_http_error(exc.GitlabGetError)
     def repository_raw_blob(
         self,
@@ -145,7 +149,7 @@ class RepositoryMixin(_RestObjectBase):
             result, streamed, action, chunk_size, iterator=iterator
         )
 
-    @cli.register_custom_action("Project", ("from_", "to"))
+    @cli.register_custom_action(cls_names="Project", required=("from_", "to"))
     @exc.on_http_error(exc.GitlabGetError)
     def repository_compare(
         self, from_: str, to: str, **kwargs: Any
@@ -168,7 +172,7 @@ class RepositoryMixin(_RestObjectBase):
         query_data = {"from": from_, "to": to}
         return self.manager.gitlab.http_get(path, query_data=query_data, **kwargs)
 
-    @cli.register_custom_action("Project")
+    @cli.register_custom_action(cls_names="Project")
     @exc.on_http_error(exc.GitlabGetError)
     def repository_contributors(
         self, **kwargs: Any
@@ -193,7 +197,7 @@ class RepositoryMixin(_RestObjectBase):
         path = f"/projects/{self.encoded_id}/repository/contributors"
         return self.manager.gitlab.http_list(path, **kwargs)
 
-    @cli.register_custom_action("Project", (), ("sha", "format"))
+    @cli.register_custom_action(cls_names="Project", optional=("sha", "format"))
     @exc.on_http_error(exc.GitlabListError)
     def repository_archive(
         self,
@@ -247,7 +251,7 @@ class RepositoryMixin(_RestObjectBase):
             result, streamed, action, chunk_size, iterator=iterator
         )
 
-    @cli.register_custom_action("Project", ("refs",))
+    @cli.register_custom_action(cls_names="Project", required=("refs",))
     @exc.on_http_error(exc.GitlabGetError)
     def repository_merge_base(
         self, refs: List[str], **kwargs: Any
@@ -273,7 +277,7 @@ class RepositoryMixin(_RestObjectBase):
         )
         return self.manager.gitlab.http_get(path, query_data=query_data, **kwargs)
 
-    @cli.register_custom_action("Project")
+    @cli.register_custom_action(cls_names="Project")
     @exc.on_http_error(exc.GitlabDeleteError)
     def delete_merged_branches(self, **kwargs: Any) -> None:
         """Delete merged branches.

--- a/gitlab/v4/objects/runners.py
+++ b/gitlab/v4/objects/runners.py
@@ -74,7 +74,7 @@ class RunnerManager(CRUDMixin, RESTManager):
     _list_filters = ("scope", "type", "status", "paused", "tag_list")
     _types = {"tag_list": types.CommaSeparatedListAttribute}
 
-    @cli.register_custom_action("RunnerManager", (), ("scope",))
+    @cli.register_custom_action(cls_names="RunnerManager", optional=("scope",))
     @exc.on_http_error(exc.GitlabListError)
     def all(self, scope: Optional[str] = None, **kwargs: Any) -> List[Runner]:
         """List all the runners.
@@ -103,7 +103,7 @@ class RunnerManager(CRUDMixin, RESTManager):
         obj = self.gitlab.http_list(path, query_data, **kwargs)
         return [self._obj_cls(self, item) for item in obj]
 
-    @cli.register_custom_action("RunnerManager", ("token",))
+    @cli.register_custom_action(cls_names="RunnerManager", required=("token",))
     @exc.on_http_error(exc.GitlabVerifyError)
     def verify(self, token: str, **kwargs: Any) -> None:
         """Validates authentication credentials for a registered Runner.

--- a/gitlab/v4/objects/secure_files.py
+++ b/gitlab/v4/objects/secure_files.py
@@ -18,7 +18,7 @@ __all__ = ["ProjectSecureFile", "ProjectSecureFileManager"]
 
 
 class ProjectSecureFile(ObjectDeleteMixin, RESTObject):
-    @cli.register_custom_action("ProjectSecureFile")
+    @cli.register_custom_action(cls_names="ProjectSecureFile")
     @exc.on_http_error(exc.GitlabGetError)
     def download(
         self,

--- a/gitlab/v4/objects/sidekiq.py
+++ b/gitlab/v4/objects/sidekiq.py
@@ -18,7 +18,7 @@ class SidekiqManager(RESTManager):
     for the sidekiq metrics API.
     """
 
-    @cli.register_custom_action("SidekiqManager")
+    @cli.register_custom_action(cls_names="SidekiqManager")
     @exc.on_http_error(exc.GitlabGetError)
     def queue_metrics(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Return the registered queues information.
@@ -35,7 +35,7 @@ class SidekiqManager(RESTManager):
         """
         return self.gitlab.http_get("/sidekiq/queue_metrics", **kwargs)
 
-    @cli.register_custom_action("SidekiqManager")
+    @cli.register_custom_action(cls_names="SidekiqManager")
     @exc.on_http_error(exc.GitlabGetError)
     def process_metrics(
         self, **kwargs: Any
@@ -54,7 +54,7 @@ class SidekiqManager(RESTManager):
         """
         return self.gitlab.http_get("/sidekiq/process_metrics", **kwargs)
 
-    @cli.register_custom_action("SidekiqManager")
+    @cli.register_custom_action(cls_names="SidekiqManager")
     @exc.on_http_error(exc.GitlabGetError)
     def job_stats(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Return statistics about the jobs performed.
@@ -71,7 +71,7 @@ class SidekiqManager(RESTManager):
         """
         return self.gitlab.http_get("/sidekiq/job_stats", **kwargs)
 
-    @cli.register_custom_action("SidekiqManager")
+    @cli.register_custom_action(cls_names="SidekiqManager")
     @exc.on_http_error(exc.GitlabGetError)
     def compound_metrics(
         self, **kwargs: Any

--- a/gitlab/v4/objects/snippets.py
+++ b/gitlab/v4/objects/snippets.py
@@ -24,7 +24,7 @@ __all__ = [
 class Snippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObject):
     _repr_attr = "title"
 
-    @cli.register_custom_action("Snippet")
+    @cli.register_custom_action(cls_names="Snippet")
     @exc.on_http_error(exc.GitlabGetError)
     def content(
         self,
@@ -89,7 +89,7 @@ class SnippetManager(CRUDMixin, RESTManager):
         ),
     )
 
-    @cli.register_custom_action("SnippetManager")
+    @cli.register_custom_action(cls_names="SnippetManager")
     def public(self, **kwargs: Any) -> Union[RESTObjectList, List[RESTObject]]:
         """List all the public snippets.
 
@@ -117,7 +117,7 @@ class ProjectSnippet(UserAgentDetailMixin, SaveMixin, ObjectDeleteMixin, RESTObj
     discussions: ProjectSnippetDiscussionManager
     notes: ProjectSnippetNoteManager
 
-    @cli.register_custom_action("ProjectSnippet")
+    @cli.register_custom_action(cls_names="ProjectSnippet")
     @exc.on_http_error(exc.GitlabGetError)
     def content(
         self,

--- a/gitlab/v4/objects/todos.py
+++ b/gitlab/v4/objects/todos.py
@@ -12,7 +12,7 @@ __all__ = [
 
 
 class Todo(ObjectDeleteMixin, RESTObject):
-    @cli.register_custom_action("Todo")
+    @cli.register_custom_action(cls_names="Todo")
     @exc.on_http_error(exc.GitlabTodoError)
     def mark_as_done(self, **kwargs: Any) -> Dict[str, Any]:
         """Mark the todo as done.
@@ -40,7 +40,7 @@ class TodoManager(ListMixin, DeleteMixin, RESTManager):
     _obj_cls = Todo
     _list_filters = ("action", "author_id", "project_id", "state", "type")
 
-    @cli.register_custom_action("TodoManager")
+    @cli.register_custom_action(cls_names="TodoManager")
     @exc.on_http_error(exc.GitlabTodoError)
     def mark_all_as_done(self, **kwargs: Any) -> None:
         """Mark all the todos as done.

--- a/gitlab/v4/objects/topics.py
+++ b/gitlab/v4/objects/topics.py
@@ -33,8 +33,8 @@ class TopicManager(CRUDMixin, RESTManager):
         return cast(Topic, super().get(id=id, lazy=lazy, **kwargs))
 
     @cli.register_custom_action(
-        "TopicManager",
-        mandatory=("source_topic_id", "target_topic_id"),
+        cls_names="TopicManager",
+        required=("source_topic_id", "target_topic_id"),
     )
     @exc.on_http_error(exc.GitlabMRClosedError)
     def merge(

--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -190,7 +190,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
     starred_projects: "StarredProjectManager"
     status: "UserStatusManager"
 
-    @cli.register_custom_action("User")
+    @cli.register_custom_action(cls_names="User")
     @exc.on_http_error(exc.GitlabBlockError)
     def block(self, **kwargs: Any) -> Optional[bool]:
         """Block the user.
@@ -215,7 +215,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
             self._attrs["state"] = "blocked"
         return server_data
 
-    @cli.register_custom_action("User")
+    @cli.register_custom_action(cls_names="User")
     @exc.on_http_error(exc.GitlabFollowError)
     def follow(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Follow the user.
@@ -233,7 +233,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
         path = f"/users/{self.encoded_id}/follow"
         return self.manager.gitlab.http_post(path, **kwargs)
 
-    @cli.register_custom_action("User")
+    @cli.register_custom_action(cls_names="User")
     @exc.on_http_error(exc.GitlabUnfollowError)
     def unfollow(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Unfollow the user.
@@ -251,7 +251,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
         path = f"/users/{self.encoded_id}/unfollow"
         return self.manager.gitlab.http_post(path, **kwargs)
 
-    @cli.register_custom_action("User")
+    @cli.register_custom_action(cls_names="User")
     @exc.on_http_error(exc.GitlabUnblockError)
     def unblock(self, **kwargs: Any) -> Optional[bool]:
         """Unblock the user.
@@ -276,7 +276,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
             self._attrs["state"] = "active"
         return server_data
 
-    @cli.register_custom_action("User")
+    @cli.register_custom_action(cls_names="User")
     @exc.on_http_error(exc.GitlabDeactivateError)
     def deactivate(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Deactivate the user.
@@ -297,7 +297,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
             self._attrs["state"] = "deactivated"
         return server_data
 
-    @cli.register_custom_action("User")
+    @cli.register_custom_action(cls_names="User")
     @exc.on_http_error(exc.GitlabActivateError)
     def activate(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Activate the user.
@@ -318,7 +318,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
             self._attrs["state"] = "active"
         return server_data
 
-    @cli.register_custom_action("User")
+    @cli.register_custom_action(cls_names="User")
     @exc.on_http_error(exc.GitlabUserApproveError)
     def approve(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Approve a user creation request.
@@ -336,7 +336,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
         path = f"/users/{self.encoded_id}/approve"
         return self.manager.gitlab.http_post(path, **kwargs)
 
-    @cli.register_custom_action("User")
+    @cli.register_custom_action(cls_names="User")
     @exc.on_http_error(exc.GitlabUserRejectError)
     def reject(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Reject a user creation request.
@@ -354,7 +354,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
         path = f"/users/{self.encoded_id}/reject"
         return self.manager.gitlab.http_post(path, **kwargs)
 
-    @cli.register_custom_action("User")
+    @cli.register_custom_action(cls_names="User")
     @exc.on_http_error(exc.GitlabBanError)
     def ban(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Ban the user.
@@ -375,7 +375,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
             self._attrs["state"] = "banned"
         return server_data
 
-    @cli.register_custom_action("User")
+    @cli.register_custom_action(cls_names="User")
     @exc.on_http_error(exc.GitlabUnbanError)
     def unban(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Unban the user.


### PR DESCRIPTION
No longer require `--id` when doing:
  gitlab project-key enable

Now only the --project-id and --key-id are required.
