### PR TITLE
feat(api): support list and delete for group service accounts

### DIFF
--- a/gitlab/v4/objects/service_accounts.py
+++ b/gitlab/v4/objects/service_accounts.py
@@ -1,15 +1,15 @@
 from gitlab.base import RESTManager, RESTObject
-from gitlab.mixins import CreateMixin
+from gitlab.mixins import CreateMixin, DeleteMixin, ListMixin, ObjectDeleteMixin
 from gitlab.types import RequiredOptional
 
 __all__ = ["GroupServiceAccount", "GroupServiceAccountManager"]
 
 
-class GroupServiceAccount(RESTObject):
+class GroupServiceAccount(ObjectDeleteMixin, RESTObject):
     pass
 
 
-class GroupServiceAccountManager(CreateMixin, RESTManager):
+class GroupServiceAccountManager(CreateMixin, DeleteMixin, ListMixin, RESTManager):
     _path = "/groups/{group_id}/service_accounts"
     _obj_cls = GroupServiceAccount
     _from_parent_attrs = {"group_id": "id"}


### PR DESCRIPTION
add DeleteMixin, ListMixin to GroupServiceAccountManager and ObjectDeleteMixin to GroupServiceAccount

<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

<!-- Remove this comment and describe your changes here. -->

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
