### PR TITLE
feat(files): add support for more optional flags

### DIFF
--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -102,11 +102,24 @@ class ProjectFileManager(CreateMixin, UpdateMixin, DeleteMixin, RESTManager):
     _optional_get_attrs: Tuple[str, ...] = ()
     _create_attrs = RequiredOptional(
         required=("file_path", "branch", "content", "commit_message"),
-        optional=("encoding", "author_email", "author_name"),
+        optional=(
+            "encoding",
+            "author_email",
+            "author_name",
+            "execute_filemode",
+            "start_branch",
+        ),
     )
     _update_attrs = RequiredOptional(
         required=("file_path", "branch", "content", "commit_message"),
-        optional=("encoding", "author_email", "author_name"),
+        optional=(
+            "encoding",
+            "author_email",
+            "author_name",
+            "execute_filemode",
+            "start_branch",
+            "last_commit_id",
+        ),
     )
 
     @cli.register_custom_action(
@@ -164,7 +177,13 @@ class ProjectFileManager(CreateMixin, UpdateMixin, DeleteMixin, RESTManager):
     @cli.register_custom_action(
         cls_names="ProjectFileManager",
         required=("file_path", "branch", "content", "commit_message"),
-        optional=("encoding", "author_email", "author_name"),
+        optional=(
+            "encoding",
+            "author_email",
+            "author_name",
+            "execute_filemode",
+            "start_branch",
+        ),
     )
     @exc.on_http_error(exc.GitlabCreateError)
     def create(


### PR DESCRIPTION
GitLab's Repository Files API supports additional flags that weren't implemented before. Notably, the "start_branch" flag is particularly useful, as previously one had to use the "project-branch" command alongside "project-file" to add a file on a separate branch.

Since this is my first contribution to this project, I'm unsure if there's anything else to add beyond these lines.

[1] https://docs.gitlab.com/ee/api/repository_files.html

<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

<!-- Remove this comment and describe your changes here. -->

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
