### PR TITLE
fix(cli): generate UserWarning if `list` does not return all entries

### DIFF
--- a/gitlab/cli.py
+++ b/gitlab/cli.py
@@ -11,6 +11,7 @@ from typing import (
     Callable,
     cast,
     Dict,
+    NoReturn,
     Optional,
     Tuple,
     Type,
@@ -97,7 +98,7 @@ def register_custom_action(
     return wrap
 
 
-def die(msg: str, e: Optional[Exception] = None) -> None:
+def die(msg: str, e: Optional[Exception] = None) -> NoReturn:
     if e:
         msg = f"{msg} ({e})"
     sys.stderr.write(f"{msg}\n")

--- a/gitlab/utils.py
+++ b/gitlab/utils.py
@@ -1,3 +1,4 @@
+import dataclasses
 import email.message
 import logging
 import pathlib
@@ -205,3 +206,9 @@ def warn(
         stacklevel=stacklevel,
         source=source,
     )
+
+
+@dataclasses.dataclass
+class WarnMessageData:
+    message: str
+    show_caller: bool

--- a/gitlab/utils.py
+++ b/gitlab/utils.py
@@ -177,6 +177,7 @@ def warn(
     *,
     category: Optional[Type[Warning]] = None,
     source: Optional[Any] = None,
+    show_caller: bool = True,
 ) -> None:
     """This `warnings.warn` wrapper function attempts to show the location causing the
     warning in the user code that called the library.
@@ -196,8 +197,10 @@ def warn(
         frame_dir = str(pathlib.Path(frame.filename).parent.resolve())
         if not frame_dir.startswith(str(pg_dir)):
             break
+    if show_caller:
+        message += warning_from
     warnings.warn(
-        message=message + warning_from,
+        message=message,
         category=category,
         stacklevel=stacklevel,
         source=source,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -123,6 +123,27 @@ class TestWarningsWrapper:
         assert __file__ in str(warning.message)
         assert warn_source == warning.source
 
+    def test_warn_no_show_caller(self):
+        warn_message = "short and stout"
+        warn_source = "teapot"
+
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            utils.warn(
+                message=warn_message,
+                category=UserWarning,
+                source=warn_source,
+                show_caller=False,
+            )
+        assert len(caught_warnings) == 1
+        warning = caught_warnings[0]
+        # File name is this file as it is the first file outside of the `gitlab/` path.
+        assert __file__ == warning.filename
+        assert warning.category == UserWarning
+        assert isinstance(warning.message, UserWarning)
+        assert warn_message in str(warning.message)
+        assert __file__ not in str(warning.message)
+        assert warn_source == warning.source
+
 
 @pytest.mark.parametrize(
     "source,expected",


### PR DESCRIPTION
Previously in the CLI, calls to `list()` would have `get_all=False` by
default. Therefore hiding the fact that not all items are being
returned if there were more than 20 items.

Added `--no-get-all` option to `list` actions. Along with the already
existing `--get-all`.

Closes: #2900
