### PR TITLE
chore: switch to ruff for linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,13 +31,9 @@ jobs:
       - run: pip install --upgrade tox
       - name: Run commitizen (https://commitizen-tools.github.io/commitizen/)
         run: tox -e cz
-      - name: Run black code formatter (https://black.readthedocs.io/en/stable/)
-        run: tox -e black -- --check
-      - name: Run flake8 (https://flake8.pycqa.org/en/latest/)
-        run: tox -e flake8
+      - name: Run ruff linter and formatter (https://docs.astral.sh/ruff/)
+        run: tox -e ruff-check
       - name: Run mypy static typing checker (http://mypy-lang.org/)
         run: tox -e mypy
-      - name: Run isort import order checker (https://pycqa.github.io/isort/)
-        run: tox -e isort -- --check
       - name: Run pylint Python code static checker (https://github.com/PyCQA/pylint)
         run: tox -e pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,23 +2,11 @@ default_language_version:
     python: python3
 
 repos:
-  - repo: https://github.com/psf/black
-    rev: 24.8.0
-    hooks:
-      - id: black
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v3.28.0
     hooks:
       - id: commitizen
         stages: [commit-msg]
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
-    hooks:
-      - id: flake8
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
   - repo: https://github.com/pycqa/pylint
     rev: v3.2.6
     hooks:
@@ -50,3 +38,10 @@ repos:
     rev: 38.18.17
     hooks:
       - id: renovate-config-validator
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.6
+    hooks:
+      - id: ruff
+        args:
+          - --fix
+      - id: ruff-format

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -42,8 +42,8 @@ This creates a clearer project history, and automates our `Releases`_ and change
 Coding Style
 ------------
 
-We use `black <https://github.com/python/black/>`_ and `isort <https://pycqa.github.io/isort/>`_
-to format our code, so you'll need to make sure you use it when committing.
+We use `ruff <https://docs.astral.sh/ruff>`_
+to lint and format our code, so you'll need to make sure you use it when committing.
 
 Pre-commit hooks will validate and format your code, so you can then stage any changes done if the commit failed.
 
@@ -52,7 +52,7 @@ To format your code according to our guidelines before committing, run:
 .. code-block:: bash
 
   cd python-gitlab/
-  tox -e black,isort
+  tox -e lint
 
 Running unit tests
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -19,9 +19,6 @@ python-gitlab
 .. image:: https://img.shields.io/gitter/room/python-gitlab/Lobby.svg
    :target: https://gitter.im/python-gitlab/Lobby
 
-.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-    :target: https://github.com/python/black
-
 .. image:: https://img.shields.io/github/license/python-gitlab/python-gitlab
    :target: https://github.com/python-gitlab/python-gitlab/blob/main/COPYING
 

--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -16,9 +16,8 @@ from typing import (
 import requests
 
 import gitlab
-from gitlab import base, cli
+from gitlab import base, cli, utils
 from gitlab import exceptions as exc
-from gitlab import utils
 
 __all__ = [
     "GetMixin",

--- a/gitlab/v4/objects/artifacts.py
+++ b/gitlab/v4/objects/artifacts.py
@@ -7,9 +7,8 @@ from typing import Any, Callable, Iterator, Optional, TYPE_CHECKING, Union
 
 import requests
 
-from gitlab import cli
+from gitlab import cli, utils
 from gitlab import exceptions as exc
-from gitlab import utils
 from gitlab.base import RESTManager, RESTObject
 
 __all__ = ["ProjectArtifact", "ProjectArtifactManager"]

--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -13,9 +13,8 @@ from typing import (
 
 import requests
 
-from gitlab import cli
+from gitlab import cli, utils
 from gitlab import exceptions as exc
-from gitlab import utils
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -3,9 +3,8 @@ from typing import Any, BinaryIO, cast, Dict, List, Optional, Type, TYPE_CHECKIN
 import requests
 
 import gitlab
-from gitlab import cli
+from gitlab import cli, types
 from gitlab import exceptions as exc
-from gitlab import types
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,

--- a/gitlab/v4/objects/issues.py
+++ b/gitlab/v4/objects/issues.py
@@ -2,9 +2,8 @@ from typing import Any, cast, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import requests
 
-from gitlab import cli, client
+from gitlab import cli, client, types
 from gitlab import exceptions as exc
-from gitlab import types
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,

--- a/gitlab/v4/objects/jobs.py
+++ b/gitlab/v4/objects/jobs.py
@@ -2,9 +2,8 @@ from typing import Any, Callable, cast, Dict, Iterator, Optional, TYPE_CHECKING,
 
 import requests
 
-from gitlab import cli
+from gitlab import cli, utils
 from gitlab import exceptions as exc
-from gitlab import utils
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import RefreshMixin, RetrieveMixin
 from gitlab.types import ArrayAttribute

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -9,9 +9,8 @@ from typing import Any, cast, Dict, Optional, TYPE_CHECKING, Union
 import requests
 
 import gitlab
-from gitlab import cli
+from gitlab import cli, types
 from gitlab import exceptions as exc
-from gitlab import types
 from gitlab.base import RESTManager, RESTObject, RESTObjectList
 from gitlab.mixins import (
     CRUDMixin,

--- a/gitlab/v4/objects/milestones.py
+++ b/gitlab/v4/objects/milestones.py
@@ -1,8 +1,7 @@
 from typing import Any, cast, TYPE_CHECKING, Union
 
-from gitlab import cli
+from gitlab import cli, types
 from gitlab import exceptions as exc
-from gitlab import types
 from gitlab.base import RESTManager, RESTObject, RESTObjectList
 from gitlab.mixins import (
     CRUDMixin,

--- a/gitlab/v4/objects/packages.py
+++ b/gitlab/v4/objects/packages.py
@@ -18,9 +18,8 @@ from typing import (
 
 import requests
 
-from gitlab import cli
+from gitlab import cli, utils
 from gitlab import exceptions as exc
-from gitlab import utils
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import DeleteMixin, GetMixin, ListMixin, ObjectDeleteMixin
 

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -18,9 +18,8 @@ from typing import (
 
 import requests
 
-from gitlab import cli, client
+from gitlab import cli, client, types, utils
 from gitlab import exceptions as exc
-from gitlab import types, utils
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,

--- a/gitlab/v4/objects/repositories.py
+++ b/gitlab/v4/objects/repositories.py
@@ -9,9 +9,8 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, TYPE_CHECKING,
 import requests
 
 import gitlab
-from gitlab import cli
+from gitlab import cli, types, utils
 from gitlab import exceptions as exc
-from gitlab import types, utils
 
 if TYPE_CHECKING:
     # When running mypy we use these as the base classes

--- a/gitlab/v4/objects/runners.py
+++ b/gitlab/v4/objects/runners.py
@@ -1,8 +1,7 @@
 from typing import Any, cast, List, Optional, Union
 
-from gitlab import cli
+from gitlab import cli, types
 from gitlab import exceptions as exc
-from gitlab import types
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import (
     CreateMixin,

--- a/gitlab/v4/objects/secure_files.py
+++ b/gitlab/v4/objects/secure_files.py
@@ -7,9 +7,8 @@ from typing import Any, Callable, cast, Iterator, Optional, TYPE_CHECKING, Union
 
 import requests
 
-from gitlab import cli
+from gitlab import cli, utils
 from gitlab import exceptions as exc
-from gitlab import utils
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import NoUpdateMixin, ObjectDeleteMixin
 from gitlab.types import FileAttribute, RequiredOptional

--- a/gitlab/v4/objects/snippets.py
+++ b/gitlab/v4/objects/snippets.py
@@ -2,9 +2,8 @@ from typing import Any, Callable, cast, Iterator, List, Optional, TYPE_CHECKING,
 
 import requests
 
-from gitlab import cli
+from gitlab import cli, utils
 from gitlab import exceptions as exc
-from gitlab import utils
 from gitlab.base import RESTManager, RESTObject, RESTObjectList
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin, UserAgentDetailMixin
 from gitlab.types import RequiredOptional

--- a/gitlab/v4/objects/topics.py
+++ b/gitlab/v4/objects/topics.py
@@ -1,8 +1,7 @@
 from typing import Any, cast, Dict, TYPE_CHECKING, Union
 
-from gitlab import cli
+from gitlab import cli, types
 from gitlab import exceptions as exc
-from gitlab import types
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
 from gitlab.types import RequiredOptional

--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -8,9 +8,8 @@ from typing import Any, cast, Dict, List, Optional, Union
 
 import requests
 
-from gitlab import cli
+from gitlab import cli, types
 from gitlab import exceptions as exc
-from gitlab import types
 from gitlab.base import RESTManager, RESTObject, RESTObjectList
 from gitlab.mixins import (
     CreateMixin,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,8 +138,19 @@ log_cli_format = "%(asctime)s.%(msecs)03d [%(levelname)8s] (%(filename)s:%(funcN
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 
 [tool.ruff.lint]
-# these will be done in a follow-up
-ignore = ["E721"]
+select = [
+            # See https://docs.astral.sh/ruff/rules
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+]
+ignore = [
+    "E501", # let line-length format it, not line-too-long
+]
+
+[tool.ruff.lint.isort]
+order-by-type = false
 
 [tool.ruff.lint.per-file-ignores]
 "gitlab/v4/objects/__init__.py" = ["F401", "F403"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,11 +59,6 @@ exclude = ["docs*", "tests*"]
 [tool.setuptools.dynamic]
 version = { attr = "gitlab._version.__version__" }
 
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-order_by_type = false
-
 [tool.mypy]
 files = "."
 exclude = "build/.*"
@@ -141,3 +136,10 @@ markers = [
 log_cli_level = "INFO"
 log_cli_format = "%(asctime)s.%(msecs)03d [%(levelname)8s] (%(filename)s:%(funcName)s:L%(lineno)s) %(message)s"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+
+[tool.ruff.lint]
+# these will be done in a follow-up
+ignore = ["E721"]
+
+[tool.ruff.lint.per-file-ignores]
+"gitlab/v4/objects/__init__.py" = ["F401", "F403"]

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,13 +1,11 @@
 -r requirements.txt
 argcomplete==2.0.0
-black==24.8.0
 commitizen==3.28.0
-flake8==7.1.1
-isort==5.13.2
 mypy==1.11.1
 pylint==3.2.6
 pytest==8.3.2
 responses==0.25.3
+ruff==0.5.6
 types-PyYAML==6.0.12.20240724
 types-requests==2.32.0.20240712
 types-setuptools==71.1.0.20240726

--- a/tests/functional/api/test_issues.py
+++ b/tests/functional/api/test_issues.py
@@ -21,8 +21,8 @@ def test_create_issue(project):
     participants = issue.participants()
     assert participants
     assert isinstance(participants, list)
-    assert type(issue.closed_by()) == list
-    assert type(issue.related_merge_requests()) == list
+    assert isinstance(issue.closed_by(), list)
+    assert isinstance(issue.related_merge_requests(), list)
 
 
 def test_issue_notes(issue):

--- a/tests/functional/cli/test_cli_v4.py
+++ b/tests/functional/cli/test_cli_v4.py
@@ -212,7 +212,6 @@ def test_create_branch(gitlab_cli, project):
 
 
 def test_create_merge_request(gitlab_cli, project):
-
     cmd = [
         "project-merge-request",
         "create",

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -117,7 +117,7 @@ class TestWarningsWrapper:
         warning = caught_warnings[0]
         # File name is this file as it is the first file outside of the `gitlab/` path.
         assert __file__ == warning.filename
-        assert warning.category == UserWarning
+        assert warning.category is UserWarning
         assert isinstance(warning.message, UserWarning)
         assert warn_message in str(warning.message)
         assert __file__ in str(warning.message)
@@ -138,7 +138,7 @@ class TestWarningsWrapper:
         warning = caught_warnings[0]
         # File name is this file as it is the first file outside of the `gitlab/` path.
         assert __file__ == warning.filename
-        assert warning.category == UserWarning
+        assert warning.category is UserWarning
         assert isinstance(warning.message, UserWarning)
         assert warn_message in str(warning.message)
         assert __file__ not in str(warning.message)

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,13 @@
 minversion = 4.0
 skipsdist = True
 skip_missing_interpreters = True
-envlist = py313,py312,py311,py310,py39,py38,black,isort,flake8,mypy,twine-check,cz,pylint
+envlist = py313,py312,py311,py310,py39,py38,ruff,mypy,twine-check,cz,pylint
 
 # NOTE(jlvillal): To use a label use the `-m` flag.
 # For example to run the `func` label group of environments do:
 #   tox -m func
 labels =
-    lint = black,isort,flake8,mypy,pylint,cz
+    lint = ruff,mypy,pylint,cz
     unit = py313,py312,py311,py310,py39,py38
 # func is the functional tests. This is very time consuming.
     func = cli_func_v4,api_func_v4
@@ -35,29 +35,25 @@ deps = -r{toxinidir}/requirements.txt
 commands =
   pytest tests/unit {posargs}
 
-[testenv:black]
+[testenv:ruff]
 basepython = python3
 deps = -r{toxinidir}/requirements-lint.txt
 commands =
-  black {posargs} .
+  ruff check --fix
+  ruff format
 
-[testenv:isort]
+[testenv:ruff-check]
 basepython = python3
 deps = -r{toxinidir}/requirements-lint.txt
 commands =
-  isort {posargs} {toxinidir}
+  ruff check
+  ruff format --check
 
 [testenv:mypy]
 basepython = python3
 deps = -r{toxinidir}/requirements-lint.txt
 commands =
   mypy {posargs}
-
-[testenv:flake8]
-basepython = python3
-deps = -r{toxinidir}/requirements-lint.txt
-commands =
-  flake8 {posargs} .
 
 [testenv:pylint]
 basepython = python3
@@ -82,19 +78,6 @@ commands =
 
 [testenv:venv]
 commands = {posargs}
-
-[flake8]
-exclude = .git,.venv,.tox,dist,doc,*egg,build,
-max-line-length = 88
-# We ignore the following because we use black to handle code-formatting
-# E203: Whitespace before ':'
-# E501: Line too long
-# E701: multiple statements on one line (colon)
-# E704: multiple statements on one line (def)
-# W503: Line break occurred before a binary operator
-extend-ignore = E203,E501,E701,E704,W503
-per-file-ignores =
-    gitlab/v4/objects/__init__.py:F401,F403
 
 [testenv:docs]
 deps = -r{toxinidir}/requirements-docs.txt


### PR DESCRIPTION
## Changes

I've seen a lot of projects migrate already, and it's really crazy fast and avoids some of the cross-linter config we have in place atm.

We could also switch pylint to it later, but maybe wait for https://github.com/astral-sh/ruff/issues/970 first.