### PR TITLE
chore(ci): use codecov token when available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,7 @@ jobs:
           files: ./coverage.xml
           flags: ${{ matrix.toxenv }}
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   coverage:
     runs-on: ubuntu-22.04
@@ -105,6 +106,7 @@ jobs:
           files: ./coverage.xml
           flags: unit
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   dist:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #2873

I added `CODECOV_TOKEN` to  https://github.com/python-gitlab/python-gitlab/settings/secrets/actions.

See https://github.com/codecov/codecov-action?tab=readme-ov-file#usage