### PR TITLE
chore: remove typing-extensions from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests==2.32.0
 requests-toolbelt==1.0.0
-typing-extensions==4.11.0 ; python_version < "3.8"


### PR DESCRIPTION
We no longer support Python versions before 3.8. So it isn't needed anymore.

