### PR TITLE
feat(api): support the new registry protection rule endpoint

### DIFF
--- a/docs/gl_objects/protected_container_repositories.rst
+++ b/docs/gl_objects/protected_container_repositories.rst
@@ -9,22 +9,22 @@ References
 
 * v4 API:
 
-  + :class:`gitlab.v4.objects.ProjectRegistryProtectionRuleRule`
-  + :class:`gitlab.v4.objects.ProjectRegistryProtectionRuleRuleManager`
-  + :attr:`gitlab.v4.objects.Project.registry_protection_rules`
+  + :class:`gitlab.v4.objects.ProjectRegistryRepositoryProtectionRuleRule`
+  + :class:`gitlab.v4.objects.ProjectRegistryRepositoryProtectionRuleRuleManager`
+  + :attr:`gitlab.v4.objects.Project.registry_repository_protection_rules`
 
-* GitLab API: https://docs.gitlab.com/ee/api/project_container_registry_protection_rules.html
+* GitLab API: https://docs.gitlab.com/ee/api/container_repository_protection_rules.html
 
 Examples
 --------
 
 List the container registry protection rules for a project::
 
-    registry_rules = project.registry_protection_rules.list()
+    registry_rules = project.registry_repository_protection_rules.list()
 
 Create a container registry protection rule::
 
