### PR TITLE
ci: disable testing of Python 3.14 development release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,9 @@ jobs:
             toxenv: py312,smoke
           - version: "3.13"
             toxenv: py313,smoke
-          - version: "3.14.0-alpha - 3.14" # SemVer's version range syntax
-            toxenv: py314,smoke
+          # NOTE(jlvillal): 2025-04-06: comment this out until our dependencies support Python 3.14
+          # - version: "3.14.0-alpha - 3.14" # SemVer's version range syntax
+          #   toxenv: py314,smoke
         include:
           - os: macos-latest
             python:


### PR DESCRIPTION
Issue: Dependencies we use do not yet support Python 3.14, and in fact fail. This in turn causes our CI to fail.

Until that changes disable testing of Python 3.14 development release in the CI.