### PR TITLE
feat(api): get single project approval rule

### DIFF
--- a/gitlab/v4/objects/merge_request_approvals.py
+++ b/gitlab/v4/objects/merge_request_approvals.py
@@ -7,8 +7,8 @@ from gitlab.mixins import (
     CRUDMixin,
     DeleteMixin,
     GetWithoutIdMixin,
-    ListMixin,
     ObjectDeleteMixin,
+    RetrieveMixin,
     SaveMixin,
     UpdateMethod,
     UpdateMixin,
@@ -58,7 +58,7 @@ class ProjectApprovalRule(SaveMixin, ObjectDeleteMixin, RESTObject):
 
 
 class ProjectApprovalRuleManager(
-    ListMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
+    RetrieveMixin, CreateMixin, UpdateMixin, DeleteMixin, RESTManager
 ):
     _path = "/projects/{project_id}/approval_rules"
     _obj_cls = ProjectApprovalRule
@@ -67,6 +67,11 @@ class ProjectApprovalRuleManager(
         required=("name", "approvals_required"),
         optional=("user_ids", "group_ids", "protected_branch_ids", "usernames"),
     )
+
+    def get(
+        self, id: Union[str, int], lazy: bool = False, **kwargs: Any
+    ) -> ProjectApprovalRule:
+        return cast(ProjectApprovalRule, super().get(id=id, lazy=lazy, **kwargs))
 
 
 class ProjectMergeRequestApproval(SaveMixin, RESTObject):


### PR DESCRIPTION
## Changes

### Issue:

While the `ProjectApprovalRuleManager` supports retrieving all approval rules for a given project (using `list()` method from `ListMixin`), attempting to retrieve a specific approval rule ([api docs](https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-a-single-project-level-rule)) on a given project does not appear to be possible.

Based on other objects in this library, I would expect to retrieve a specific approval rule with the `.get()` method exposed by `GetMixin`, but `ProjectApprovalRuleManager` [is not currently inheriting that](https://github.com/python-gitlab/python-gitlab/blob/v5.0.0/gitlab/v4/objects/merge_request_approvals.py#L60). As a result, the user gets an attribute not found error:

> AttributeError: 'ProjectApprovalRuleManager' object has no attribute 'get'


### Solution:

Replacing the inheritance of `ListMixin` for that class with `RetrieveMixin` provides both `.list()` and `.get()` (through inheritance). The list behavior remains the same, and we now can retrieve a specific approval rule:

```
DEBUG:http.client:send: b'GET /api/v4/projects/11115/approval_rules/27956 HTTP/1.1\r\nHost: gitlab.com\r\nUser-Agent: python-gitlab/5.0.0\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\nContent-type: application/json\r\nPRIVATE-TOKEN: [MASKED]\r\n\r\n'
DEBUG:http.client:reply: 'HTTP/1.1 200 OK\r\n'
```


## Documentation and testing

> Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

Not presently planning to add any since I don't see any existing tests for this class, but happy to make some if thats appropriate.

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
