### PR TITLE
fix(files): add support for optional ref parameter for cli project-file raw

### DIFF
--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -277,6 +277,7 @@ class ProjectFileManager(CreateMixin, UpdateMixin, DeleteMixin, RESTManager):
     @cli.register_custom_action(
         cls_names="ProjectFileManager",
         required=("file_path",),
+        optional=("ref",),
     )
     @exc.on_http_error(exc.GitlabGetError)
     def raw(

--- a/tests/functional/cli/test_cli_files.py
+++ b/tests/functional/cli/test_cli_files.py
@@ -1,0 +1,21 @@
+def test_project_file_raw(gitlab_cli, project, project_file):
+    cmd = ["project-file", "raw", "--project-id", project.id, "--file-path", "README"]
+    ret = gitlab_cli(cmd)
+    assert ret.success
+    assert "Initial content" in ret.stdout
+
+
+def test_project_file_raw_ref(gitlab_cli, project, project_file):
+    cmd = [
+        "project-file",
+        "raw",
+        "--project-id",
+        project.id,
+        "--file-path",
+        "README",
+        "--ref",
+        "main",
+    ]
+    ret = gitlab_cli(cmd)
+    assert ret.success
+    assert "Initial content" in ret.stdout


### PR DESCRIPTION
Add an optional ref parameter for cli project-file raw (https://github.com/python-gitlab/python-gitlab/issues/3032).   The ref parameter was removed in python-gitlab v4.8.0.

## Changes
Add an optional ref parameter for project-file raw.

### Documentation and testing
- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [X] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional).  Functional tests were added for `gitlab project-file raw` and `gitlab project-file raw --ref <ref>`

closes #3032 