### PR TITLE
chore: reduce usage of 'from mod_foo import class_foo'

### DIFF
--- a/gitlab/_backends/requests_backend.py
+++ b/gitlab/_backends/requests_backend.py
@@ -4,9 +4,6 @@ import dataclasses
 from typing import Any, BinaryIO, Dict, Optional, TYPE_CHECKING, Union
 
 import requests
-from requests import PreparedRequest
-from requests.auth import AuthBase
-from requests.structures import CaseInsensitiveDict
 from requests_toolbelt.multipart.encoder import MultipartEncoder  # type: ignore
 
 from . import protocol
@@ -17,24 +14,24 @@ class TokenAuth:
         self.token = token
 
 
-class OAuthTokenAuth(TokenAuth, AuthBase):
-    def __call__(self, r: PreparedRequest) -> PreparedRequest:
+class OAuthTokenAuth(TokenAuth, requests.auth.AuthBase):
+    def __call__(self, r: requests.PreparedRequest) -> requests.PreparedRequest:
         r.headers["Authorization"] = f"Bearer {self.token}"
         r.headers.pop("PRIVATE-TOKEN", None)
         r.headers.pop("JOB-TOKEN", None)
         return r
 
 
-class PrivateTokenAuth(TokenAuth, AuthBase):
-    def __call__(self, r: PreparedRequest) -> PreparedRequest:
+class PrivateTokenAuth(TokenAuth, requests.auth.AuthBase):
+    def __call__(self, r: requests.PreparedRequest) -> requests.PreparedRequest:
         r.headers["PRIVATE-TOKEN"] = self.token
         r.headers.pop("JOB-TOKEN", None)
         r.headers.pop("Authorization", None)
         return r
 
 
-class JobTokenAuth(TokenAuth, AuthBase):
-    def __call__(self, r: PreparedRequest) -> PreparedRequest:
+class JobTokenAuth(TokenAuth, requests.auth.AuthBase):
+    def __call__(self, r: requests.PreparedRequest) -> requests.PreparedRequest:
         r.headers["JOB-TOKEN"] = self.token
         r.headers.pop("PRIVATE-TOKEN", None)
         r.headers.pop("Authorization", None)
@@ -68,7 +65,7 @@ class RequestsResponse(protocol.BackendResponse):
         return self._response.status_code
 
     @property
-    def headers(self) -> CaseInsensitiveDict[str]:
+    def headers(self) -> requests.structures.CaseInsensitiveDict[str]:
         return self._response.headers
 
     @property

--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -19,7 +19,7 @@ from typing import (
     Union,
 )
 
-from requests.structures import CaseInsensitiveDict
+import requests
 
 import gitlab.config
 from gitlab.base import RESTObject
@@ -107,7 +107,7 @@ def die(msg: str, e: Optional[Exception] = None) -> None:
 def gitlab_resource_to_cls(
     gitlab_resource: str, namespace: ModuleType
 ) -> Type[RESTObject]:
-    classes = CaseInsensitiveDict(namespace.__dict__)
+    classes = requests.structures.CaseInsensitiveDict(namespace.__dict__)
     lowercase_class = gitlab_resource.replace("-", "")
     class_type = classes[lowercase_class]
     if TYPE_CHECKING:

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -3,6 +3,7 @@
 import os
 import re
 import time
+import urllib
 from typing import (
     Any,
     BinaryIO,
@@ -15,7 +16,6 @@ from typing import (
     TYPE_CHECKING,
     Union,
 )
-from urllib import parse
 
 import requests
 
@@ -517,10 +517,10 @@ class Gitlab:
             )
 
     def enable_debug(self, mask_credentials: bool = True) -> None:
+        import http.client
         import logging
-        from http import client
 
-        client.HTTPConnection.debuglevel = 1
+        http.client.HTTPConnection.debuglevel = 1
         logging.basicConfig()
         logger = logging.getLogger()
         logger.setLevel(logging.DEBUG)
@@ -538,7 +538,7 @@ class Gitlab:
         def print_as_log(*args: Any) -> None:
             httpclient_log.log(logging.DEBUG, " ".join(args))
 
