### PR TITLE
fix: Have `participants()` method use `http_list()`

### DIFF
--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -911,7 +911,9 @@ class ParticipantsMixin(_RestObjectBase):
 
     @cli.register_custom_action(cls_names=("ProjectMergeRequest", "ProjectIssue"))
     @exc.on_http_error(exc.GitlabListError)
-    def participants(self, **kwargs: Any) -> Dict[str, Any]:
+    def participants(
+        self, **kwargs: Any
+    ) -> Union[gitlab.client.GitlabList, List[Dict[str, Any]]]:
         """List the participants.
 
         Args:
@@ -929,7 +931,7 @@ class ParticipantsMixin(_RestObjectBase):
         """
 
         path = f"{self.manager.path}/{self.encoded_id}/participants"
-        result = self.manager.gitlab.http_get(path, **kwargs)
+        result = self.manager.gitlab.http_list(path, **kwargs)
         if TYPE_CHECKING:
             assert not isinstance(result, requests.Response)
         return result

--- a/gitlab/v4/objects/issues.py
+++ b/gitlab/v4/objects/issues.py
@@ -1,6 +1,8 @@
-from typing import Any, cast, Dict, Optional, Tuple, TYPE_CHECKING, Union
+from typing import Any, cast, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
-from gitlab import cli
+import requests
+
+from gitlab import cli, client
 from gitlab import exceptions as exc
 from gitlab import types
 from gitlab.base import RESTManager, RESTObject
@@ -182,7 +184,9 @@ class ProjectIssue(
 
     @cli.register_custom_action(cls_names="ProjectIssue")
     @exc.on_http_error(exc.GitlabGetError)
-    def related_merge_requests(self, **kwargs: Any) -> Dict[str, Any]:
+    def related_merge_requests(
+        self, **kwargs: Any
+    ) -> Union[client.GitlabList, List[Dict[str, Any]]]:
         """List merge requests related to the issue.
 
         Args:
@@ -196,14 +200,16 @@ class ProjectIssue(
             The list of merge requests.
         """
         path = f"{self.manager.path}/{self.encoded_id}/related_merge_requests"
-        result = self.manager.gitlab.http_get(path, **kwargs)
+        result = self.manager.gitlab.http_list(path, **kwargs)
         if TYPE_CHECKING:
-            assert isinstance(result, dict)
+            assert not isinstance(result, requests.Response)
         return result
 
     @cli.register_custom_action(cls_names="ProjectIssue")
     @exc.on_http_error(exc.GitlabGetError)
-    def closed_by(self, **kwargs: Any) -> Dict[str, Any]:
+    def closed_by(
+        self, **kwargs: Any
+    ) -> Union[client.GitlabList, List[Dict[str, Any]]]:
         """List merge requests that will close the issue when merged.
 
         Args:
@@ -217,9 +223,9 @@ class ProjectIssue(
             The list of merge requests.
         """
         path = f"{self.manager.path}/{self.encoded_id}/closed_by"
-        result = self.manager.gitlab.http_get(path, **kwargs)
+        result = self.manager.gitlab.http_list(path, **kwargs)
         if TYPE_CHECKING:
-            assert isinstance(result, dict)
+            assert not isinstance(result, requests.Response)
         return result
 
 

--- a/tests/functional/api/test_issues.py
+++ b/tests/functional/api/test_issues.py
@@ -18,7 +18,9 @@ def test_create_issue(project):
     assert issue in project.issues.list(state="opened")
     assert issue2 in project.issues.list(state="closed")
 
-    assert issue.participants()
+    participants = issue.participants()
+    assert participants
+    assert isinstance(participants, list)
     assert type(issue.closed_by()) == list
     assert type(issue.related_merge_requests()) == list
 

--- a/tests/functional/api/test_merge_requests.py
+++ b/tests/functional/api/test_merge_requests.py
@@ -104,7 +104,9 @@ def test_merge_request_basic(project):
     # basic testing: only make sure that the methods exist
     mr.commits()
     mr.changes()
-    assert mr.participants()
+    participants = mr.participants()
+    assert participants
+    assert isinstance(participants, list)
 
 
 def test_merge_request_rebase(project):


### PR DESCRIPTION
Previously it was using `http_get()` but the `participants` API returns a list of participants. Also by using this then we will warn if only a subset of the participants are returned.

Closes: #2913

