### PR TITLE
feat(api): project/group hook test triggering

### DIFF
--- a/docs/gl_objects/groups.rst
+++ b/docs/gl_objects/groups.rst
@@ -89,7 +89,7 @@ Remove a group::
     group.delete()
 
 Restore a Group marked for deletion (Premium only):::
-    
+
     group.restore()
 
 
@@ -368,9 +368,9 @@ SAML group links
 
 Add a SAML group link to an existing GitLab group::
 
-    saml_link = group.saml_group_links.create({ 
-        "saml_group_name": "<your_saml_group_name>", 
-        "access_level": <chosen_access_level> 
+    saml_link = group.saml_group_links.create({
+        "saml_group_name": "<your_saml_group_name>",
+        "access_level": <chosen_access_level>
     })
 
 List a group's SAML group links::
@@ -418,6 +418,10 @@ Update a group hook::
 
     hook.push_events = 0
     hook.save()
+
+Test a group hook::
+
+    hook.test("push_events")
 
 Delete a group hook::
 

--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -353,7 +353,7 @@ Import the project using file stored on a remote URL::
     output = gl.projects.remote_import(
         url="https://whatever.com/url/file.tar.gz",
         path="my_new_remote_project",
-        name="My New Remote Project", 
+        name="My New Remote Project",
         namespace="my-group",
         override_params={'visibility': 'private'},
     )
@@ -367,7 +367,7 @@ Import the project using file stored on AWS S3::
         file_key="aws-file-key",
         access_key_id="aws-access-key-id",
         secret_access_key="secret-access-key",
-        name="My New Remote Project", 
+        name="My New Remote Project",
         namespace="my-group",
         override_params={'visibility': 'private'},
     )
@@ -449,7 +449,7 @@ Get file details from headers, without fetching its entire content::
     print(headers["X-Gitlab-Size"])
 
 Get a raw file::
-    
+
     raw_content = project.files.raw(file_path='README.rst', ref='main')
     print(raw_content)
     with open('/tmp/raw-download.txt', 'wb') as f:
@@ -688,6 +688,10 @@ Update a project hook::
 
     hook.push_events = 0
     hook.save()
+
+Test a project hook::
+
+    hook.test("push_events")
 
 Delete a project hook::
 

--- a/gitlab/exceptions.py
+++ b/gitlab/exceptions.py
@@ -316,6 +316,10 @@ class GitlabDeploymentApprovalError(GitlabOperationError):
     pass
 
 
+class GitlabHookTestError(GitlabOperationError):
+    pass
+
+
 # For an explanation of how these type-hints work see:
 # https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators
 #
@@ -370,6 +374,7 @@ __all__ = [
     "GitlabGetError",
     "GitlabGroupTransferError",
     "GitlabHeadError",
+    "GitlabHookTestError",
     "GitlabHousekeepingError",
     "GitlabHttpError",
     "GitlabImportError",

--- a/gitlab/v4/objects/hooks.py
+++ b/gitlab/v4/objects/hooks.py
@@ -1,5 +1,6 @@
 from typing import Any, cast, Union
 
+from gitlab import exceptions as exc
 from gitlab.base import RESTManager, RESTObject
 from gitlab.mixins import CRUDMixin, NoUpdateMixin, ObjectDeleteMixin, SaveMixin
 from gitlab.types import RequiredOptional
@@ -30,6 +31,20 @@ class HookManager(NoUpdateMixin, RESTManager):
 
 class ProjectHook(SaveMixin, ObjectDeleteMixin, RESTObject):
     _repr_attr = "url"
+
+    @exc.on_http_error(exc.GitlabHookTestError)
+    def test(self, trigger: str) -> None:
+        """
+        Test a Project Hook
+
+        Args:
+            trigger: Type of trigger event to test
+
+        Raises:
+            GitlabHookTestError: If the hook test attempt failed
+        """
+        path = f"{self.manager.path}/{self.encoded_id}/test/{trigger}"
+        self.manager.gitlab.http_post(path)
 
 
 class ProjectHookManager(CRUDMixin, RESTManager):
@@ -77,6 +92,20 @@ class ProjectHookManager(CRUDMixin, RESTManager):
 
 class GroupHook(SaveMixin, ObjectDeleteMixin, RESTObject):
     _repr_attr = "url"
+
+    @exc.on_http_error(exc.GitlabHookTestError)
+    def test(self, trigger: str) -> None:
+        """
+        Test a Group Hook
+
+        Args:
+            trigger: Type of trigger event to test
+
+        Raises:
+            GitlabHookTestError: If the hook test attempt failed
+        """
+        path = f"{self.manager.path}/{self.encoded_id}/test/{trigger}"
+        self.manager.gitlab.http_post(path)
 
 
 class GroupHookManager(CRUDMixin, RESTManager):


### PR DESCRIPTION
Add the ability to trigger tests of project and group hooks.

Fixes #2924 

## Changes

* Add the ability to trigger tests of project and group hooks

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
