### PR TITLE
feat(api): add support for container registry protection rules

### DIFF
--- a/docs/api-objects.rst
+++ b/docs/api-objects.rst
@@ -48,6 +48,7 @@ API examples
    gl_objects/projects
    gl_objects/project_access_tokens
    gl_objects/protected_branches
+   gl_objects/protected_container_repositories
    gl_objects/protected_environments
    gl_objects/protected_packages
    gl_objects/releases

--- a/docs/gl_objects/protected_container_repositories.rst
+++ b/docs/gl_objects/protected_container_repositories.rst
@@ -1,0 +1,44 @@
+################################
+Protected container repositories
+################################
+
+You can list and manage container registry protection rules in a project.
+
+References
+----------
+
+* v4 API:
+
+  + :class:`gitlab.v4.objects.ProjectRegistryProtectionRuleRule`
+  + :class:`gitlab.v4.objects.ProjectRegistryProtectionRuleRuleManager`
+  + :attr:`gitlab.v4.objects.Project.registry_protection_rules`
+
+* GitLab API: https://docs.gitlab.com/ee/api/project_container_registry_protection_rules.html
+
+Examples
+--------
+
+List the container registry protection rules for a project::
+
+    registry_rules = project.registry_protection_rules.list()
+
+Create a container registry protection rule::
+
+    registry_rule = project.registry_protection_rules.create(
+        {
+            'repository_path_pattern': 'test/image',
+            'minimum_access_level_for_push': 'maintainer',
+            'minimum_access_level_for_delete': 'maintainer',
+        }
+    )
+
+Update a container registry protection rule::
+
+    registry_rule.minimum_access_level_for_push = 'owner'
+    registry_rule.save()
+
+Delete a container registry protection rule::
+
+    registry_rule = project.registry_protection_rules.delete(registry_rule.id)
+    # or
+    registry_rule.delete()

--- a/gitlab/v4/objects/__init__.py
+++ b/gitlab/v4/objects/__init__.py
@@ -54,6 +54,7 @@ from .pipelines import *
 from .project_access_tokens import *
 from .projects import *
 from .push_rules import *
+from .registry_protection_rules import *
 from .releases import *
 from .repositories import *
 from .resource_groups import *

