### PR TITLE
fix: don't raise `RedirectError` for redirected `HEAD` requests

### DIFF
--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -625,8 +625,8 @@ class Gitlab:
         for item in result.history:
             if item.status_code not in (301, 302):
                 continue
-            # GET methods can be redirected without issue
-            if item.request.method == "GET":
+            # GET and HEAD methods can be redirected without issue
+            if item.request.method in ("GET", "HEAD"):
                 continue
             target = item.headers.get("location")
             raise gitlab.exceptions.RedirectError(


### PR DESCRIPTION
## Changes

Aims to fix the issue described in:
https://github.com/python-gitlab/python-gitlab/issues/2876
