### PR TITLE
chore(ci): set a 30 minute timeout for 'functional' tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,7 @@ jobs:
         run: tox --skip-missing-interpreters false
 
   functional:
+    timeout-minutes: 30
     runs-on: ubuntu-24.04
     strategy:
       matrix:


### PR DESCRIPTION
Currently the functional API test takes around 17 minutes to run. And the functional CLI test takes around 12 minutes to run.

Occasionally a job gets stuck and will sit until the default 360 minutes job timeout occurs.

Now have a 30 minute timeout for the 'functional' tests.