### PR TITLE
feat(cli): enable token rotation via CLI

### DIFF
--- a/gitlab/mixins.py
+++ b/gitlab/mixins.py
@@ -663,6 +663,14 @@ class RotateMixin(_RestManagerBase):
     _path: Optional[str]
     gitlab: gitlab.Gitlab
 
+    @cli.register_custom_action(
+        cls_names=(
+            "PersonalAccessTokenManager",
+            "GroupAccessTokenManager",
+            "ProjectAccessTokenManager",
+        ),
+        optional=("expires_at",),
+    )
     @exc.on_http_error(exc.GitlabRotateError)
     def rotate(
         self, id: Union[str, int], expires_at: Optional[str] = None, **kwargs: Any
@@ -696,7 +704,12 @@ class ObjectRotateMixin(_RestObjectBase):
     _updated_attrs: Dict[str, Any]
     manager: base.RESTManager
 
-    def rotate(self, **kwargs: Any) -> None:
+    @cli.register_custom_action(
+        cls_names=("PersonalAccessToken", "GroupAccessToken", "ProjectAccessToken"),
+        optional=("expires_at",),
+    )
+    @exc.on_http_error(exc.GitlabRotateError)
+    def rotate(self, **kwargs: Any) -> Dict[str, Any]:
         """Rotate the current access token object.
 
         Args:
@@ -711,6 +724,7 @@ class ObjectRotateMixin(_RestObjectBase):
             assert self.encoded_id is not None
         server_data = self.manager.rotate(self.encoded_id, **kwargs)
         self._update_attrs(server_data)
+        return server_data
 
 
 class SubscribableMixin(_RestObjectBase):


### PR DESCRIPTION
Closes https://github.com/python-gitlab/python-gitlab/issues/2766

## Changes

Adds the register decorator for the relevant objects.

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
