### PR TITLE
docs(api-usage-graphql): fix the example graphql query string

### DIFF
--- a/docs/api-usage-graphql.rst
+++ b/docs/api-usage-graphql.rst
@@ -49,12 +49,12 @@ Get the result of a query:
 
 .. code-block:: python
 
-    query = """{
-        query {
-          currentUser {
+    query = """
+    {
+        currentUser {
             name
-          }
         }
+    }
     """
 
     result = gq.execute(query)
@@ -63,12 +63,12 @@ Get the result of a query using the async client:
 
 .. code-block:: python
 
-    query = """{
-        query {
-          currentUser {
+    query = """
+    {
+        currentUser {
             name
-          }
         }
+    }
     """
 
     result = await async_gq.execute(query)


### PR DESCRIPTION
## Changes

Update the example GraphQL query string, as the original one could not be executed successfully.

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