-        setattr(client, "print", print_as_log)
+        setattr(http.client, "print", print_as_log)
 
         if not mask_credentials:
             return
@@ -684,11 +684,11 @@ class Gitlab:
         raw_url = self._build_url(path)
 
         # parse user-provided URL params to ensure we don't add our own duplicates
-        parsed = parse.urlparse(raw_url)
-        params = parse.parse_qs(parsed.query)
+        parsed = urllib.parse.urlparse(raw_url)
+        params = urllib.parse.parse_qs(parsed.query)
         utils.copy_dict(src=query_data, dest=params)
 
-        url = parse.urlunparse(parsed._replace(query=""))
+        url = urllib.parse.urlunparse(parsed._replace(query=""))
 
         # Deal with kwargs: by default a user uses kwargs to send data to the
         # gitlab server, but this generates problems (python keyword conflicts

--- a/gitlab/config.py
+++ b/gitlab/config.py
@@ -1,16 +1,15 @@
 import configparser
 import os
+import pathlib
 import shlex
 import subprocess
-from os.path import expanduser, expandvars
-from pathlib import Path
 from typing import List, Optional, Union
 
 from gitlab.const import USER_AGENT
 
 _DEFAULT_FILES: List[str] = [
     "/etc/python-gitlab.cfg",
-    str(Path.home() / ".python-gitlab.cfg"),
+    str(pathlib.Path.home() / ".python-gitlab.cfg"),
 ]
 
 HELPER_PREFIX = "helper:"
@@ -20,8 +19,8 @@ HELPER_ATTRIBUTES = ["job_token", "http_password", "private_token", "oauth_token
 _CONFIG_PARSER_ERRORS = (configparser.NoOptionError, configparser.NoSectionError)
 
 
-def _resolve_file(filepath: Union[Path, str]) -> str:
-    resolved = Path(filepath).resolve(strict=True)
+def _resolve_file(filepath: Union[pathlib.Path, str]) -> str:
+    resolved = pathlib.Path(filepath).resolve(strict=True)
     return str(resolved)
 
 
@@ -269,7 +268,10 @@ class GitlabConfigParser:
                 continue
 
             helper = value[len(HELPER_PREFIX) :].strip()
-            commmand = [expanduser(expandvars(token)) for token in shlex.split(helper)]
+            commmand = [
+                os.path.expanduser(os.path.expandvars(token))
+                for token in shlex.split(helper)
+            ]
 
             try:
                 value = (

--- a/gitlab/const.py
+++ b/gitlab/const.py
@@ -1,14 +1,14 @@
-from enum import Enum, IntEnum
+import enum
 
 from gitlab._version import __title__, __version__
 
 
-class GitlabEnum(str, Enum):
+class GitlabEnum(str, enum.Enum):
     """An enum mixed in with str to make it JSON-serializable."""
 
 
 # https://gitlab.com/gitlab-org/gitlab/-/blob/e97357824bedf007e75f8782259fe07435b64fbb/lib/gitlab/access.rb#L12-18
-class AccessLevel(IntEnum):
+class AccessLevel(enum.IntEnum):
     NO_ACCESS: int = 0
     MINIMAL_ACCESS: int = 5
     GUEST: int = 10

--- a/gitlab/v4/objects/packages.py
+++ b/gitlab/v4/objects/packages.py
@@ -4,7 +4,7 @@ https://docs.gitlab.com/ee/api/packages.html
 https://docs.gitlab.com/ee/user/packages/generic_packages/
 """
 
-from pathlib import Path
+import pathlib
 from typing import (
     Any,
     BinaryIO,
@@ -57,7 +57,7 @@ class GenericPackageManager(RESTManager):
         package_name: str,
         package_version: str,
         file_name: str,
-        path: Optional[Union[str, Path]] = None,
+        path: Optional[Union[str, pathlib.Path]] = None,
         select: Optional[str] = None,
         data: Optional[Union[bytes, BinaryIO]] = None,
         **kwargs: Any,


### PR DESCRIPTION
Reduce usage of doing:
  from SOME_MODULE import SOME_CLASS_OR_FUNCTION

Instead use:
  import SOME_MODULE

And then use the full module name. This improves readability and makes obvious to the reader where the class or function has come from.