### PR TITLE
fix(projects): fix 'import_project' file argument type for typings

### DIFF
--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -3,6 +3,7 @@ GitLab API:
 https://docs.gitlab.com/ee/api/projects.html
 """
 
+import io
 from typing import (
     Any,
     Callable,
@@ -786,7 +787,7 @@ class ProjectManager(CRUDMixin, RESTManager):
     @exc.on_http_error(exc.GitlabImportError)
     def import_project(
         self,
-        file: str,
+        file: io.BufferedReader,
         path: str,
         name: Optional[str] = None,
         namespace: Optional[str] = None,


### PR DESCRIPTION
## Changes

Official documentations for the 'import_project' API use a file object.

```python
with open('/tmp/export.tgz', 'rb') as f:
    output = gl.projects.import_project(
        f, path='my_new_project', name='My New Project'
    )
```

However the `import_project` file argument is declared as `str`, breaking Python typings checks.

```bash
src/features/gitlab.py:344: error: Argument 1 to "import_project" of                        
"ProjectManager" has incompatible type "BufferedReader"; expected "str"                                                                                                                 
[arg-type]
                    file,
                    ^~~~
Found 1 error in 1 file (checked 22 source files)
```

### Documentation and testing

- Detected over `gitlab-projects-migrate` : https://gitlab.com/AdrianDC/gitlab-projects-migrate/-/jobs/6873996382