### PR TITLE
fix(files): make `ref` parameter optional in get raw file API

### DIFF
--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -228,13 +228,14 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         self.gitlab.http_delete(path, query_data=data, **kwargs)
 
     @cli.register_custom_action(
-        cls_names="ProjectFileManager", required=("file_path", "ref")
+        cls_names="ProjectFileManager",
+        required=("file_path",),
     )
     @exc.on_http_error(exc.GitlabGetError)
     def raw(
         self,
         file_path: str,
-        ref: str,
+        ref: Optional[str] = None,
         streamed: bool = False,
         action: Optional[Callable[..., Any]] = None,
         chunk_size: int = 1024,
@@ -245,16 +246,16 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         """Return the content of a file for a commit.
 
         Args:
-            ref: ID of the commit
             file_path: Path of the file to return
+            ref: ID of the commit
             streamed: If True the data will be processed by chunks of
                 `chunk_size` and each chunk is passed to `action` for
                 treatment
-            iterator: If True directly return the underlying response
-                iterator
-            action: Callable responsible of dealing with chunk of
+            action: Callable responsible for dealing with each chunk of
                 data
             chunk_size: Size of each chunk
+            iterator: If True directly return the underlying response
+                iterator
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -266,7 +267,10 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         """
         file_path = utils.EncodedId(file_path)
         path = f"{self.path}/{file_path}/raw"
-        query_data = {"ref": ref}
+        if ref:
+            query_data = {"ref": ref}
+        else:
+            query_data = None
         result = self.gitlab.http_get(
             path, query_data=query_data, streamed=streamed, raw=True, **kwargs
         )

--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -267,7 +267,7 @@ class ProjectFileManager(GetMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTMa
         """
         file_path = utils.EncodedId(file_path)
         path = f"{self.path}/{file_path}/raw"
-        if ref:
+        if ref is not None:
             query_data = {"ref": ref}
         else:
             query_data = None

--- a/tests/functional/api/test_repository.py
+++ b/tests/functional/api/test_repository.py
@@ -46,6 +46,9 @@ def test_repository_files(project):
     blame = project.files.blame(file_path="README.rst", ref="main")
     assert blame
 
+    raw_file = project.files.raw(file_path="README.rst", ref="main")
+    assert os.fsdecode(raw_file) == "Initial content"
+
     raw_file = project.files.raw(file_path="README.rst")
     assert os.fsdecode(raw_file) == "Initial content"
 

--- a/tests/functional/api/test_repository.py
+++ b/tests/functional/api/test_repository.py
@@ -46,7 +46,7 @@ def test_repository_files(project):
     blame = project.files.blame(file_path="README.rst", ref="main")
     assert blame
 
-    raw_file = project.files.raw(file_path="README.rst", ref="main")
+    raw_file = project.files.raw(file_path="README.rst")
     assert os.fsdecode(raw_file) == "Initial content"
 
 


### PR DESCRIPTION
The `ref` parameter for the raw file API was made optional in GitLab v13.11.0.

## Changes

- Make the `ref` parameter for the corresponding method on `ProjectFileManager` optional to match the API.
- Minor changes to the docstring for this method.

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)
