### PR TITLE
chore(docs): Fix CHANGELOG tracebacks codeblocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7596,7 +7596,12 @@ Missing attributes: * merge_requests_author_approval * merge_requests_disable_co
 - **readme**: Fix Docker image reference
   ([`b9a40d8`](https://github.com/python-gitlab/python-gitlab/commit/b9a40d822bcff630a4c92c395c134f8c002ed1cb))
 
-v1.8.0 is not available. ``` Unable to find image
+  v1.8.0 is not available.
+  ```
+  Unable to find image 'registry.gitlab.com/python-gitlab/python-gitlab:v1.8.0' locally
+  docker: Error response from daemon: manifest for registry.gitlab.com/python-gitlab/python-gitlab:v1.8.0 not found: manifest unknown: manifest unknown.
+  ```
+
   'registry.gitlab.com/python-gitlab/python-gitlab:v1.8.0' locally docker: Error response from
   daemon: manifest for registry.gitlab.com/python-gitlab/python-gitlab:v1.8.0 not found: manifest
   unknown: manifest unknown. ```
@@ -7928,9 +7933,12 @@ The integration tests failed because a test called 'decode()' on a string-type v
   GitLabException class handles byte-to-string conversion already in its __init__. This commit
   removes the call to 'decode()' in the test.
 
-``` Traceback (most recent call last): File "./tools/python_test_v4.py", line 801, in <module>
-  assert 'Retry later' in error_message.decode() AttributeError: 'str' object has no attribute
-  'decode' ```
+  ```
+  Traceback (most recent call last):
+    File "./tools/python_test_v4.py", line 801, in <module>
+      assert 'Retry later' in error_message.decode()
+  AttributeError: 'str' object has no attribute 'decode'
+  ```
 
 - Handle empty 'Retry-After' header from GitLab
   ([`7a3724f`](https://github.com/python-gitlab/python-gitlab/commit/7a3724f3fca93b4f55aed5132cf46d3718c4f594))


### PR DESCRIPTION
With v5.1.0 CHANGELOG.md was updated that mangled v1.10.0 triple backtick codeblock Traceback output that made sphinx [fail](https://github.com/python-gitlab/python-gitlab/actions/runs/12060608158/job/33631303063#step:5:204)  with a non-zero return code.

The resulting docs appears to be processes as text after the failing [line](https://python-gitlab.readthedocs.io/en/v5.1.0/changelog.html#v1-10-0-2019-07-22).  While reviewing other backtick codeblocks fix [v1.8.0](https://python-gitlab.readthedocs.io/en/v5.0.0/changelog.html#id258) to the original traceback.

## Changes

Fix CHANGELOG triple backtick codeblocks for Traceblock.

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

Rerunning `sphinx-build -j auto -n -W --keep-going -b html docs build/sphinx/html` returns in a no warnings with a zero return code.

