### PR TITLE
feat(api): add support for commit sequence

### DIFF
--- a/gitlab/v4/objects/commits.py
+++ b/gitlab/v4/objects/commits.py
@@ -129,6 +129,24 @@ class ProjectCommit(RESTObject):
 
     @cli.register_custom_action(cls_names="ProjectCommit")
     @exc.on_http_error(exc.GitlabGetError)
+    def sequence(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
+        """Get the sequence number of the commit.
+
+        Args:
+            **kwargs: Extra options to send to the server (e.g. sudo)
+
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabGetError: If the sequence number could not be retrieved
+
+        Returns:
+            The commit's sequence number
+        """
+        path = f"{self.manager.path}/{self.encoded_id}/sequence"
+        return self.manager.gitlab.http_get(path, **kwargs)
+
+    @cli.register_custom_action(cls_names="ProjectCommit")
+    @exc.on_http_error(exc.GitlabGetError)
     def signature(self, **kwargs: Any) -> Union[Dict[str, Any], requests.Response]:
         """Get the signature of the commit.
 

--- a/tests/unit/objects/test_commits.py
+++ b/tests/unit/objects/test_commits.py
@@ -78,6 +78,23 @@ def resp_get_commit_gpg_signature():
         yield rsps
 
 
+@pytest.fixture
+def resp_get_commit_sequence():
+    content = {
+        "count": 1,
+    }
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.GET,
+            url="http://localhost/api/v4/projects/1/repository/commits/6b2257ea/sequence",
+            json=content,
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
 def test_get_commit(project, resp_commit):
     commit = project.commits.get("6b2257ea")
     assert commit.short_id == "6b2257ea"
@@ -113,3 +130,9 @@ def test_get_commit_gpg_signature(project, resp_get_commit_gpg_signature):
     signature = commit.signature()
     assert signature["gpg_key_primary_keyid"] == "8254AAB3FBD54AC9"
     assert signature["verification_status"] == "verified"
+
+
+def test_get_commit_sequence(project, resp_get_commit_sequence):
+    commit = project.commits.get("6b2257ea", lazy=True)
+    sequence = commit.sequence()
+    assert sequence["count"] == 1


### PR DESCRIPTION
<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

This implements ["Get the sequence of a commit"](https://docs.gitlab.com/ee/api/commits.html#get-the-sequence-of-a-commit), [introduced](https://gitlab.com/gitlab-org/gitlab/-/issues/438151) in GitLab 16.9.

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
