### PR TITLE
chore(ci): specify name of "stale" label

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - uses: actions/stale@v9.0.0
         with:
+          stale-issue-label: "stale"
+          stale-pr-label: "stale"
+
           any-of-labels: 'need info,Waiting for response,stale'
           stale-issue-message: >
             This issue was marked stale because it has been open 60 days with no


### PR DESCRIPTION
Saw the following error in the log:
  [#2618] Removing the label "Stale" from this issue...
  ##[error][#2618] Error when removing the label: "Label does not exist"

My theory is that the case doesn't match ("Stale" != "stale") and that is why it failed.  Our label is "stale" so update this to match. Thought of changing the label name on GitHub but then would also require a change here to the "any-of-labels". So it seemed simpler to just change it here.

It is confusing though that it detected the label "stale", but then couldn't delete it.

<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

<!-- Remove this comment and describe your changes here. -->

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
