### PR TITLE
feat(graphql): add async client

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,9 +25,10 @@ python-gitlab
 .. image:: https://img.shields.io/github/license/python-gitlab/python-gitlab
    :target: https://github.com/python-gitlab/python-gitlab/blob/main/COPYING
 
-``python-gitlab`` is a Python package providing access to the GitLab server API.
+``python-gitlab`` is a Python package providing access to the GitLab APIs.
 
-It supports the v4 API of GitLab, and provides a CLI tool (``gitlab``).
+It includes a client for GitLab's v4 REST API, synchronous and asynchronous GraphQL API
+clients, as well as a CLI tool (``gitlab``) wrapping REST API endpoints.
 
 .. _features:
 
@@ -39,6 +40,7 @@ Features
 * write Pythonic code to manage your GitLab resources.
 * pass arbitrary parameters to the GitLab API. Simply follow GitLab's docs
   on what parameters are available.
+* use a synchronous or asynchronous client when using the GraphQL API.
 * access arbitrary endpoints as soon as they are available on GitLab, by using
   lower-level API methods.
 * use persistent requests sessions for authentication, proxy and certificate handling.

--- a/docs/api-usage-graphql.rst
+++ b/docs/api-usage-graphql.rst
@@ -2,7 +2,8 @@
 Using the GraphQL API (beta)
 ############################
 
-python-gitlab provides basic support for executing GraphQL queries and mutations.
+python-gitlab provides basic support for executing GraphQL queries and mutations,
+providing both a synchronous and asynchronous client.
 
 .. danger::
 
@@ -13,10 +14,11 @@ python-gitlab provides basic support for executing GraphQL queries and mutations
    It is currently unstable and its implementation may change. You can expect a more
    mature client in one of the upcoming versions.
 
-The ``gitlab.GraphQL`` class
-==================================
+The ``gitlab.GraphQL`` and ``gitlab.AsyncGraphQL`` classes
+==========================================================
 
-As with the REST client, you connect to a GitLab instance by creating a ``gitlab.GraphQL`` object:
+As with the REST client, you connect to a GitLab instance by creating a ``gitlab.GraphQL``
+(for synchronous code) or ``gitlab.AsyncGraphQL`` instance (for asynchronous code):
 
 .. code-block:: python
 
@@ -34,6 +36,12 @@ As with the REST client, you connect to a GitLab instance by creating a ``gitlab
    # personal access token or OAuth2 token authentication (self-hosted GitLab instance)
    gq = gitlab.GraphQL('https://gitlab.example.com', token='glpat-JVNSESs8EwWRx5yDxM5q')
 
+   # or the async equivalents
+   async_gq = gitlab.AsyncGraphQL()
+   async_gq = gitlab.AsyncGraphQL('https://gitlab.example.com')
+   async_gq = gitlab.AsyncGraphQL(token='glpat-JVNSESs8EwWRx5yDxM5q')
+   async_gq = gitlab.AsyncGraphQL('https://gitlab.example.com', token='glpat-JVNSESs8EwWRx5yDxM5q')
+  
 Sending queries
 ===============
 
