### PR TITLE
feat: introduce related_issues to merge requests

### DIFF
--- a/docs/gl_objects/merge_requests.rst
+++ b/docs/gl_objects/merge_requests.rst
@@ -144,6 +144,10 @@ List the changes of a MR::
 
     changes = mr.changes()
 
+List issues related to this merge request::
+
+    related_issues = mr.related_issues()
+
 List issues that will close on merge::
 
     mr.closes_issues()

--- a/gitlab/v4/objects/merge_requests.py
+++ b/gitlab/v4/objects/merge_requests.py
@@ -199,6 +199,35 @@ class ProjectMergeRequest(
 
     @cli.register_custom_action(cls_names="ProjectMergeRequest")
     @exc.on_http_error(exc.GitlabListError)
+    def related_issues(self, **kwargs: Any) -> RESTObjectList:
+        """List issues related to this merge request."
+
+        Args:
+            all: If True, return all the items, without pagination
+            per_page: Number of items to retrieve per request
+            page: ID of the page to return (starts with page 1)
+            **kwargs: Extra options to send to the server (e.g. sudo)
+
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabListError: If the list could not be retrieved
+
+        Returns:
+            List of issues
+        """
+
+        path = f"{self.manager.path}/{self.encoded_id}/related_issues"
+        data_list = self.manager.gitlab.http_list(path, iterator=True, **kwargs)
+
+        if TYPE_CHECKING:
+            assert isinstance(data_list, gitlab.GitlabList)
+
+        manager = ProjectIssueManager(self.manager.gitlab, parent=self.manager._parent)
+
+        return RESTObjectList(manager, ProjectIssue, data_list)
+
+    @cli.register_custom_action(cls_names="ProjectMergeRequest")
+    @exc.on_http_error(exc.GitlabListError)
     def closes_issues(self, **kwargs: Any) -> RESTObjectList:
         """List issues that will close on merge."
 

--- a/tests/unit/objects/test_merge_requests.py
+++ b/tests/unit/objects/test_merge_requests.py
@@ -15,6 +15,7 @@ from gitlab.v4.objects import (
     ProjectMergeRequestReviewerDetail,
     ProjectIssue,
 )
+from gitlab.base import RESTObjectList
 
 mr_content = {
     "id": 1,
@@ -214,6 +215,6 @@ def test_list_related_issues(project, resp_list_merge_requests_related_issues):
     mr = project.mergerequests.get(1)
     this_mr_related_issues = mr.related_issues()
     assert isinstance(mr, ProjectMergeRequest)
-    assert isinstance(this_mr_related_issues, list)
+    assert isinstance(this_mr_related_issues, RESTObjectList)
     assert isinstance(this_mr_related_issues[0], ProjectIssue)
     assert this_mr_related_issues[0].title == related_issues[0]["title"]

--- a/tests/unit/objects/test_merge_requests.py
+++ b/tests/unit/objects/test_merge_requests.py
@@ -40,9 +40,7 @@ mr_content = {
             "web_url": "http://gitlab.example.com//kenyatta_oconnell",
         }
     ],
-    "related_issues": [
-        1, 2
-    ]
+    "related_issues": [1, 2],
 }
 
 reviewers_content = [
@@ -100,6 +98,7 @@ def test_list_related_issues(project, resp_list_merge_requests):
     mrs = project.mergerequests.list()
     assert isinstance(mrs[0], ProjectMergeRequest)
     assert mrs[0].related_issues == mr_content["related_issues"]
+
 
 def test_list_project_merge_requests(project, resp_list_merge_requests):
     mrs = project.mergerequests.list()

--- a/tests/unit/objects/test_merge_requests.py
+++ b/tests/unit/objects/test_merge_requests.py
@@ -40,7 +40,6 @@ mr_content = {
             "web_url": "http://gitlab.example.com//kenyatta_oconnell",
         }
     ],
-    "related_issues": [1, 2],
 }
 
 reviewers_content = [
@@ -92,12 +91,6 @@ def resp_get_merge_request_reviewers():
             status=200,
         )
         yield rsps
-
-
-def test_list_related_issues(project, resp_list_merge_requests):
-    mrs = project.mergerequests.list()
-    assert isinstance(mrs[0], ProjectMergeRequest)
-    assert mrs[0].related_issues == mr_content["related_issues"]
 
 
 def test_list_project_merge_requests(project, resp_list_merge_requests):

--- a/tests/unit/objects/test_merge_requests.py
+++ b/tests/unit/objects/test_merge_requests.py
@@ -212,7 +212,7 @@ def test_get_merge_request_reviewers(project, resp_get_merge_request_reviewers):
 
 def test_list_related_issues(project, resp_list_merge_requests_related_issues):
     mr = project.mergerequests.get(1)
-    this_mr_related_issues = mr.related_issues.list()
+    this_mr_related_issues = mr.related_issues()
     assert isinstance(mr, ProjectMergeRequest)
     assert isinstance(this_mr_related_issues, list)
     assert isinstance(this_mr_related_issues[0], ProjectIssue)

--- a/tests/unit/objects/test_merge_requests.py
+++ b/tests/unit/objects/test_merge_requests.py
@@ -172,13 +172,13 @@ def resp_list_merge_requests_related_issues():
         rsps.add(
             method=responses.GET,
             url="http://localhost/api/v4/projects/1/merge_requests/1",
-            json=[mr_content],
+            json=mr_content,
             content_type="application/json",
             status=200,
         )
         rsps.add(
             method=responses.GET,
-            url="http://localhost/api/v4/projects/1/merge_requests/1/related_issues",
+            url="http://localhost/api/v4/projects/3/merge_requests/1/related_issues",
             json=related_issues,
             content_type="application/json",
             status=200,
@@ -211,9 +211,9 @@ def test_get_merge_request_reviewers(project, resp_get_merge_request_reviewers):
 
 
 def test_list_related_issues(project, resp_list_merge_requests_related_issues):
-    mrs = project.mergerequests.list()
-    this_mr_related_issues = mrs[0].related_issues.list()
-    assert isinstance(mrs[0], ProjectMergeRequest)
+    mr = project.mergerequests.get(1)
+    this_mr_related_issues = mr.related_issues.list()
+    assert isinstance(mr, ProjectMergeRequest)
     assert isinstance(this_mr_related_issues, list)
     assert isinstance(this_mr_related_issues[0], ProjectIssue)
     assert this_mr_related_issues[0].title == related_issues[0]["title"]

--- a/tests/unit/objects/test_merge_requests.py
+++ b/tests/unit/objects/test_merge_requests.py
@@ -171,9 +171,7 @@ def resp_list_merge_requests_related_issues():
     with responses.RequestsMock() as rsps:
         rsps.add(
             method=responses.GET,
-            url=re.compile(
-                r"http://localhost/api/v4/projects/1/(deployments/1/)?merge_requests"
-            ),
+            url="http://localhost/api/v4/projects/1/merge_requests/1",
             json=[mr_content],
             content_type="application/json",
             status=200,
@@ -214,8 +212,8 @@ def test_get_merge_request_reviewers(project, resp_get_merge_request_reviewers):
 
 def test_list_related_issues(project, resp_list_merge_requests_related_issues):
     mr = project.mergerequests.get(1)
-    this_mr_related_issue = mr.related_issues.list()
+    this_mrs_related_issues = mr.related_issues.list()
     assert isinstance(mr, ProjectMergeRequest)
-    assert isinstance(this_mr_related_issue, list)
-    assert isinstance(this_mr_related_issue[0], ProjectIssue)
-    assert this_mr_related_issue[0]["title"] == related_issues[0]["title"]
+    assert isinstance(this_mrs_related_issues, list)
+    assert isinstance(this_mrs_related_issues[0], ProjectIssue)
+    assert this_mr_related_issue[0].title == related_issues[0]["title"]

--- a/tests/unit/objects/test_merge_requests.py
+++ b/tests/unit/objects/test_merge_requests.py
@@ -178,7 +178,7 @@ def resp_list_merge_requests_related_issues():
         )
         rsps.add(
             method=responses.GET,
-            url="http://localhost/api/v4/projects/3/merge_requests/1/related_issues",
+            url="http://localhost/api/v4/projects/1/merge_requests/1/related_issues",
             json=related_issues,
             content_type="application/json",
             status=200,

--- a/tests/unit/objects/test_merge_requests.py
+++ b/tests/unit/objects/test_merge_requests.py
@@ -13,6 +13,7 @@ from gitlab.v4.objects import (
     ProjectDeploymentMergeRequest,
     ProjectMergeRequest,
     ProjectMergeRequestReviewerDetail,
+    ProjectIssue,
 )
 
 mr_content = {
@@ -57,6 +58,78 @@ reviewers_content = [
     }
 ]
 
+related_issues = [
+    {
+        "id": 1,
+        "iid": 1,
+        "project_id": 1,
+        "title": "Fake Title for Merge Requests via API",
+        "description": "Something here",
+        "state": "closed",
+        "created_at": "2024-05-14T04:01:40.042Z",
+        "updated_at": "2024-06-13T05:29:13.661Z",
+        "closed_at": "2024-06-13T05:29:13.602Z",
+        "closed_by": {
+            "id": 2,
+            "name": "Sam Bauch",
+            "username": "kenyatta_oconnell",
+            "state": "active",
+            "avatar_url": "https://www.gravatar.com/avatar/956c92487c6f6f7616b536927e22c9a0?s=80&d=identicon",
+            "web_url": "http://gitlab.example.com//kenyatta_oconnell",
+        },
+        "labels": [
+            "FakeCategory",
+            "fake:ml",
+        ],
+        "assignees": [
+            {
+                "id": 2,
+                "name": "Sam Bauch",
+                "username": "kenyatta_oconnell",
+                "state": "active",
+                "avatar_url": "https://www.gravatar.com/avatar/956c92487c6f6f7616b536927e22c9a0?s=80&d=identicon",
+                "web_url": "http://gitlab.example.com//kenyatta_oconnell",
+            }
+        ],
+        "author": {
+            "id": 2,
+            "name": "Sam Bauch",
+            "username": "kenyatta_oconnell",
+            "state": "active",
+            "avatar_url": "https://www.gravatar.com/avatar/956c92487c6f6f7616b536927e22c9a0?s=80&d=identicon",
+            "web_url": "http://gitlab.example.com//kenyatta_oconnell",
+        },
+        "type": "ISSUE",
+        "assignee": {
+            "id": 4459593,
+            "username": "fakeuser",
+            "name": "Fake User",
+            "state": "active",
+            "locked": False,
+            "avatar_url": "https://example.com/uploads/-/system/user/avatar/4459593/avatar.png",
+            "web_url": "https://example.com/fakeuser",
+        },
+        "user_notes_count": 9,
+        "merge_requests_count": 0,
+        "upvotes": 1,
+        "downvotes": 0,
+        "due_date": None,
+        "confidential": False,
+        "discussion_locked": None,
+        "issue_type": "issue",
+        "web_url": "https://example.com/fakeorg/fakeproject/-/issues/461536",
+        "time_stats": {
+            "time_estimate": 0,
+            "total_time_spent": 0,
+            "human_time_estimate": None,
+            "human_total_time_spent": None,
+        },
+        "task_completion_status": {"count": 0, "completed_count": 0},
+        "weight": None,
+        "blocking_issues_count": 0,
+    }
+]
+
 
 @pytest.fixture
 def resp_list_merge_requests():
@@ -93,6 +166,28 @@ def resp_get_merge_request_reviewers():
         yield rsps
 
 
+@pytest.fixture
+def resp_list_merge_requests_related_issues():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.GET,
+            url=re.compile(
+                r"http://localhost/api/v4/projects/1/(deployments/1/)?merge_requests"
+            ),
+            json=[mr_content],
+            content_type="application/json",
+            status=200,
+        )
+        rsps.add(
+            method=responses.GET,
+            url="http://localhost/api/v4/projects/1/merge_requests/1/related_issues",
+            json=related_issues,
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
 def test_list_project_merge_requests(project, resp_list_merge_requests):
     mrs = project.mergerequests.list()
     assert isinstance(mrs[0], ProjectMergeRequest)
@@ -115,3 +210,12 @@ def test_get_merge_request_reviewers(project, resp_get_merge_request_reviewers):
     assert mr.reviewers[0]["name"] == reviewers_details[0].user["name"]
     assert reviewers_details[0].state == "unreviewed"
     assert reviewers_details[0].created_at == "2022-07-27T17:03:27.684Z"
+
+
+def test_list_related_issues(project, resp_list_merge_requests_related_issues):
+    mr = project.mergerequests.get(1)
+    this_mr_related_issue = mr.related_issues.list()
+    assert isinstance(mr, ProjectMergeRequest)
+    assert isinstance(this_mr_related_issue, list)
+    assert isinstance(this_mr_related_issue[0], ProjectIssue)
+    assert this_mr_related_issue[0]["title"] == related_issues[0]["title"]

--- a/tests/unit/objects/test_merge_requests.py
+++ b/tests/unit/objects/test_merge_requests.py
@@ -9,13 +9,13 @@ import re
 import pytest
 import responses
 
+from gitlab.base import RESTObjectList
 from gitlab.v4.objects import (
     ProjectDeploymentMergeRequest,
+    ProjectIssue,
     ProjectMergeRequest,
     ProjectMergeRequestReviewerDetail,
-    ProjectIssue,
 )
-from gitlab.base import RESTObjectList
 
 mr_content = {
     "id": 1,
@@ -214,7 +214,8 @@ def test_get_merge_request_reviewers(project, resp_get_merge_request_reviewers):
 def test_list_related_issues(project, resp_list_merge_requests_related_issues):
     mr = project.mergerequests.get(1)
     this_mr_related_issues = mr.related_issues()
+    the_issue = next(iter(this_mr_related_issues))
     assert isinstance(mr, ProjectMergeRequest)
     assert isinstance(this_mr_related_issues, RESTObjectList)
-    assert isinstance(this_mr_related_issues[0], ProjectIssue)
-    assert this_mr_related_issues[0].title == related_issues[0]["title"]
+    assert isinstance(the_issue, ProjectIssue)
+    assert the_issue.title == related_issues[0]["title"]

--- a/tests/unit/objects/test_merge_requests.py
+++ b/tests/unit/objects/test_merge_requests.py
@@ -75,7 +75,7 @@ related_issues = [
             "username": "kenyatta_oconnell",
             "state": "active",
             "avatar_url": "https://www.gravatar.com/avatar/956c92487c6f6f7616b536927e22c9a0?s=80&d=identicon",
-            "web_url": "http://gitlab.example.com//kenyatta_oconnell",
+            "web_url": "http://gitlab.example.com/kenyatta_oconnell",
         },
         "labels": [
             "FakeCategory",
@@ -88,7 +88,7 @@ related_issues = [
                 "username": "kenyatta_oconnell",
                 "state": "active",
                 "avatar_url": "https://www.gravatar.com/avatar/956c92487c6f6f7616b536927e22c9a0?s=80&d=identicon",
-                "web_url": "http://gitlab.example.com//kenyatta_oconnell",
+                "web_url": "http://gitlab.example.com/kenyatta_oconnell",
             }
         ],
         "author": {
@@ -211,9 +211,9 @@ def test_get_merge_request_reviewers(project, resp_get_merge_request_reviewers):
 
 
 def test_list_related_issues(project, resp_list_merge_requests_related_issues):
-    mr = project.mergerequests.get(1)
-    this_mrs_related_issues = mr.related_issues.list()
-    assert isinstance(mr, ProjectMergeRequest)
-    assert isinstance(this_mrs_related_issues, list)
-    assert isinstance(this_mrs_related_issues[0], ProjectIssue)
-    assert this_mr_related_issue[0].title == related_issues[0]["title"]
+    mrs = project.mergerequests.list()
+    this_mr_related_issues = mrs[0].related_issues.list()
+    assert isinstance(mrs[0], ProjectMergeRequest)
+    assert isinstance(this_mr_related_issues, list)
+    assert isinstance(this_mr_related_issues[0], ProjectIssue)
+    assert this_mr_related_issues[0].title == related_issues[0]["title"]

--- a/tests/unit/objects/test_merge_requests.py
+++ b/tests/unit/objects/test_merge_requests.py
@@ -40,6 +40,9 @@ mr_content = {
             "web_url": "http://gitlab.example.com//kenyatta_oconnell",
         }
     ],
+    "related_issues": [
+        1, 2
+    ]
 }
 
 reviewers_content = [
@@ -92,6 +95,11 @@ def resp_get_merge_request_reviewers():
         )
         yield rsps
 
+
+def test_list_related_issues(project, resp_list_merge_requests):
+    mrs = project.mergerequests.list()
+    assert isinstance(mrs[0], ProjectMergeRequest)
+    assert mrs[0].related_issues == mr_content["related_issues"]
 
 def test_list_project_merge_requests(project, resp_list_merge_requests):
     mrs = project.mergerequests.list()


### PR DESCRIPTION
<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

- This PR introduces `related_issues` for the `merge_requests` object, returning a list of all related issues.

### Context

GitLab released `related_issues` ([official docs](https://docs.gitlab.com/ee/api/merge_requests.html#list-issues-related-to-the-merge-request)), an endpoint which collects all issues that relate to the current MR. This can be from:
- commit messages on the MR that contain issue links
- issue links commented in the MR
- issue links in the title of the MR
- issues created from discussions in the MR

See the change introduced: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/155422

#### PoC:

```sh
curl --header "PRIVATE-TOKEN: <your_access_token>" \
  --url "https://127.0.0.1:3000/api/v4/projects/7/merge_requests/1/related_issues"
```

<!-- Remove this comment and describe your changes here. -->

### Documentation and testing

Both docs & tests updated

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
