### PR TITLE
fix(registry-protection): fix api url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v5.3.1 (2025-01-07)
+
+### Bug Fixes
+
+- Fix container registry protection rules to use the correct URL for endpoint
+  ([#3079](https://github.com/python-gitlab/python-gitlab/pull/3079))
 
 ## v5.3.0 (2024-12-28)
 

--- a/docs/gl_objects/protected_container_repositories.rst
+++ b/docs/gl_objects/protected_container_repositories.rst
@@ -11,7 +11,7 @@ References
 
   + :class:`gitlab.v4.objects.ProjectRegistryRepositoryProtectionRuleRule`
   + :class:`gitlab.v4.objects.ProjectRegistryRepositoryProtectionRuleRuleManager`
-  + :attr:`gitlab.v4.objects.Project.registry_repository_protection_rules`
+  + :attr:`gitlab.v4.objects.Project.registry_protection_repository_rules`
 
 * GitLab API: https://docs.gitlab.com/ee/api/container_repository_protection_rules.html
 
@@ -20,11 +20,11 @@ Examples
 
 List the container registry protection rules for a project::
 
-    registry_rules = project.registry_repository_protection_rules.list()
+    registry_rules = project.registry_protection_repository_rules.list()
 
 Create a container registry protection rule::
 
-    registry_rule = project.registry_repository_protection_rules.create(
+    registry_rule = project.registry_protection_repository_rules.create(
         {
             'repository_path_pattern': 'test/image',
             'minimum_access_level_for_push': 'maintainer',
@@ -39,6 +39,6 @@ Update a container registry protection rule::
 
 Delete a container registry protection rule::
 
-    registry_rule = project.registry_repository_protection_rules.delete(registry_rule.id)
+    registry_rule = project.registry_protection_repository_rules.delete(registry_rule.id)
     # or
     registry_rule.delete()

--- a/gitlab/_version.py
+++ b/gitlab/_version.py
@@ -3,4 +3,4 @@ __copyright__ = "Copyright 2013-2019 Gauvain Pocentek, 2019-2023 python-gitlab t
 __email__ = "gauvainpocentek@gmail.com"
 __license__ = "LGPL3"
 __title__ = "python-gitlab"
-__version__ = "5.3.0"
+__version__ = "5.3.1"

--- a/gitlab/v4/objects/__init__.py
+++ b/gitlab/v4/objects/__init__.py
@@ -55,8 +55,8 @@ from .pipelines import *
 from .project_access_tokens import *
 from .projects import *
 from .push_rules import *
+from .registry_protection_repository_rules import *
 from .registry_protection_rules import *
-from .registry_repository_protection_rules import *
 from .releases import *
 from .repositories import *
 from .resource_groups import *

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -86,11 +86,11 @@ from .pipelines import (  # noqa: F401
 )
 from .project_access_tokens import ProjectAccessTokenManager  # noqa: F401
 from .push_rules import ProjectPushRulesManager  # noqa: F401
+from .registry_protection_repository_rules import (  # noqa: F401
+    ProjectRegistryRepositoryProtectionRuleManager,
+)
 from .registry_protection_rules import (  # noqa: F401; deprecated
     ProjectRegistryProtectionRuleManager,
-)
-from .registry_repository_protection_rules import (  # noqa: F401
-    ProjectRegistryRepositoryProtectionRuleManager,
 )
 from .releases import ProjectReleaseManager  # noqa: F401
 from .repositories import RepositoryMixin
@@ -242,7 +242,7 @@ class Project(
     protectedtags: ProjectProtectedTagManager
     pushrules: ProjectPushRulesManager
     registry_protection_rules: ProjectRegistryProtectionRuleManager
-    registry_repository_protection_rules: ProjectRegistryRepositoryProtectionRuleManager
+    registry_protection_repository_rules: ProjectRegistryRepositoryProtectionRuleManager
     releases: ProjectReleaseManager
     resource_groups: ProjectResourceGroupManager
     remote_mirrors: "ProjectRemoteMirrorManager"

--- a/gitlab/v4/objects/registry_protection_repository_rules.py
+++ b/gitlab/v4/objects/registry_protection_repository_rules.py
@@ -15,7 +15,7 @@ class ProjectRegistryRepositoryProtectionRule(SaveMixin, RESTObject):
 class ProjectRegistryRepositoryProtectionRuleManager(
     ListMixin, CreateMixin, UpdateMixin, RESTManager
 ):
-    _path = "/projects/{project_id}/registry/repository/protection/rules"
+    _path = "/projects/{project_id}/registry/protection/repository/rules"
     _obj_cls = ProjectRegistryRepositoryProtectionRule
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(

--- a/tests/functional/api/test_registry.py
+++ b/tests/functional/api/test_registry.py
@@ -11,10 +11,10 @@ def protected_registry_feature(gl: Gitlab):
 
 @pytest.mark.skip(reason="Not released yet")
 def test_project_protected_registry(project: Project):
-    rules = project.registry_repository_protection_rules.list()
+    rules = project.registry_protection_repository_rules.list()
     assert isinstance(rules, list)
 
-    protected_registry = project.registry_repository_protection_rules.create(
+    protected_registry = project.registry_protection_repository_rules.create(
         {
             "repository_path_pattern": "test/image",
             "minimum_access_level_for_push": "maintainer",

--- a/tests/unit/objects/test_registry_protection_rules.py
+++ b/tests/unit/objects/test_registry_protection_rules.py
@@ -21,7 +21,7 @@ def resp_list_protected_registries():
     with responses.RequestsMock() as rsps:
         rsps.add(
             method=responses.GET,
-            url="http://localhost/api/v4/projects/1/registry/repository/protection/rules",
+            url="http://localhost/api/v4/projects/1/registry/protection/repository/rules",
             json=[protected_registry_content],
             content_type="application/json",
             status=200,
@@ -34,7 +34,7 @@ def resp_create_protected_registry():
     with responses.RequestsMock() as rsps:
         rsps.add(
             method=responses.POST,
-            url="http://localhost/api/v4/projects/1/registry/repository/protection/rules",
+            url="http://localhost/api/v4/projects/1/registry/protection/repository/rules",
             json=protected_registry_content,
             content_type="application/json",
             status=201,
@@ -50,7 +50,7 @@ def resp_update_protected_registry():
     with responses.RequestsMock() as rsps:
         rsps.add(
             method=responses.PATCH,
-            url="http://localhost/api/v4/projects/1/registry/repository/protection/rules/1",
+            url="http://localhost/api/v4/projects/1/registry/protection/repository/rules/1",
             json=updated_content,
             content_type="application/json",
             status=200,
@@ -59,13 +59,13 @@ def resp_update_protected_registry():
 
 
 def test_list_project_protected_registries(project, resp_list_protected_registries):
-    protected_registry = project.registry_repository_protection_rules.list()[0]
+    protected_registry = project.registry_protection_repository_rules.list()[0]
     assert isinstance(protected_registry, ProjectRegistryRepositoryProtectionRule)
     assert protected_registry.repository_path_pattern == "test/image"
 
 
 def test_create_project_protected_registry(project, resp_create_protected_registry):
-    protected_registry = project.registry_repository_protection_rules.create(
+    protected_registry = project.registry_protection_repository_rules.create(
         {
             "repository_path_pattern": "test/image",
             "minimum_access_level_for_push": "maintainer",
@@ -76,7 +76,7 @@ def test_create_project_protected_registry(project, resp_create_protected_regist
 
 
 def test_update_project_protected_registry(project, resp_update_protected_registry):
-    updated = project.registry_repository_protection_rules.update(
+    updated = project.registry_protection_repository_rules.update(
         1, {"repository_path_pattern": "abc*"}
     )
     assert updated["repository_path_pattern"] == "abc*"


### PR DESCRIPTION
See: https://docs.gitlab.com/ee/api/container_repository_protection_rules.html#list-container-repository-protection-rules

Currently its actually the wrong way around:

Before:

```python
>>> project.registry_repository_protection_rules.list()
DEBUG:http.client:send: b'GET /api/v4/projects/1/registry/repository/protection/rules?per_page=100 HTTP/1.1\r\nHost: gitlab\r\nUser-Agent: python-gitlab/5.3.0\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\nContent-type: application/json\r\nAuthorization: Bearer [MASKED]\r\n\r\n'
DEBUG:http.client:reply: 'HTTP/1.1 404 Not Found\r\n'
DEBUG:http.client:header: Server: nginx
DEBUG:http.client:header: Date: Tue, 07 Jan 2025 10:48:07 GMT
DEBUG:http.client:header: Content-Type: application/json
DEBUG:http.client:header: Content-Length: 25
DEBUG:http.client:header: Connection: keep-alive
DEBUG:http.client:header: Cache-Control: no-cache
DEBUG:http.client:header: Vary: Origin
DEBUG:http.client:header: X-Content-Type-Options: nosniff
DEBUG:http.client:header: X-Frame-Options: SAMEORIGIN
DEBUG:http.client:header: X-Gitlab-Meta: {"correlation_id":"01JH0620XEC35XT2EQR7PPNBVJ","version":"1"}
DEBUG:http.client:header: X-Request-Id: 01JH0620XEC35XT2EQR7PPNBVJ
DEBUG:http.client:header: X-Runtime: 0.141841
DEBUG:http.client:header: Strict-Transport-Security: max-age=63072000
DEBUG:urllib3.connectionpool:http://gitlab:80 "GET /api/v4/projects/1/registry/repository/protection/rules?per_page=100 HTTP/1.1" 404 25
Traceback (most recent call last):
  File "/builds/code-ops/gitlab-audit/.venv/lib/python3.13/site-packages/gitlab/exceptions.py", line 344, in wrapped_f
    return f(*args, **kwargs)
  File "/builds/code-ops/gitlab-audit/.venv/lib/python3.13/site-packages/gitlab/mixins.py", line 247, in list
    obj = self.gitlab.http_list(path, **data)
  File "/builds/code-ops/gitlab-audit/.venv/lib/python3.13/site-packages/gitlab/client.py", line 908, in http_list
    gl_list = GitlabList(self, url, query_data, get_next=False, **kwargs)
  File "/builds/code-ops/gitlab-audit/.venv/lib/python3.13/site-packages/gitlab/client.py", line 1177, in __init__
    self._query(url, query_data, **self._kwargs)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/builds/code-ops/gitlab-audit/.venv/lib/python3.13/site-packages/gitlab/client.py", line 1187, in _query
    result = self._gl.http_request("get", url, query_data=query_data, **kwargs)
  File "/builds/code-ops/gitlab-audit/.venv/lib/python3.13/site-packages/gitlab/client.py", line 773, in http_request
    raise gitlab.exceptions.GitlabHttpError(
    ...<3 lines>...
    )
gitlab.exceptions.GitlabHttpError: 404: 404 Not Found

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<python-input-22>", line 1, in <module>
    project.registry_repository_protection_rules.list()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/builds/code-ops/gitlab-audit/.venv/lib/python3.13/site-packages/gitlab/exceptions.py", line 346, in wrapped_f
    raise error(e.error_message, e.response_code, e.response_body) from e
gitlab.exceptions.GitlabListError: 404: 404 Not Found
>>> project.registry_protection_rules.list()
DEBUG:http.client:send: b'GET /api/v4/projects/1/registry/protection/rules?per_page=100 HTTP/1.1\r\nHost: gitlab\r\nUser-Agent: python-gitlab/5.3.0\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\nContent-type: application/json\r\nAuthorization: Bearer [MASKED]\r\n\r\n'
DEBUG:http.client:reply: 'HTTP/1.1 404 Not Found\r\n'
DEBUG:http.client:header: Server: nginx
DEBUG:http.client:header: Date: Tue, 07 Jan 2025 10:48:22 GMT
DEBUG:http.client:header: Content-Type: application/json
DEBUG:http.client:header: Content-Length: 25
DEBUG:http.client:header: Connection: keep-alive
DEBUG:http.client:header: Cache-Control: no-cache
DEBUG:http.client:header: Vary: Origin
DEBUG:http.client:header: X-Content-Type-Options: nosniff
DEBUG:http.client:header: X-Frame-Options: SAMEORIGIN
DEBUG:http.client:header: X-Gitlab-Meta: {"correlation_id":"01JH062FVQ7T6H61WKZJ620S9G","version":"1"}
DEBUG:http.client:header: X-Request-Id: 01JH062FVQ7T6H61WKZJ620S9G
DEBUG:http.client:header: X-Runtime: 0.049562
DEBUG:http.client:header: Strict-Transport-Security: max-age=63072000
DEBUG:urllib3.connectionpool:http://gitlab:80 "GET /api/v4/projects/1/registry/protection/rules?per_page=100 HTTP/1.1" 404 25
Traceback (most recent call last):
  File "/builds/code-ops/gitlab-audit/.venv/lib/python3.13/site-packages/gitlab/exceptions.py", line 344, in wrapped_f
    return f(*args, **kwargs)
  File "/builds/code-ops/gitlab-audit/.venv/lib/python3.13/site-packages/gitlab/mixins.py", line 247, in list
    obj = self.gitlab.http_list(path, **data)
  File "/builds/code-ops/gitlab-audit/.venv/lib/python3.13/site-packages/gitlab/client.py", line 908, in http_list
    gl_list = GitlabList(self, url, query_data, get_next=False, **kwargs)
  File "/builds/code-ops/gitlab-audit/.venv/lib/python3.13/site-packages/gitlab/client.py", line 1177, in __init__
    self._query(url, query_data, **self._kwargs)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/builds/code-ops/gitlab-audit/.venv/lib/python3.13/site-packages/gitlab/client.py", line 1187, in _query
    result = self._gl.http_request("get", url, query_data=query_data, **kwargs)
  File "/builds/code-ops/gitlab-audit/.venv/lib/python3.13/site-packages/gitlab/client.py", line 773, in http_request
    raise gitlab.exceptions.GitlabHttpError(
    ...<3 lines>...
    )
gitlab.exceptions.GitlabHttpError: 404: 404 Not Found

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<python-input-23>", line 1, in <module>
    project.registry_protection_rules.list()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/builds/code-ops/gitlab-audit/.venv/lib/python3.13/site-packages/gitlab/exceptions.py", line 346, in wrapped_f
    raise error(e.error_message, e.response_code, e.response_body) from e
gitlab.exceptions.GitlabListError: 404: 404 Not Found
```

Tested:

```python
>>> gl.features.set(name="container_registry_protected_containers", value=True)
DEBUG:http.client:send: b'POST /api/v4/features//container_registry_protected_containers HTTP/1.1\r\nHost: gitlab\r\nUser-Agent: python-gitlab/5.3.0\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\nContent-type: application/json\r\nContent-Length: 15\r\nAuthorization: Bearer [MASKED]\r\n\r\n'
DEBUG:http.client:send: b'{"value": true}'
DEBUG:http.client:reply: 'HTTP/1.1 201 Created\r\n'
DEBUG:http.client:header: Server: nginx
DEBUG:http.client:header: Date: Tue, 07 Jan 2025 10:58:31 GMT
DEBUG:http.client:header: Content-Type: application/json
DEBUG:http.client:header: Content-Length: 476
DEBUG:http.client:header: Connection: keep-alive
DEBUG:http.client:header: Cache-Control: max-age=0, private, must-revalidate
DEBUG:http.client:header: Etag: W/"5b661f94995ef9e283fac6c535acc1d1"
DEBUG:http.client:header: Vary: Origin
DEBUG:http.client:header: X-Content-Type-Options: nosniff
DEBUG:http.client:header: X-Frame-Options: SAMEORIGIN
DEBUG:http.client:header: X-Gitlab-Meta: {"correlation_id":"01JH06N2Q947JCCM1RYDF0ZW70","version":"1"}
DEBUG:http.client:header: X-Request-Id: 01JH06N2Q947JCCM1RYDF0ZW70
DEBUG:http.client:header: X-Runtime: 0.181467
DEBUG:http.client:header: Strict-Transport-Security: max-age=63072000
DEBUG:http.client:header: Referrer-Policy: strict-origin-when-cross-origin
DEBUG:urllib3.connectionpool:http://gitlab:80 "POST /api/v4/features//container_registry_protected_containers HTTP/1.1" 201 476
<Feature name:container_registry_protected_containers>
>>> gl.http_get("/projects/1/registry/protection/repository/rules")
DEBUG:http.client:send: b'GET /api/v4/projects/1/registry/protection/repository/rules HTTP/1.1\r\nHost: gitlab\r\nUser-Agent: python-gitlab/5.3.0\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\nContent-type: application/json\r\nAuthorization: Bearer [MASKED]\r\n\r\n'
DEBUG:http.client:reply: 'HTTP/1.1 200 OK\r\n'
DEBUG:http.client:header: Server: nginx
DEBUG:http.client:header: Date: Tue, 07 Jan 2025 10:58:34 GMT
DEBUG:http.client:header: Content-Type: application/json
DEBUG:http.client:header: Content-Length: 2
DEBUG:http.client:header: Connection: keep-alive
DEBUG:http.client:header: Cache-Control: max-age=0, private, must-revalidate
DEBUG:http.client:header: Etag: W/"4f53cda18c2baa0c0354bb5f9a3ecbe5"
DEBUG:http.client:header: Vary: Origin
DEBUG:http.client:header: X-Content-Type-Options: nosniff
DEBUG:http.client:header: X-Frame-Options: SAMEORIGIN
DEBUG:http.client:header: X-Gitlab-Meta: {"correlation_id":"01JH06N5BRMKH54WAD5D8ZB7AT","version":"1"}
DEBUG:http.client:header: X-Request-Id: 01JH06N5BRMKH54WAD5D8ZB7AT
DEBUG:http.client:header: X-Runtime: 0.357174
DEBUG:http.client:header: Strict-Transport-Security: max-age=63072000
DEBUG:http.client:header: Referrer-Policy: strict-origin-when-cross-origin
DEBUG:urllib3.connectionpool:http://gitlab:80 "GET /api/v4/projects/1/registry/protection/repository/rules HTTP/1.1" 200 2
[]
>>> gl.http_get("/projects/1/registry/protection/repository/rules")
```

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
