### PR TITLE
chore(ci): make pre-commit check happy

### DIFF
--- a/docs/api-usage.rst
+++ b/docs/api-usage.rst
@@ -428,7 +428,7 @@ then ``save`` the object (using ``sudo``):
    group = gl.groups.get('example-group')
    notification_setting = group.notificationsettings.get(sudo='user1')
    notification_setting.level = gitlab.const.NOTIFICATION_LEVEL_GLOBAL
-   # Must use `sudo` again when doing the save.
+   # Must use 'sudo' again when doing the save.
    notification_setting.save(sudo='user1')
 
 


### PR DESCRIPTION
pre-commit incorrectly wants double back-quotes inside the code section. Rather than fight it, just use single quotes.


