### PR TITLE
chore(cli): on the CLI help show the API endpoint of resources

### DIFF
--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -134,7 +134,6 @@ def _get_base_parser(add_help: bool = True) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         add_help=add_help,
         description="GitLab API Command Line Interface",
-        formatter_class=VerticalHelpFormatter,
         allow_abbrev=False,
     )
     parser.add_argument("--version", help="Display the version.", action="store_true")

--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -382,8 +382,12 @@ def extend_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
 
     for cls in sorted(classes, key=operator.attrgetter("__name__")):
         arg_name = cli.cls_to_gitlab_resource(cls)
+        mgr_cls_name = f"{cls.__name__}Manager"
+        mgr_cls = getattr(gitlab.v4.objects, mgr_cls_name)
         object_group = subparsers.add_parser(
-            arg_name, formatter_class=cli.VerticalHelpFormatter
+            arg_name,
+            formatter_class=cli.VerticalHelpFormatter,
+            help=f"API endpoint: {mgr_cls._path}",
         )
 
         object_subparsers = object_group.add_subparsers(

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -34,12 +34,6 @@ def test_config_error_with_help_prints_help(script_runner):
     assert ret.returncode == 0
 
 
-def test_global_help_prints_resources_vertically(script_runner):
-    ret = script_runner.run(["gitlab", "--help"])
-    assert """resource:\n  application\n  application-appearance\n""" in ret.stdout
-    assert ret.returncode == 0
-
-
 def test_resource_help_prints_actions_vertically(script_runner):
     ret = script_runner.run(["gitlab", "project", "--help"])
     assert """action:\n  list\n  get""" in ret.stdout


### PR DESCRIPTION
This makes it easier for people to map CLI command names to the API.

Looks like this:
```
    $ gitlab --help
    <snip>
                            The GitLab resource to manipulate.
        application         API endpoint: /applications
        application-appearance
                            API endpoint: /application/appearance
        application-settings
                            API endpoint: /application/settings
        application-statistics
                            API endpoint: /application/statistics
    <snip>
```
