### PR TITLE
feat: add a minimal GraphQL client

### DIFF
--- a/docs/api-usage-graphql.rst
+++ b/docs/api-usage-graphql.rst
@@ -1,0 +1,52 @@
+############################
+Using the GraphQL API (beta)
+############################
+
+python-gitlab provides basic support for executing GraphQL queries and mutations.
+
+.. danger::
+
+   The GraphQL client is experimental and only provides basic support.
+   It does not currently support pagination, obey rate limits,
+   or attempt complex retries. You can use it to build simple queries and mutations.
+
+   It is currently unstable and its implementation may change. You can expect a more
+   mature client in one of the upcoming versions.
+
+The ``gitlab.GraphQL`` class
+==================================
+
+As with the REST client, you connect to a GitLab instance by creating a ``gitlab.GraphQL`` object:
+
+.. code-block:: python
+
+   import gitlab
+
+   # anonymous read-only access for public resources (GitLab.com)
+   gq = gitlab.GraphQL()
+
+   # anonymous read-only access for public resources (self-hosted GitLab instance)
+   gq = gitlab.GraphQL('https://gitlab.example.com')
+
+   # personal access token or OAuth2 token authentication (GitLab.com)
+   gq = gitlab.GraphQL(token='glpat-JVNSESs8EwWRx5yDxM5q')
+
+   # personal access token or OAuth2 token authentication (self-hosted GitLab instance)
+   gq = gitlab.GraphQL('https://gitlab.example.com', token='glpat-JVNSESs8EwWRx5yDxM5q')
+
+Sending queries
+===============
+
+Get the result of a query:
+
+.. code-block:: python
+
+    query = """{
+        query {
+          currentUser {
+            name
+          }
+        }
+    """
+
+    result = gq.execute(query)

--- a/docs/api-usage.rst
+++ b/docs/api-usage.rst
@@ -1,8 +1,8 @@
-############################
-Getting started with the API
-############################
+##################
+Using the REST API
+##################
 
-python-gitlab only supports GitLab API v4.
+python-gitlab currently only supports v4 of the GitLab REST API.
 
 ``gitlab.Gitlab`` class
 =======================

--- a/docs/cli-usage.rst
+++ b/docs/cli-usage.rst
@@ -1,6 +1,6 @@
-############################
-Getting started with the CLI
-############################
+#############
+Using the CLI
+#############
 
 ``python-gitlab`` provides a :command:`gitlab` command-line tool to interact
 with GitLab servers.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,7 @@
    cli-usage
    api-usage
    api-usage-advanced
+   api-usage-graphql
    cli-examples
    api-objects
    api/gitlab

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -27,7 +27,7 @@ from gitlab._version import (  # noqa: F401
     __title__,
     __version__,
 )
-from gitlab.client import Gitlab, GitlabList  # noqa: F401
+from gitlab.client import Gitlab, GitlabList, GraphQL  # noqa: F401
 from gitlab.exceptions import *  # noqa: F401,F403
 
 warnings.filterwarnings("default", category=DeprecationWarning, module="^gitlab")
@@ -42,5 +42,6 @@ __all__ = [
     "__version__",
     "Gitlab",
     "GitlabList",
+    "GraphQL",
 ]
 __all__.extend(gitlab.exceptions.__all__)

--- a/gitlab/_backends/graphql.py
+++ b/gitlab/_backends/graphql.py
@@ -1,0 +1,24 @@
+from typing import Any
+
+import httpx
+from gql.transport.httpx import HTTPXTransport
+
+
+class GitlabTransport(HTTPXTransport):
+    """A gql httpx transport that reuses an existing httpx.Client.
+    By default, gql's transports do not have a keep-alive session
+    and do not enable providing your own session that's kept open.
+    This transport lets us provide and close our session on our own
+    and provide additional auth.
+    For details, see https://github.com/graphql-python/gql/issues/91.
+    """
+
+    def __init__(self, *args: Any, client: httpx.Client, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.client = client
+
+    def connect(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass

--- a/gitlab/utils.py
+++ b/gitlab/utils.py
@@ -9,12 +9,24 @@ from typing import Any, Callable, Dict, Iterator, Literal, Optional, Tuple, Type
 
 import requests
 
-from gitlab import types
+from gitlab import const, types
 
 
 class _StdoutStream:
     def __call__(self, chunk: Any) -> None:
         print(chunk)
+
+
+def get_base_url(url: Optional[str] = None) -> str:
+    """Return the base URL with the trailing slash stripped.
+    If the URL is a Falsy value, return the default URL.
+    Returns:
+        The base URL
+    """
+    if not url:
+        return const.DEFAULT_URL
+
+    return url.rstrip("/")
 
 
 def get_content_type(content_type: Optional[str]) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 autocompletion = ["argcomplete>=1.10.0,<3"]
 yaml = ["PyYaml>=6.0.1"]
+graphql = ["gql[httpx]>=3.5.0,<4"]
 
 [project.scripts]
 gitlab = "gitlab.cli:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
+gql==3.5.0
+httpx==0.27.0
 requests==2.32.3
 requests-toolbelt==1.0.0

--- a/tests/functional/api/test_graphql.py
+++ b/tests/functional/api/test_graphql.py
@@ -1,0 +1,20 @@
+import logging
+
+import pytest
+
+import gitlab
+
+
+@pytest.fixture
+def gl_gql(gitlab_url: str, gitlab_token: str) -> gitlab.GraphQL:
+    logging.info("Instantiating gitlab.GraphQL instance")
+    instance = gitlab.GraphQL(gitlab_url, token=gitlab_token)
+
+    return instance
+
+
+def test_query_returns_valid_response(gl_gql: gitlab.GraphQL):
+    query = "query {currentUser {active}}"
+
+    response = gl_gql.execute(query)
+    assert response["currentUser"]["active"] is True

--- a/tests/functional/fixtures/set_token.rb
+++ b/tests/functional/fixtures/set_token.rb
@@ -3,7 +3,7 @@
 user = User.find_by_username('root')
 
 token = user.personal_access_tokens.first_or_create(scopes: ['api', 'sudo'], name: 'default', expires_at: 365.days.from_now);
-token.set_token('python-gitlab-token');
+token.set_token('glpat-python-gitlab-token_');
 token.save!
 
 puts token.token

--- a/tests/install/test_install.py
+++ b/tests/install/test_install.py
@@ -3,4 +3,4 @@ import pytest
 
 def test_install() -> None:
     with pytest.raises(ImportError):
-        import httpx  # type: ignore # noqa
+        import aiohttp  # type: ignore # noqa

--- a/tests/unit/test_graphql.py
+++ b/tests/unit/test_graphql.py
@@ -1,0 +1,14 @@
+import pytest
+
+import gitlab
+
+
+def test_import_error_includes_message(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(gitlab.client, "_GQL_INSTALLED", False)
+    with pytest.raises(ImportError, match="GraphQL client could not be initialized"):
+        gitlab.GraphQL()
+
+
+def test_graphql_as_context_manager_exits():
+    with gitlab.GraphQL() as gl:
+        assert isinstance(gl, gitlab.GraphQL)


### PR DESCRIPTION
Related to #1357 

Adds a minimal client without any bells and whistles, to keep the diff small and then we can bring in more common handling from the REST client.

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
