### PR TITLE
feat(api): add support for package protection rules

### DIFF
--- a/docs/api-objects.rst
+++ b/docs/api-objects.rst
@@ -49,6 +49,7 @@ API examples
    gl_objects/project_access_tokens
    gl_objects/protected_branches
    gl_objects/protected_environments
+   gl_objects/protected_packages
    gl_objects/releases
    gl_objects/runners
    gl_objects/remote_mirrors

--- a/docs/gl_objects/protected_packages.rst
+++ b/docs/gl_objects/protected_packages.rst
@@ -1,0 +1,44 @@
+##################
+Protected packages
+##################
+
+You can list and manage package protection rules in a project.
+
+References
+----------
+
+* v4 API:
+
+  + :class:`gitlab.v4.objects.ProjectPackageProtectionRule`
+  + :class:`gitlab.v4.objects.ProjectPackageProtectionRuleManager`
+  + :attr:`gitlab.v4.objects.Project.package_protection_rules`
+
+* GitLab API: https://docs.gitlab.com/ee/api/project_packages_protection_rules.html
+
+Examples
+--------
+
+List the package protection rules for a project::
+
+    package_rules = project.package_protection_rules.list()
+
+Create a package protection rule::
+
+    package_rule = project.package_protection_rules.create(
+        {
+            'package_name_pattern': 'v*',
+            'package_type': 'npm',
+            'minimum_access_level_for_push': 'maintainer'
+        }
+    )
+
+Update a package protection rule::
+
+    package_rule.minimum_access_level_for_push = 'developer'
+    package_rule.save()
+
+Delete a package protection rule::
+
+    package_rule = project.package_protection_rules.delete(package_rule.id)
+    # or
+    package_rule.delete()

--- a/gitlab/v4/objects/__init__.py
+++ b/gitlab/v4/objects/__init__.py
@@ -46,6 +46,7 @@ from .milestones import *
 from .namespaces import *
 from .notes import *
 from .notification_settings import *
+from .package_protection_rules import *
 from .packages import *
 from .pages import *
 from .personal_access_tokens import *

--- a/gitlab/v4/objects/package_protection_rules.py
+++ b/gitlab/v4/objects/package_protection_rules.py
@@ -1,0 +1,36 @@
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import (
+    CreateMixin,
+    DeleteMixin,
+    ListMixin,
+    ObjectDeleteMixin,
+    SaveMixin,
+    UpdateMethod,
+    UpdateMixin,
+)
+from gitlab.types import RequiredOptional
+
+__all__ = [
+    "ProjectPackageProtectionRule",
+    "ProjectPackageProtectionRuleManager",
+]
+
+
+class ProjectPackageProtectionRule(ObjectDeleteMixin, SaveMixin, RESTObject):
+    _repr_attr = "name"
+
+
+class ProjectPackageProtectionRuleManager(
+    ListMixin, CreateMixin, DeleteMixin, UpdateMixin, RESTManager
+):
+    _path = "/projects/{project_id}/packages/protection/rules"
+    _obj_cls = ProjectPackageProtectionRule
+    _from_parent_attrs = {"project_id": "id"}
+    _create_attrs = RequiredOptional(
+        required=(
+            "package_name_pattern",
+            "package_type",
+            "minimum_access_level_for_push",
+        ),
+    )
+    _update_method = UpdateMethod.PATCH

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -75,6 +75,7 @@ from .merge_trains import ProjectMergeTrainManager  # noqa: F401
 from .milestones import ProjectMilestoneManager  # noqa: F401
 from .notes import ProjectNoteManager  # noqa: F401
 from .notification_settings import ProjectNotificationSettingsManager  # noqa: F401
+from .package_protection_rules import ProjectPackageProtectionRuleManager
 from .packages import GenericPackageManager, ProjectPackageManager  # noqa: F401
 from .pages import ProjectPagesDomainManager  # noqa: F401
 from .pipelines import (  # noqa: F401
@@ -209,6 +210,7 @@ class Project(
     notes: ProjectNoteManager
     notificationsettings: ProjectNotificationSettingsManager
     packages: ProjectPackageManager
+    package_protection_rules: ProjectPackageProtectionRuleManager
     pagesdomains: ProjectPagesDomainManager
     pipelines: ProjectPipelineManager
     pipelineschedules: ProjectPipelineScheduleManager

--- a/tests/unit/objects/test_package_protection_rules.py
+++ b/tests/unit/objects/test_package_protection_rules.py
@@ -1,0 +1,98 @@
+"""
+GitLab API: https://docs.gitlab.com/ee/api/project_packages_protection_rules.html
+"""
+
+import pytest
+import responses
+
+from gitlab.v4.objects import ProjectPackageProtectionRule
+
+protected_package_content = {
+    "id": 1,
+    "project_id": 7,
+    "package_name_pattern": "v*",
+    "package_type": "npm",
+    "minimum_access_level_for_push": "maintainer",
+}
+
+
+@pytest.fixture
+def resp_list_protected_packages():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.GET,
+            url="http://localhost/api/v4/projects/1/packages/protection/rules",
+            json=[protected_package_content],
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
+@pytest.fixture
+def resp_create_protected_package():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.POST,
+            url="http://localhost/api/v4/projects/1/packages/protection/rules",
+            json=protected_package_content,
+            content_type="application/json",
+            status=201,
+        )
+        yield rsps
+
+
+@pytest.fixture
+def resp_update_protected_package():
+    updated_content = protected_package_content.copy()
+    updated_content["package_name_pattern"] = "abc*"
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.PATCH,
+            url="http://localhost/api/v4/projects/1/packages/protection/rules/1",
+            json=updated_content,
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
+@pytest.fixture
+def resp_delete_protected_package():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.DELETE,
+            url="http://localhost/api/v4/projects/1/packages/protection/rules/1",
+            status=204,
+        )
+        yield rsps
+
+
+def test_list_project_protected_packages(project, resp_list_protected_packages):
+    protected_package = project.package_protection_rules.list()[0]
+    assert isinstance(protected_package, ProjectPackageProtectionRule)
+    assert protected_package.package_type == "npm"
+
+
+def test_create_project_protected_package(project, resp_create_protected_package):
+    protected_package = project.package_protection_rules.create(
+        {
+            "package_name_pattern": "v*",
+            "package_type": "npm",
+            "minimum_access_level_for_push": "maintainer",
+        }
+    )
+    assert isinstance(protected_package, ProjectPackageProtectionRule)
+    assert protected_package.package_type == "npm"
+
+
+def test_update_project_protected_package(project, resp_update_protected_package):
+    updated = project.package_protection_rules.update(
+        1, {"package_name_pattern": "abc*"}
+    )
+    assert updated["package_name_pattern"] == "abc*"
+
+
+def test_delete_project_protected_package(project, resp_delete_protected_package):
+    project.package_protection_rules.delete(1)


### PR DESCRIPTION
<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

https://docs.gitlab.com/ee/api/project_packages_protection_rules.html#list-package-protection-rules

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
