### PR TITLE
Make repr() of project approval rules consistent with merge request approval rules

### DIFF
--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -54,6 +54,7 @@ class ProjectApprovalManager(GetWithoutIdMixin, UpdateMixin, RESTManager):
 
 class ProjectApprovalRule(SaveMixin, ObjectDeleteMixin, RESTObject):
     _id_attr = "id"
+    _repr_attr = "name"
 
 
 class ProjectApprovalRuleManager(

--- a/tests/unit/objects/test_project_merge_request_approvals.py
+++ b/tests/unit/objects/test_project_merge_request_approvals.py
@@ -25,6 +25,135 @@ updated_approval_rule_approvals_required = 1
 
 
 @pytest.fixture
+def resp_prj_approval_rules():
+    prj_ars_content = [
+        {
+            "id": approval_rule_id,
+            "name": approval_rule_name,
+            "rule_type": "regular",
+            "report_type": None,
+            "eligible_approvers": [
+                {
+                    "id": user_ids[0],
+                    "name": "John Doe",
+                    "username": "jdoe",
+                    "state": "active",
+                    "avatar_url": "https://www.gravatar.com/avatar/0?s=80&d=identicon",
+                    "web_url": "http://localhost/jdoe",
+                },
+                {
+                    "id": user_ids[1],
+                    "name": "Group Member 1",
+                    "username": "group_member_1",
+                    "state": "active",
+                    "avatar_url": "https://www.gravatar.com/avatar/0?s=80&d=identicon",
+                    "web_url": "http://localhost/group_member_1",
+                },
+            ],
+            "approvals_required": approvals_required,
+            "users": [
+                {
+                    "id": 5,
+                    "name": "John Doe",
+                    "username": "jdoe",
+                    "state": "active",
+                    "avatar_url": "https://www.gravatar.com/avatar/0?s=80&d=identicon",
+                    "web_url": "http://localhost/jdoe",
+                }
+            ],
+            "groups": [
+                {
+                    "id": 5,
+                    "name": "group1",
+                    "path": "group1",
+                    "description": "",
+                    "visibility": "public",
+                    "lfs_enabled": False,
+                    "avatar_url": None,
+                    "web_url": "http://localhost/groups/group1",
+                    "request_access_enabled": False,
+                    "full_name": "group1",
+                    "full_path": "group1",
+                    "parent_id": None,
+                    "ldap_cn": None,
+                    "ldap_access": None,
+                }
+            ],
+            "applies_to_all_protected_branches": False,
+            "protected_branches": [
+                {
+                    "id": 1,
+                    "name": "main",
+                    "push_access_levels": [
+                        {
+                            "access_level": 30,
+                            "access_level_description": "Developers + Maintainers",
+                        }
+                    ],
+                    "merge_access_levels": [
+                        {
+                            "access_level": 30,
+                            "access_level_description": "Developers + Maintainers",
+                        }
+                    ],
+                    "unprotect_access_levels": [
+                        {"access_level": 40, "access_level_description": "Maintainers"}
+                    ],
+                    "code_owner_approval_required": "false",
+                }
+            ],
+            "contains_hidden_groups": False,
+        }
+    ]
+
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(
+            method=responses.GET,
+            url="http://localhost/api/v4/projects/1/approval_rules",
+            json=prj_ars_content,
+            content_type="application/json",
+            status=200,
+        )
+        rsps.add(
+            method=responses.GET,
+            url="http://localhost/api/v4/projects/1/approval_rules/7",
+            json=prj_ars_content[0],
+            content_type="application/json",
+            status=200,
+        )
+
+        new_prj_ars_content = dict(prj_ars_content[0])
+        new_prj_ars_content["name"] = new_approval_rule_name
+        new_prj_ars_content["approvals_required"] = new_approval_rule_approvals_required
+
+        rsps.add(
+            method=responses.POST,
+            url="http://localhost/api/v4/projects/1/approval_rules",
+            json=new_prj_ars_content,
+            content_type="application/json",
+            status=200,
+        )
+
+        updated_mr_ars_content = copy.deepcopy(prj_ars_content[0])
+        updated_mr_ars_content["eligible_approvers"] = [
+            prj_ars_content[0]["eligible_approvers"][0]
+        ]
+
+        updated_mr_ars_content["approvals_required"] = (
+            updated_approval_rule_approvals_required
+        )
+
+        rsps.add(
+            method=responses.PUT,
+            url="http://localhost/api/v4/projects/1/approval_rules/7",
+            json=updated_mr_ars_content,
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
+@pytest.fixture
 def resp_mr_approval_rules():
     mr_ars_content = [
         {
@@ -167,6 +296,17 @@ def test_project_approval_manager_update_method_post(project):
         approvals, gitlab.v4.objects.merge_request_approvals.ProjectApprovalManager
     )
     assert approvals._update_method is UpdateMethod.POST
+
+
+def test_list_project_approval_rules(project, resp_prj_approval_rules):
+    approval_rules = project.approvalrules.list()
+    assert len(approval_rules) == 1
+    assert approval_rules[0].name == approval_rule_name
+    assert approval_rules[0].id == approval_rule_id
+    assert (
+        repr(approval_rules[0])
+        == f"<ProjectApprovalRule id:{approval_rule_id} name:{approval_rule_name}>"
+    )
 
 
 def test_list_merge_request_approval_rules(project, resp_mr_approval_rules):


### PR DESCRIPTION
## Changes

The representation attribute for `ProjectMergeRequestApprovalRule` is `name` (see [here](https://github.com/python-gitlab/python-gitlab/blob/main/gitlab/v4/objects/merge_request_approvals.py#L139)), which makes sense based on the API documentation. However, the API for `ProjectApprovalRule` is [nearly the same](https://docs.gitlab.com/ee/api/merge_request_approvals.html#create-project-level-rule), but we don't set the representation attribute to `name` for that class (see [here](https://github.com/python-gitlab/python-gitlab/blob/main/gitlab/v4/objects/merge_request_approvals.py#L55)).

This MR sets `_repr_attr` for the `ProjectApprovalRule` class , as well as adds a unit test for ensure we can list a project's approval rules, and call `repr()` on it.

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)