### PR TITLE
feat(snippets): add support for listing all instance snippets

### DIFF
--- a/docs/gl_objects/snippets.rst
+++ b/docs/gl_objects/snippets.rst
@@ -22,7 +22,16 @@ List snippets owned by the current user::
 
 List the public snippets::
 
-    public_snippets = gl.snippets.public()
+    public_snippets = gl.snippets.list_public()
+
+List all snippets::
+
+    all_snippets = gl.snippets.list_all()
+
+.. warning::
+
+   Only users with the Administrator or Auditor access levels can see all snippets
+   (both personal and project). See the upstream API documentation for more details.
 
 Get a snippet::
 

--- a/gitlab/v4/objects/snippets.py
+++ b/gitlab/v4/objects/snippets.py
@@ -90,11 +90,35 @@ class SnippetManager(CRUDMixin, RESTManager):
     )
 
     @cli.register_custom_action(cls_names="SnippetManager")
-    def public(self, **kwargs: Any) -> Union[RESTObjectList, List[RESTObject]]:
-        """List all the public snippets.
+    def list_public(self, **kwargs: Any) -> Union[RESTObjectList, List[RESTObject]]:
+        """List all public snippets.
 
         Args:
-            all: If True the returned object will be a list
+            get_all: If True, return all the items, without pagination
+            per_page: Number of items to retrieve per request
+            page: ID of the page to return (starts with page 1)
+            iterator: If set to True and no pagination option is
+                defined, return a generator instead of a list
+            **kwargs: Extra options to send to the server (e.g. sudo)
+
+        Raises:
+            GitlabListError: If the list could not be retrieved
+
+        Returns:
+            The list of snippets, or a generator if `iterator` is True
+        """
+        return self.list(path="/snippets/public", **kwargs)
+
+    @cli.register_custom_action(cls_names="SnippetManager")
+    def list_all(self, **kwargs: Any) -> Union[RESTObjectList, List[RESTObject]]:
+        """List all snippets.
+
+        Args:
+            get_all: If True, return all the items, without pagination
+            per_page: Number of items to retrieve per request
+            page: ID of the page to return (starts with page 1)
+            iterator: If set to True and no pagination option is
+                defined, return a generator instead of a list
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -103,6 +127,32 @@ class SnippetManager(CRUDMixin, RESTManager):
         Returns:
             A generator for the snippets list
         """
+        return self.list(path="/snippets/all", **kwargs)
+
+    def public(self, **kwargs: Any) -> Union[RESTObjectList, List[RESTObject]]:
+        """List all public snippets.
+
+        Args:
+            get_all: If True, return all the items, without pagination
+            per_page: Number of items to retrieve per request
+            page: ID of the page to return (starts with page 1)
+            iterator: If set to True and no pagination option is
+                defined, return a generator instead of a list
+            **kwargs: Extra options to send to the server (e.g. sudo)
+
+        Raises:
+            GitlabListError: If the list could not be retrieved
+
+        Returns:
+            The list of snippets, or a generator if `iterator` is True
+        """
+        utils.warn(
+            message=(
+                "Gitlab.snippets.public() is deprecated and will be removed in a"
+                "future major version. Use Gitlab.snippets.list_public() instead."
+            ),
+            category=DeprecationWarning,
+        )
         return self.list(path="/snippets/public", **kwargs)
 
     def get(self, id: Union[str, int], lazy: bool = False, **kwargs: Any) -> Snippet:

--- a/tests/functional/api/test_snippets.py
+++ b/tests/functional/api/test_snippets.py
@@ -23,6 +23,13 @@ def test_snippets(gl):
     content = snippet.content()
     assert content.decode() == "import gitlab"
 
+    all_snippets = gl.snippets.list_all(get_all=True)
+    public_snippets = gl.snippets.public(get_all=True)
+    list_public_snippets = gl.snippets.list_public(get_all=True)
+    assert isinstance(all_snippets, list)
+    assert isinstance(list_public_snippets, list)
+    assert public_snippets == list_public_snippets
+
     snippet.delete()
 
 


### PR DESCRIPTION
## Changes

See https://docs.gitlab.com/ee/api/snippets.html#list-all-snippets

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
