### PR TITLE
chore: remove "v3" question from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -19,5 +19,4 @@ assignees: ''
 ## Specifications
 
   - python-gitlab version:
-  - API version you are using (v3/v4):
   - Gitlab server version (or gitlab.com):


### PR DESCRIPTION
python-gitlab hasn't supported the GitLab v3 API since 2018. The last version of python-gitlab to support it was v1.4

Support was removed in:

commit fe89b949922c028830dd49095432ba627d330186
Author: Gauvain Pocentek <gauvain@pocentek.net>
Date:   Sat May 19 17:10:08 2018 +0200

    Drop API v3 support

    Drop the code, the tests, and update the documentation.

<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

<!-- Remove this comment and describe your changes here. -->

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