-    registry_rule = project.registry_protection_rules.create(
+    registry_rule = project.registry_repository_protection_rules.create(
         {
             'repository_path_pattern': 'test/image',
             'minimum_access_level_for_push': 'maintainer',
@@ -39,6 +39,6 @@ Update a container registry protection rule::
 
 Delete a container registry protection rule::
 
-    registry_rule = project.registry_protection_rules.delete(registry_rule.id)
+    registry_rule = project.registry_repository_protection_rules.delete(registry_rule.id)
     # or
     registry_rule.delete()

--- a/gitlab/v4/objects/__init__.py
+++ b/gitlab/v4/objects/__init__.py
@@ -56,6 +56,7 @@ from .project_access_tokens import *
 from .projects import *
 from .push_rules import *
 from .registry_protection_rules import *
+from .registry_repository_protection_rules import *
 from .releases import *
 from .repositories import *
 from .resource_groups import *

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -86,8 +86,11 @@ from .pipelines import (  # noqa: F401
 )
 from .project_access_tokens import ProjectAccessTokenManager  # noqa: F401
 from .push_rules import ProjectPushRulesManager  # noqa: F401
-from .registry_protection_rules import (  # noqa: F401
+from .registry_protection_rules import (  # noqa: F401; deprecated
     ProjectRegistryProtectionRuleManager,
+)
+from .registry_repository_protection_rules import (  # noqa: F401
+    ProjectRegistryRepositoryProtectionRuleManager,
 )
 from .releases import ProjectReleaseManager  # noqa: F401
 from .repositories import RepositoryMixin
@@ -239,6 +242,7 @@ class Project(
     protectedtags: ProjectProtectedTagManager
     pushrules: ProjectPushRulesManager
     registry_protection_rules: ProjectRegistryProtectionRuleManager
+    registry_repository_protection_rules: ProjectRegistryRepositoryProtectionRuleManager
     releases: ProjectReleaseManager
     resource_groups: ProjectResourceGroupManager
     remote_mirrors: "ProjectRemoteMirrorManager"

--- a/gitlab/v4/objects/registry_repository_protection_rules.py
+++ b/gitlab/v4/objects/registry_repository_protection_rules.py
@@ -1,0 +1,35 @@
+from gitlab.base import RESTManager, RESTObject
+from gitlab.mixins import CreateMixin, ListMixin, SaveMixin, UpdateMethod, UpdateMixin
+from gitlab.types import RequiredOptional
+
+__all__ = [
+    "ProjectRegistryRepositoryProtectionRule",
+    "ProjectRegistryRepositoryProtectionRuleManager",
+]
+
+
+class ProjectRegistryRepositoryProtectionRule(SaveMixin, RESTObject):
+    _repr_attr = "repository_path_pattern"
+
+
+class ProjectRegistryRepositoryProtectionRuleManager(
+    ListMixin, CreateMixin, UpdateMixin, RESTManager
+):
+    _path = "/projects/{project_id}/registry/repository/protection/rules"
+    _obj_cls = ProjectRegistryRepositoryProtectionRule
+    _from_parent_attrs = {"project_id": "id"}
+    _create_attrs = RequiredOptional(
+        required=("repository_path_pattern",),
+        optional=(
+            "minimum_access_level_for_push",
+            "minimum_access_level_for_delete",
+        ),
+    )
+    _update_attrs = RequiredOptional(
+        optional=(
+            "repository_path_pattern",
+            "minimum_access_level_for_push",
+            "minimum_access_level_for_delete",
+        ),
+    )
+    _update_method = UpdateMethod.PATCH

--- a/tests/functional/api/test_registry.py
+++ b/tests/functional/api/test_registry.py
@@ -11,10 +11,10 @@ def protected_registry_feature(gl: Gitlab):
 
 @pytest.mark.skip(reason="Not released yet")
 def test_project_protected_registry(project: Project):
-    rules = project.registry_protection_rules.list()
+    rules = project.registry_repository_protection_rules.list()
     assert isinstance(rules, list)
 
-    protected_registry = project.registry_protection_rules.create(
+    protected_registry = project.registry_repository_protection_rules.create(
         {
             "repository_path_pattern": "test/image",
             "minimum_access_level_for_push": "maintainer",

--- a/tests/unit/objects/test_registry_protection_rules.py
+++ b/tests/unit/objects/test_registry_protection_rules.py
@@ -1,11 +1,11 @@
 """
-GitLab API: https://docs.gitlab.com/ee/api/project_container_registry_protection_rules.html
+GitLab API: https://docs.gitlab.com/ee/api/container_repository_protection_rules.html
 """
 
 import pytest
 import responses
 
-from gitlab.v4.objects import ProjectRegistryProtectionRule
+from gitlab.v4.objects import ProjectRegistryRepositoryProtectionRule
 
 protected_registry_content = {
     "id": 1,
@@ -21,7 +21,7 @@ def resp_list_protected_registries():
     with responses.RequestsMock() as rsps:
         rsps.add(
             method=responses.GET,
-            url="http://localhost/api/v4/projects/1/registry/protection/rules",
+            url="http://localhost/api/v4/projects/1/registry/repository/protection/rules",
             json=[protected_registry_content],
             content_type="application/json",
             status=200,
@@ -34,7 +34,7 @@ def resp_create_protected_registry():
     with responses.RequestsMock() as rsps:
         rsps.add(
             method=responses.POST,
-            url="http://localhost/api/v4/projects/1/registry/protection/rules",
+            url="http://localhost/api/v4/projects/1/registry/repository/protection/rules",
             json=protected_registry_content,
             content_type="application/json",
             status=201,
@@ -50,7 +50,7 @@ def resp_update_protected_registry():
     with responses.RequestsMock() as rsps:
         rsps.add(
             method=responses.PATCH,
-            url="http://localhost/api/v4/projects/1/registry/protection/rules/1",
+            url="http://localhost/api/v4/projects/1/registry/repository/protection/rules/1",
             json=updated_content,
             content_type="application/json",
             status=200,
@@ -59,24 +59,24 @@ def resp_update_protected_registry():
 
 
 def test_list_project_protected_registries(project, resp_list_protected_registries):
-    protected_registry = project.registry_protection_rules.list()[0]
-    assert isinstance(protected_registry, ProjectRegistryProtectionRule)
+    protected_registry = project.registry_repository_protection_rules.list()[0]
+    assert isinstance(protected_registry, ProjectRegistryRepositoryProtectionRule)
     assert protected_registry.repository_path_pattern == "test/image"
 
 
 def test_create_project_protected_registry(project, resp_create_protected_registry):
-    protected_registry = project.registry_protection_rules.create(
+    protected_registry = project.registry_repository_protection_rules.create(
         {
             "repository_path_pattern": "test/image",
             "minimum_access_level_for_push": "maintainer",
         }
     )
-    assert isinstance(protected_registry, ProjectRegistryProtectionRule)
+    assert isinstance(protected_registry, ProjectRegistryRepositoryProtectionRule)
     assert protected_registry.repository_path_pattern == "test/image"
 
 
 def test_update_project_protected_registry(project, resp_update_protected_registry):
-    updated = project.registry_protection_rules.update(
+    updated = project.registry_repository_protection_rules.update(
         1, {"repository_path_pattern": "abc*"}
     )
     assert updated["repository_path_pattern"] == "abc*"


### PR DESCRIPTION
## Changes

Gitlab changed from the REST container registry protection endpoint from
`/projects/{project_id}/registry/protection/rules`
to
`/projects/{project_id}/registry/repository/protection/rules`

Not great, but can't blame them as it's still behind a feature flag. This adds the new endpoint pretty much with a copy paste. As of GitLab 17.7 the old endpoint no longer works.

Looked at a few ways to deprecate all the methods but not sure it's worth it, but might do it in a follow-up.
https://www.geeksforgeeks.org/attaching-a-decorator-to-all-functions-within-a-class-in-python/ might work.

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)
