### PR TITLE
chore(ci): replace docs artifact with readthedocs previews

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,18 +26,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.4.0
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install dependencies
         run: pip install tox
       - name: Build docs
         env:
           TOXENV: docs
         run: tox
-      - name: Archive generated docs
-        uses: actions/upload-artifact@v4.6.0
-        with:
-          name: html-docs
-          path: build/sphinx/html/
 
   twine-check:
     runs-on: ubuntu-24.04
@@ -46,7 +41,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.4.0
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install dependencies
         run: pip install tox twine wheel
       - name: Check twine readme rendering


### PR DESCRIPTION
Closes https://github.com/python-gitlab/python-gitlab/issues/1445

## Changes

Enabled https://docs.readthedocs.com/platform/stable/guides/pull-requests.html
Keeps the actual docs build in CI just in case.

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
