### PR TITLE
feat(api): add exclusive GET attrs for /projects/:id/members

### DIFF
--- a/gitlab/v4/objects/members.py
+++ b/gitlab/v4/objects/members.py
@@ -102,8 +102,9 @@ class ProjectMemberManager(CRUDMixin, RESTManager):
     _obj_cls = ProjectMember
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(
-        required=("access_level", "user_id"),
+        required=("access_level",),
         optional=("expires_at", "tasks_to_be_done"),
+        exclusive=("username", "user_id"),
     )
     _update_attrs = RequiredOptional(
         required=("access_level",), optional=("expires_at",)


### PR DESCRIPTION
#2964 introduced support for passing a `username` to `/groups/:id/members`. The same should also be possible for `/projects/:id/members`.