@@ -50,3 +58,17 @@ Get the result of a query:
     """
 
     result = gq.execute(query)
+
+Get the result of a query using the async client:
+
+.. code-block:: python
+
+    query = """{
+        query {
+          currentUser {
+            name
+          }
+        }
+    """
+
+    result = await async_gq.execute(query)

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -27,7 +27,7 @@ from gitlab._version import (  # noqa: F401
     __title__,
     __version__,
 )
-from gitlab.client import Gitlab, GitlabList, GraphQL  # noqa: F401
+from gitlab.client import AsyncGraphQL, Gitlab, GitlabList, GraphQL  # noqa: F401
 from gitlab.exceptions import *  # noqa: F401,F403
 
 warnings.filterwarnings("default", category=DeprecationWarning, module="^gitlab")
@@ -42,6 +42,7 @@ __all__ = [
     "__version__",
     "Gitlab",
     "GitlabList",
+    "AsyncGraphQL",
     "GraphQL",
 ]
 __all__.extend(gitlab.exceptions.__all__)

--- a/gitlab/_backends/graphql.py
+++ b/gitlab/_backends/graphql.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import httpx
-from gql.transport.httpx import HTTPXTransport
+from gql.transport.httpx import HTTPXAsyncTransport, HTTPXTransport
 
 
 class GitlabTransport(HTTPXTransport):
@@ -21,4 +21,24 @@ class GitlabTransport(HTTPXTransport):
         pass
 
     def close(self) -> None:
+        pass
+
+
+class GitlabAsyncTransport(HTTPXAsyncTransport):
+    """An async gql httpx transport that reuses an existing httpx.AsyncClient.
+    By default, gql's transports do not have a keep-alive session
+    and do not enable providing your own session that's kept open.
+    This transport lets us provide and close our session on our own
+    and provide additional auth.
+    For details, see https://github.com/graphql-python/gql/issues/91.
+    """
+
+    def __init__(self, *args: Any, client: httpx.AsyncClient, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.client = client
+
+    async def connect(self) -> None:
+        pass
+
+    async def close(self) -> None:
         pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-gitlab"
-description="A python wrapper for the GitLab API"
+description="The python wrapper for the GitLab REST and GraphQL APIs."
 readme = "README.rst"
 authors = [
     {name = "Gauvain Pocentek", email= "gauvain@pocentek.net"}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+anyio==4.6.2.post1
 build==1.2.2.post1
 coverage==7.6.8
 pytest-console-scripts==1.4.1
@@ -8,4 +9,5 @@ pytest==8.3.4
 PyYaml==6.0.2
 responses==0.25.3
 respx==0.21.1
+trio==0.27.0
 wheel==0.45.1

--- a/tests/functional/api/test_graphql.py
+++ b/tests/functional/api/test_graphql.py
@@ -1,5 +1,3 @@
-import logging
-
 import pytest
 
 import gitlab
@@ -7,14 +5,24 @@ import gitlab
 
 @pytest.fixture
 def gl_gql(gitlab_url: str, gitlab_token: str) -> gitlab.GraphQL:
-    logging.info("Instantiating gitlab.GraphQL instance")
-    instance = gitlab.GraphQL(gitlab_url, token=gitlab_token)
+    return gitlab.GraphQL(gitlab_url, token=gitlab_token)
 
-    return instance
+
+@pytest.fixture
+def gl_async_gql(gitlab_url: str, gitlab_token: str) -> gitlab.AsyncGraphQL:
+    return gitlab.AsyncGraphQL(gitlab_url, token=gitlab_token)
 
 
 def test_query_returns_valid_response(gl_gql: gitlab.GraphQL):
     query = "query {currentUser {active}}"
 
     response = gl_gql.execute(query)
+    assert response["currentUser"]["active"] is True
+
+
+@pytest.mark.anyio
+async def test_async_query_returns_valid_response(gl_async_gql: gitlab.AsyncGraphQL):
+    query = "query {currentUser {active}}"
+
+    response = await gl_async_gql.execute(query)
     assert response["currentUser"]["active"] is True

--- a/tests/unit/test_graphql.py
+++ b/tests/unit/test_graphql.py
@@ -5,9 +5,19 @@ import respx
 import gitlab
 
 
+@pytest.fixture(scope="module")
+def api_url() -> str:
+    return "https://gitlab.example.com/api/graphql"
+
+
 @pytest.fixture
 def gl_gql() -> gitlab.GraphQL:
     return gitlab.GraphQL("https://gitlab.example.com")
+
+
+@pytest.fixture
+def gl_async_gql() -> gitlab.AsyncGraphQL:
+    return gitlab.AsyncGraphQL("https://gitlab.example.com")
 
 
 def test_import_error_includes_message(monkeypatch: pytest.MonkeyPatch):
@@ -16,9 +26,22 @@ def test_import_error_includes_message(monkeypatch: pytest.MonkeyPatch):
         gitlab.GraphQL()
 
 
+@pytest.mark.anyio
+async def test_async_import_error_includes_message(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(gitlab.client, "_GQL_INSTALLED", False)
+    with pytest.raises(ImportError, match="GraphQL client could not be initialized"):
+        gitlab.AsyncGraphQL()
+
+
 def test_graphql_as_context_manager_exits():
     with gitlab.GraphQL() as gl:
         assert isinstance(gl, gitlab.GraphQL)
+
+
+@pytest.mark.anyio
+async def test_async_graphql_as_context_manager_aexits():
+    async with gitlab.AsyncGraphQL() as gl:
+        assert isinstance(gl, gitlab.AsyncGraphQL)
 
 
 def test_graphql_retries_on_429_response(
@@ -35,14 +58,29 @@ def test_graphql_retries_on_429_response(
     gl_gql.execute("query {currentUser {id}}")
 
 
-def test_graphql_raises_when_max_retries_exceeded(respx_mock: respx.MockRouter):
-    url = "https://gitlab.example.com/api/graphql"
+@pytest.mark.anyio
+async def test_async_graphql_retries_on_429_response(
+    api_url: str, gl_async_gql: gitlab.AsyncGraphQL, respx_mock: respx.MockRouter
+):
+    responses = [
+        httpx.Response(429, headers={"retry-after": "1"}),
+        httpx.Response(
+            200, json={"data": {"currentUser": {"id": "gid://gitlab/User/1"}}}
+        ),
+    ]
+    respx_mock.post(api_url).mock(side_effect=responses)
+    await gl_async_gql.execute("query {currentUser {id}}")
+
+
+def test_graphql_raises_when_max_retries_exceeded(
+    api_url: str, respx_mock: respx.MockRouter
+):
     responses = [
         httpx.Response(502),
         httpx.Response(502),
         httpx.Response(502),
     ]
-    respx_mock.post(url).mock(side_effect=responses)
+    respx_mock.post(api_url).mock(side_effect=responses)
 
     gl_gql = gitlab.GraphQL(
         "https://gitlab.example.com", max_retries=1, retry_transient_errors=True
@@ -51,10 +89,36 @@ def test_graphql_raises_when_max_retries_exceeded(respx_mock: respx.MockRouter):
         gl_gql.execute("query {currentUser {id}}")
 
 
-def test_graphql_raises_on_401_response(
-    gl_gql: gitlab.GraphQL, respx_mock: respx.MockRouter
+@pytest.mark.anyio
+async def test_async_graphql_raises_when_max_retries_exceeded(
+    api_url: str, respx_mock: respx.MockRouter
 ):
-    url = "https://gitlab.example.com/api/graphql"
-    respx_mock.post(url).mock(return_value=httpx.Response(401))
+    responses = [
+        httpx.Response(502),
+        httpx.Response(502),
+        httpx.Response(502),
+    ]
+    respx_mock.post(api_url).mock(side_effect=responses)
+
+    gl_async_gql = gitlab.AsyncGraphQL(
+        "https://gitlab.example.com", max_retries=1, retry_transient_errors=True
+    )
+    with pytest.raises(gitlab.GitlabHttpError):
+        await gl_async_gql.execute("query {currentUser {id}}")
+
+
+def test_graphql_raises_on_401_response(
+    api_url: str, gl_gql: gitlab.GraphQL, respx_mock: respx.MockRouter
+):
+    respx_mock.post(api_url).mock(return_value=httpx.Response(401))
     with pytest.raises(gitlab.GitlabAuthenticationError):
         gl_gql.execute("query {currentUser {id}}")
+
+
+@pytest.mark.anyio
+async def test_async_graphql_raises_on_401_response(
+    api_url: str, gl_async_gql: gitlab.AsyncGraphQL, respx_mock: respx.MockRouter
+):
+    respx_mock.post(api_url).mock(return_value=httpx.Response(401))
+    with pytest.raises(gitlab.GitlabAuthenticationError):
+        await gl_async_gql.execute("query {currentUser {id}}")


### PR DESCRIPTION
Users have been asking for years for some kind of async support. This is pretty easy to do with the GraphQL client as we're only talking to a single endpoint so it's a good start. 

## Changes

Adds `AsyncGraphQL` and a private base client for common graphql logic. 

Related to https://github.com/python-gitlab/python-gitlab/issues/1357
Related to https://github.com/python-gitlab/python-gitlab/issues/1025

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)