### PR TITLE
Feat(api): Add support for latest pipeline

### DIFF
--- a/docs/gl_objects/pipelines_and_jobs.rst
+++ b/docs/gl_objects/pipelines_and_jobs.rst
@@ -49,6 +49,11 @@ Delete a pipeline::
 
     pipeline.delete()
 
+Get latest pipeline::
+
+    projet.pipelines.latest(ref="main")
+
+
 Triggers
 ========
 

--- a/gitlab/v4/objects/pipelines.py
+++ b/gitlab/v4/objects/pipelines.py
@@ -139,6 +139,27 @@ class ProjectPipelineManager(RetrieveMixin, CreateMixin, DeleteMixin, RESTManage
             ProjectPipeline, CreateMixin.create(self, data, path=path, **kwargs)
         )
 
+    def latest(self, ref: Optional[str] = None, lazy: bool = False) -> ProjectPipeline:
+        """Get the latest pipeline for the most recent commit
+                            on a specific ref in a project
+
+        Args:
+            ref: The branch or tag to check for the latest pipeline.
+                            Defaults to the default branch when not specified.
+        Returns:
+            A Pipeline instance
+        """
+        data = {}
+        if ref:
+            data = {"ref": ref}
+        if TYPE_CHECKING:
+            assert self._obj_cls is not None
+            assert self.path is not None
+        server_data = self.gitlab.http_get(self.path + "/latest", query_data=data)
+        if TYPE_CHECKING:
+            assert not isinstance(server_data, requests.Response)
+        return self._obj_cls(self, server_data, lazy=lazy)
+
 
 class ProjectPipelineJob(RESTObject):
     pass

--- a/tests/unit/objects/test_pipelines.py
+++ b/tests/unit/objects/test_pipelines.py
@@ -39,6 +39,62 @@ pipeline_content = {
     "web_url": "https://example.com/foo/bar/pipelines/46",
 }
 
+pipeline_latest = {
+    "id": 47,
+    "project_id": 1,
+    "status": "pending",
+    "ref": "main",
+    "sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+    "before_sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+    "tag": False,
+    "yaml_errors": None,
+    "user": {
+        "name": "Administrator",
+        "username": "root",
+        "id": 1,
+        "state": "active",
+        "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+        "web_url": "http://localhost:3000/root",
+    },
+    "created_at": "2016-08-11T11:28:34.085Z",
+    "updated_at": "2016-08-11T11:32:35.169Z",
+    "started_at": None,
+    "finished_at": "2016-08-11T11:32:35.145Z",
+    "committed_at": None,
+    "duration": None,
+    "queued_duration": 0.010,
+    "coverage": None,
+    "web_url": "https://example.com/foo/bar/pipelines/46",
+}
+
+pipeline_latest_other_ref = {
+    "id": 48,
+    "project_id": 1,
+    "status": "pending",
+    "ref": "feature-ref",
+    "sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+    "before_sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+    "tag": False,
+    "yaml_errors": None,
+    "user": {
+        "name": "Administrator",
+        "username": "root",
+        "id": 1,
+        "state": "active",
+        "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+        "web_url": "http://localhost:3000/root",
+    },
+    "created_at": "2016-08-11T11:28:34.085Z",
+    "updated_at": "2016-08-11T11:32:35.169Z",
+    "started_at": None,
+    "finished_at": "2016-08-11T11:32:35.145Z",
+    "committed_at": None,
+    "duration": None,
+    "queued_duration": 0.010,
+    "coverage": None,
+    "web_url": "https://example.com/foo/bar/pipelines/46",
+}
+
 
 test_report_content = {
     "total_time": 5,
@@ -162,10 +218,37 @@ def resp_get_pipeline_test_report_summary():
         yield rsps
 
 
+@pytest.fixture
+def resp_get_latest():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.GET,
+            url="http://localhost/api/v4/projects/1/pipelines/latest",
+            json=pipeline_latest,
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
+@pytest.fixture
+def resp_get_latest_other_ref():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.GET,
+            url="http://localhost/api/v4/projects/1/pipelines/latest",
+            json=pipeline_latest_other_ref,
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
 def test_get_project_pipeline(project, resp_get_pipeline):
     pipeline = project.pipelines.get(1)
     assert isinstance(pipeline, ProjectPipeline)
     assert pipeline.ref == "main"
+    assert pipeline.id == 46
 
 
 def test_cancel_project_pipeline(project, resp_cancel_pipeline):
@@ -198,3 +281,17 @@ def test_get_project_pipeline_test_report_summary(
     assert isinstance(test_report_summary, ProjectPipelineTestReportSummary)
     assert test_report_summary.total["count"] == 3363
     assert test_report_summary.test_suites[0]["name"] == "test"
+
+
+def test_latest_pipeline(project, resp_get_latest):
+    pipeline = project.pipelines.latest()
+    assert isinstance(pipeline, ProjectPipeline)
+    assert pipeline.ref == "main"
+    assert pipeline.id == 47
+
+
+def test_latest_pipeline_other_ref(project, resp_get_latest_other_ref):
+    pipeline = project.pipelines.latest(ref="feature-ref")
+    assert isinstance(pipeline, ProjectPipeline)
+    assert pipeline.ref == "feature-ref"
+    assert pipeline.id == 48


### PR DESCRIPTION

## Changes
Add support for https://docs.gitlab.com/ee/api/pipelines.html#get-the-latest-pipeline

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
