### PR TITLE
test(cli): allow up to 30 seconds for a project export

### DIFF
--- a/tests/functional/cli/test_cli_projects.py
+++ b/tests/functional/cli/test_cli_projects.py
@@ -40,7 +40,7 @@ def project_export(project):
         time.sleep(0.5)
         export.refresh()
         count += 1
-        if count == 30:
+        if count >= 60:
             raise Exception("Project export taking too much time")
 
     return export


### PR DESCRIPTION
Before we allowed a maximum of around 15 seconds for the project-export. Often times the CI was failing with this value.

Change it to a maximum of around 30 seconds.