### PR TITLE
feat(api): add exclusive GET attrs for /groups/:id/members

### DIFF
--- a/gitlab/v4/objects/members.py
+++ b/gitlab/v4/objects/members.py
@@ -37,8 +37,9 @@ class GroupMemberManager(CRUDMixin, RESTManager):
     _obj_cls = GroupMember
     _from_parent_attrs = {"group_id": "id"}
     _create_attrs = RequiredOptional(
-        required=("access_level", "user_id"),
+        required=("access_level",),
         optional=("expires_at", "tasks_to_be_done"),
+        exclusive=("username", "user_id"),
     )
     _update_attrs = RequiredOptional(
         required=("access_level",), optional=("expires_at",)


### PR DESCRIPTION
I'm not sure if this PR needs tests or documentation updates. If you think it is necessary - I will add it.

Taken from here: https://docs.gitlab.com/17.3/ee/api/members.html#add-a-member-to-a-group-or-project