### PR TITLE
chore(renovate): pin httpx until respx is fixed

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -27,6 +27,11 @@
   ],
   "packageRules": [
     {
+      "description": "Pin httpx until https://github.com/lundberg/respx/issues/277 is solved",
+      "matchPackageNames": "httpx",
+      "allowedVersions": "<0.28.0"
+    },
+    {
       "depTypeList": [
         "action"
       ],


### PR DESCRIPTION
I guess we'll keep getting spammed by renovate if we dont do this for now :)

Related to:

#3058 
https://github.com/lundberg/respx/issues/279
https://github.com/lundberg/respx/pull/278
https://github.com/lundberg/respx/issues/277