### PR TITLE
chore: update pylint to 3.3.1 and resolve issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/pycqa/pylint
-    rev: v3.2.7
+    rev: v3.3.1
     hooks:
       - id: pylint
         additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ disable = [
     "too-many-instance-attributes",
     "too-many-lines",
     "too-many-locals",
+    "too-many-positional-arguments",
     "too-many-public-methods",
     "too-many-statements",
     "unsubscriptable-object",

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -5,7 +5,7 @@ commitizen==3.29.0
 flake8==7.1.1
 isort==5.13.2
 mypy==1.11.2
-pylint==3.2.7
+pylint==3.3.1
 pytest==8.3.3
 responses==0.25.3
 respx==0.21.1


### PR DESCRIPTION
pylint 3.3.1 appears to have added "too-many-positional-arguments" check with a value of 5.

I don't disagree with this, but we have many functions which exceed this value. We might think about converting some of positional arguments over to keyword arguments in the future. But that is for another time.

For now disable the check across the project.