### PR TITLE
fix: raise GitlabHeadError in `project.files.head()` method

### DIFF
--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -137,6 +137,7 @@ class ProjectFileManager(CreateMixin, UpdateMixin, DeleteMixin, RESTManager):
             assert isinstance(server_data, dict)
         return self._obj_cls(self, server_data)
 
+    @exc.on_http_error(exc.GitlabHeadError)
     def head(
         self, file_path: str, ref: str, **kwargs: Any
     ) -> "requests.structures.CaseInsensitiveDict[Any]":


### PR DESCRIPTION
When an error occurs, raise `GitlabHeadError` in
`project.files.head()` method.

Closes: #3004

