### PR TITLE
feat: remove support for Python 3.8, require 3.9 or higher

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python:
-          - version: "3.8"
-            toxenv: py38,smoke
           - version: "3.9"
             toxenv: py39,smoke
           - version: "3.10"

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Features
 Installation
 ------------
 
-As of 4.0.0, ``python-gitlab`` is compatible with Python 3.8+.
+As of 5.0.0, ``python-gitlab`` is compatible with Python 3.9+.
 
 Use ``pip`` to install the latest stable version of ``python-gitlab``:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ maintainers = [
     {name = "Nejc Habjan", email="nejc.habjan@siemens.com"},
     {name = "Roger Meier", email="r.meier@siemens.com"}
 ]
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 dependencies = [
     "requests>=2.32.0",
     "requests-toolbelt>=1.0.0",
@@ -30,7 +30,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Python 3.8 is End-of-Life (EOL) as of 2024-10 as stated in https://devguide.python.org/versions/ and
https://peps.python.org/pep-0569/#lifespan

By dropping support for Python 3.8 and requiring Python 3.9 or higher it allows python-gitlab to take advantage of new features in Python 3.9, which are documented at:
https://docs.python.org/3/whatsnew/3.9.html

Closes: #2968

BREAKING CHANGE: As of python-gitlab 5.0.0, Python 3.8 is no longer supported. Python 3.9 or higher is required.