--- a/gitlab/v4/objects/package_protection_rules.py
+++ b/gitlab/v4/objects/package_protection_rules.py
@@ -17,7 +17,7 @@ __all__ = [
 
 
 class ProjectPackageProtectionRule(ObjectDeleteMixin, SaveMixin, RESTObject):
-    _repr_attr = "name"
+    _repr_attr = "package_name_pattern"
 
 
 class ProjectPackageProtectionRuleManager(
@@ -28,6 +28,13 @@ class ProjectPackageProtectionRuleManager(
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(
         required=(
+            "package_name_pattern",
+            "package_type",
+            "minimum_access_level_for_push",
+        ),
+    )
+    _update_attrs = RequiredOptional(
+        optional=(
             "package_name_pattern",
             "package_type",
             "minimum_access_level_for_push",

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -85,6 +85,9 @@ from .pipelines import (  # noqa: F401
 )
 from .project_access_tokens import ProjectAccessTokenManager  # noqa: F401
 from .push_rules import ProjectPushRulesManager  # noqa: F401
+from .registry_protection_rules import (  # noqa: F401
+    ProjectRegistryProtectionRuleManager,
+)
 from .releases import ProjectReleaseManager  # noqa: F401
 from .repositories import RepositoryMixin
 from .resource_groups import ProjectResourceGroupManager
@@ -218,6 +221,7 @@ class Project(
     protectedbranches: ProjectProtectedBranchManager
     protectedtags: ProjectProtectedTagManager
     pushrules: ProjectPushRulesManager
+    registry_protection_rules: ProjectRegistryProtectionRuleManager
     releases: ProjectReleaseManager
     resource_groups: ProjectResourceGroupManager
     remote_mirrors: "ProjectRemoteMirrorManager"

--- a/gitlab/v4/objects/registry_protection_rules.py
+++ b/gitlab/v4/objects/registry_protection_rules.py
@@ -1,0 +1,35 @@
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CreateMixin, ListMixin, SaveMixin, UpdateMethod, UpdateMixin
+from gitlab.types import RequiredOptional
+
+__all__ = [
+    "ProjectRegistryProtectionRule",
+    "ProjectRegistryProtectionRuleManager",
+]
+
+
+class ProjectRegistryProtectionRule(SaveMixin, RESTObject):
+    _repr_attr = "repository_path_pattern"
+
+
+class ProjectRegistryProtectionRuleManager(
+    ListMixin, CreateMixin, UpdateMixin, RESTManager
+):
+    _path = "/projects/{project_id}/registry/protection/rules"
+    _obj_cls = ProjectRegistryProtectionRule
+    _from_parent_attrs = {"project_id": "id"}
+    _create_attrs = RequiredOptional(
+        required=("repository_path_pattern",),
+        optional=(
+            "minimum_access_level_for_push",
+            "minimum_access_level_for_delete",
+        ),
+    )
+    _update_attrs = RequiredOptional(
+        optional=(
+            "repository_path_pattern",
+            "minimum_access_level_for_push",
+            "minimum_access_level_for_delete",
+        ),
+    )
+    _update_method = UpdateMethod.PATCH

--- a/tests/functional/api/test_registry.py
+++ b/tests/functional/api/test_registry.py
@@ -9,13 +9,11 @@ def protected_registry_feature(gl: Gitlab):
     gl.features.set(name="container_registry_protected_containers", value=True)
 
 
-def test_list_project_protected_registries(project: Project):
+@pytest.mark.skip(reason="Not released yet")
+def test_project_protected_registry(project: Project):
     rules = project.registry_protection_rules.list()
     assert isinstance(rules, list)
 
-
-@pytest.mark.skip(reason="Not released yet")
-def test_create_project_protected_registry(project: Project):
     protected_registry = project.registry_protection_rules.create(
         {
             "repository_path_pattern": "test/image",

--- a/tests/functional/api/test_registry.py
+++ b/tests/functional/api/test_registry.py
@@ -1,0 +1,30 @@
+import pytest
+
+from gitlab import Gitlab
+from gitlab.v4.objects import Project, ProjectRegistryProtectionRule
+
+
+@pytest.fixture(scope="module", autouse=True)
+def protected_registry_feature(gl: Gitlab):
+    gl.features.set(name="container_registry_protected_containers", value=True)
+
+
+def test_list_project_protected_registries(project: Project):
+    rules = project.registry_protection_rules.list()
+    assert isinstance(rules, list)
+
+
+@pytest.mark.skip(reason="Not released yet")
+def test_create_project_protected_registry(project: Project):
+    protected_registry = project.registry_protection_rules.create(
+        {
+            "repository_path_pattern": "test/image",
+            "minimum_access_level_for_push": "maintainer",
+        }
+    )
+    assert isinstance(protected_registry, ProjectRegistryProtectionRule)
+    assert protected_registry.repository_path_pattern == "test/image"
+
+    protected_registry.minimum_access_level_for_push = "owner"
+    protected_registry.save()
+    assert protected_registry.minimum_access_level_for_push == "owner"

--- a/tests/unit/objects/test_registry_protection_rules.py
+++ b/tests/unit/objects/test_registry_protection_rules.py
@@ -1,0 +1,82 @@
+"""
+GitLab API: https://docs.gitlab.com/ee/api/project_container_registry_protection_rules.html
+"""
+
+import pytest
+import responses
+
+from gitlab.v4.objects import ProjectRegistryProtectionRule
+
+protected_registry_content = {
+    "id": 1,
+    "project_id": 7,
+    "repository_path_pattern": "test/image",
+    "minimum_access_level_for_push": "maintainer",
+    "minimum_access_level_for_delete": "maintainer",
+}
+
+
+@pytest.fixture
+def resp_list_protected_registries():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.GET,
+            url="http://localhost/api/v4/projects/1/registry/protection/rules",
+            json=[protected_registry_content],
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
+@pytest.fixture
+def resp_create_protected_registry():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.POST,
+            url="http://localhost/api/v4/projects/1/registry/protection/rules",
+            json=protected_registry_content,
+            content_type="application/json",
+            status=201,
+        )
+        yield rsps
+
+
+@pytest.fixture
+def resp_update_protected_registry():
+    updated_content = protected_registry_content.copy()
+    updated_content["repository_path_pattern"] = "abc*"
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.PATCH,
+            url="http://localhost/api/v4/projects/1/registry/protection/rules/1",
+            json=updated_content,
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
+def test_list_project_protected_registries(project, resp_list_protected_registries):
+    protected_registry = project.registry_protection_rules.list()[0]
+    assert isinstance(protected_registry, ProjectRegistryProtectionRule)
+    assert protected_registry.repository_path_pattern == "test/image"
+
+
+def test_create_project_protected_registry(project, resp_create_protected_registry):
+    protected_registry = project.registry_protection_rules.create(
+        {
+            "repository_path_pattern": "test/image",
+            "minimum_access_level_for_push": "maintainer",
+        }
+    )
+    assert isinstance(protected_registry, ProjectRegistryProtectionRule)
+    assert protected_registry.repository_path_pattern == "test/image"
+
+
+def test_update_project_protected_registry(project, resp_update_protected_registry):
+    updated = project.registry_protection_rules.update(
+        1, {"repository_path_pattern": "abc*"}
+    )
+    assert updated["repository_path_pattern"] == "abc*"


### PR DESCRIPTION
<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

https://docs.gitlab.com/ee/user/packages/container_registry/container_protection_rules.html

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
