### PR TITLE
feat: add protectedbranches to group class (#3164)

### DIFF
--- a/docs/gl_objects/protected_branches.rst
+++ b/docs/gl_objects/protected_branches.rst
@@ -2,8 +2,8 @@
 Protected branches
 ##################
 
-You can define a list of protected branch names on a repository. Names can use
-wildcards (``*``).
+You can define a list of protected branch names on a repository or group.
+Names can use wildcards (``*``).
 
 References
 ----------
@@ -13,19 +13,24 @@ References
   + :class:`gitlab.v4.objects.ProjectProtectedBranch`
   + :class:`gitlab.v4.objects.ProjectProtectedBranchManager`
   + :attr:`gitlab.v4.objects.Project.protectedbranches`
+  + :class:`gitlab.v4.objects.GroupProtectedBranch`
+  + :class:`gitlab.v4.objects.GroupProtectedBranchManager`
+  + :attr:`gitlab.v4.objects.Group.protectedbranches`
 
 * GitLab API: https://docs.gitlab.com/api/protected_branches#protected-branches-api
 
 Examples
 --------
 
-Get the list of protected branches for a project::
+Get the list of protected branches for a project or group::
 
-    p_branches = project.protectedbranches.list(get_all=True)
+    p_branches = project.protectedbranches.list()
+    p_branches = group.protectedbranches.list()
 
 Get a single protected branch::
 
     p_branch = project.protectedbranches.get('main')
+    p_branch = group.protectedbranches.get('main')
 
 Update a protected branch::
 

--- a/gitlab/v4/objects/branches.py
+++ b/gitlab/v4/objects/branches.py
@@ -49,3 +49,27 @@ class ProjectProtectedBranchManager(CRUDMixin[ProjectProtectedBranch]):
         ),
     )
     _update_method = UpdateMethod.PATCH
+
+
+class GroupProtectedBranch(SaveMixin, ObjectDeleteMixin, RESTObject):
+    _id_attr = "name"
+
+
+class GroupProtectedBranchManager(CRUDMixin[GroupProtectedBranch]):
+    _path = "/groups/{group_id}/protected_branches"
+    _obj_cls = GroupProtectedBranch
+    _from_parent_attrs = {"group_id": "id"}
+    _create_attrs = RequiredOptional(
+        required=("name",),
+        optional=(
+            "push_access_level",
+            "merge_access_level",
+            "unprotect_access_level",
+            "allow_force_push",
+            "allowed_to_push",
+            "allowed_to_merge",
+            "allowed_to_unprotect",
+            "code_owner_approval_required",
+        ),
+    )
+    _update_method = UpdateMethod.PATCH

--- a/gitlab/v4/objects/groups.py
+++ b/gitlab/v4/objects/groups.py
@@ -24,6 +24,7 @@ from .access_requests import GroupAccessRequestManager  # noqa: F401
 from .audit_events import GroupAuditEventManager  # noqa: F401
 from .badges import GroupBadgeManager  # noqa: F401
 from .boards import GroupBoardManager  # noqa: F401
+from .branches import GroupProtectedBranchManager  # noqa: F401
 from .clusters import GroupClusterManager  # noqa: F401
 from .container_registry import GroupRegistryRepositoryManager  # noqa: F401
 from .custom_attributes import GroupCustomAttributeManager  # noqa: F401
@@ -102,6 +103,7 @@ class Group(SaveMixin, ObjectDeleteMixin, RESTObject):
     packages: GroupPackageManager
     projects: GroupProjectManager
     shared_projects: SharedProjectManager
+    protectedbranches: GroupProtectedBranchManager
     pushrules: GroupPushRulesManager
     registry_repositories: GroupRegistryRepositoryManager
     runners: GroupRunnerManager


### PR DESCRIPTION
<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

<!-- Remove this comment and describe your changes here. -->
- Adds `protectedbranches` attr to the [Group]() class objects. This allows one to retrieve (`.list()`) or set (`.create()`) protected branches to trickle downstream to sub-groups/projects.
  - Ref: https://docs.gitlab.com/api/group_protected_branches/


### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->

Closes #3164