### PR TITLE
docs(api-usage): fix link to Gitlab REST API Authentication Docs

### DIFF
--- a/docs/api-usage.rst
+++ b/docs/api-usage.rst
@@ -16,7 +16,7 @@ To connect to GitLab.com or another GitLab instance, create a ``gitlab.Gitlab`` 
    access token.
 
    For the full list of available options and how to obtain these tokens, please see
-   https://docs.gitlab.com/ee/api/index.html#authentication.
+   https://docs.gitlab.com/ee/api/rest/authentication.html.
 
 .. code-block:: python
 


### PR DESCRIPTION
## Changes


Set correct link to Gitlab's REST API authentication docs.

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)


