### PR TITLE
Add support for project tag list filters

### DIFF
--- a/gitlab/v4/objects/tags.py
+++ b/gitlab/v4/objects/tags.py
@@ -19,6 +19,7 @@ class ProjectTagManager(NoUpdateMixin[ProjectTag]):
     _path = "/projects/{project_id}/repository/tags"
     _obj_cls = ProjectTag
     _from_parent_attrs = {"project_id": "id"}
+    _list_filters = ("order_by", "sort", "search")
     _create_attrs = RequiredOptional(
         required=("tag_name", "ref"), optional=("message",)
     )


### PR DESCRIPTION
Added _list_filters attribute to `gitlab.v4.objects.tags.ProjectTagManager` to support defined api list filters: `order_by`, `sort` and `search`.

Closes #3156
