### PR TITLE
chore: add Python 3.13 as supported

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,17 +34,21 @@ jobs:
             toxenv: py311,smoke
           - version: "3.12"
             toxenv: py312,smoke
-          - version: '3.13.0-alpha - 3.13' # SemVer's version range syntax
+          - version: "3.13"
             toxenv: py313,smoke
+          # NOTE(jlvillal): 2024-10-17: Enable this once we fix
+          # https://github.com/python-gitlab/python-gitlab/issues/3013
+          # - version: "3.14.0-alpha - 3.14" # SemVer's version range syntax
+          #   toxenv: py314,smoke
         include:
           - os: macos-latest
             python:
-              version: "3.12"
-              toxenv: py312,smoke
+              version: "3.13"
+              toxenv: py313,smoke
           - os: windows-latest
             python:
-              version: "3.12"
-              toxenv: py312,smoke
+              version: "3.13"
+              toxenv: py313,smoke
     steps:
       - uses: actions/checkout@v4.2.1
       - name: Set up Python ${{ matrix.python.version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 keywords = ["api", "client", "gitlab", "python", "python-gitlab", "wrapper"]
 license = {text = "LGPL-3.0-or-later"}

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 4.0
 skipsdist = True
 skip_missing_interpreters = True
-envlist = py313,py312,py311,py310,py39,py38,black,isort,flake8,mypy,twine-check,cz,pylint
+envlist = py313,py312,py311,py310,py39,black,isort,flake8,mypy,twine-check,cz,pylint
 
 # NOTE(jlvillal): To use a label use the `-m` flag.
 # For example to run the `func` label group of environments do:


### PR DESCRIPTION
Mark that Python 3.13 is supported.

Use Python 3.13 for the Mac and Windows tests.

Also remove the 'py38' tox environment. We no longer support Python 3.8.
