### PR TITLE
fix: handle large number of approval rules

### DIFF
--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -122,7 +122,7 @@ class ProjectMergeRequestApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTMan
             self._parent.approval_rules
         )
         # update any existing approval rule matching the name
-        existing_approval_rules = approval_rules.list()
+        existing_approval_rules = approval_rules.list(iterator=True)
         for ar in existing_approval_rules:
             if ar.name == approval_rule_name:
                 ar.user_ids = data["user_ids"]


### PR DESCRIPTION
Use `iterator=True` when going through the list of current approval rules. This allows it to handle more than the default of 20 approval rules.

Closes: #2825