### PR TITLE
chore: add ability to set help for custom_actions. Also add help to the `project-key` action

### DIFF
--- a/gitlab/v4/cli.py
+++ b/gitlab/v4/cli.py
@@ -300,11 +300,14 @@ def _populate_sub_parser_by_class(
     if cls.__name__ in cli.custom_actions:
         name = cls.__name__
         for action_name in cli.custom_actions[name]:
+            custom_action = cli.custom_actions[name][action_name]
             # NOTE(jlvillal): If we put a function for the `default` value of
             # the `get` it will always get called, which will break things.
             action_parser = action_parsers.get(action_name)
             if action_parser is None:
-                sub_parser_action = sub_parser.add_parser(action_name)
+                sub_parser_action = sub_parser.add_parser(
+                    action_name, help=custom_action.help
+                )
             else:
                 sub_parser_action = action_parser
             # Get the attributes for URL/path construction
@@ -315,7 +318,6 @@ def _populate_sub_parser_by_class(
                     )
                 sub_parser_action.add_argument("--sudo", required=False)
 
-            custom_action = cli.custom_actions[name][action_name]
             # We need to get the object somehow
             if not issubclass(cls, gitlab.mixins.GetWithoutIdMixin):
                 if cls._id_attr is not None and custom_action.requires_id:
@@ -386,7 +388,6 @@ def extend_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         mgr_cls = getattr(gitlab.v4.objects, mgr_cls_name)
         object_group = subparsers.add_parser(
             arg_name,
-            formatter_class=cli.VerticalHelpFormatter,
             help=f"API endpoint: {mgr_cls._path}",
         )
 

--- a/gitlab/v4/objects/deploy_keys.py
+++ b/gitlab/v4/objects/deploy_keys.py
@@ -37,7 +37,10 @@ class ProjectKeyManager(CRUDMixin, RESTManager):
     _update_attrs = RequiredOptional(optional=("title", "can_push"))
 
     @cli.register_custom_action(
-        cls_names="ProjectKeyManager", required=("key_id",), requires_id=False
+        cls_names="ProjectKeyManager",
+        required=("key_id",),
+        requires_id=False,
+        help="Enable a deploy key for the project",
     )
     @exc.on_http_error(exc.GitlabProjectDeployKeyError)
     def enable(

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -36,13 +36,15 @@ def test_config_error_with_help_prints_help(script_runner):
 
 def test_resource_help_prints_actions_vertically(script_runner):
     ret = script_runner.run(["gitlab", "project", "--help"])
-    assert """action:\n  list\n  get""" in ret.stdout
+    assert "    list                List the GitLab resources\n" in ret.stdout
+    assert "    get                 Get a GitLab resource\n" in ret.stdout
     assert ret.returncode == 0
 
 
 def test_resource_help_prints_actions_vertically_only_one_action(script_runner):
     ret = script_runner.run(["gitlab", "event", "--help"])
-    assert """action:\n  list\n""" in ret.stdout
+    assert "  {list}      Action to execute on the GitLab resource.\n"
+    assert "    list      List the GitLab resources\n" in ret.stdout
     assert ret.returncode == 0
 
 


### PR DESCRIPTION
Now when registering a custom_action can add help text if desired.

Also delete the VerticalHelpFormatter as no longer needed. When the
help value is set to `None` or some other value, the actions will get
printed vertically. Before when the help value was not set the actions
would all get put onto one line.


Add some help text for `gitlab project-key enable`. This both adds
help text and shows how to use the new `help` feature.

Example:
```
$ gitlab project-key --help
usage: gitlab project-key [-h] {list,get,create,update,delete,enable} ...

options:
  -h, --help            show this help message and exit

action:
  {list,get,create,update,delete,enable}
                        Action to execute on the GitLab resource.
    list                List the GitLab resources
    get                 Get a GitLab resource
    create              Create a GitLab resource
    update              Update a GitLab resource
    delete              Delete a GitLab resource
    enable              Enable a deploy key for the project
```