### PR TITLE
chore(ci): stale: allow issues/PRs that have stale label to be closed

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/stale@v9.0.0
         with:
-          any-of-labels: 'need info,Waiting for response'
+          any-of-labels: 'need info,Waiting for response,stale'
           stale-issue-message: >
             This issue was marked stale because it has been open 60 days with no
             activity. Please remove the stale label or comment on this issue. Otherwise,


### PR DESCRIPTION
If a `stale` label is manually applied, allow the issue or PR to be closed by the stale job.

Previously it would require the `stale` label and to also have one of 'need info' or 'Waiting for response' labels added.

