### PR TITLE
feat(api): add support for avatar removal

### DIFF
--- a/docs/gl_objects/groups.rst
+++ b/docs/gl_objects/groups.rst
@@ -82,6 +82,11 @@ Set the avatar image for a group::
     group.avatar = open('path/to/file.png', 'rb')
     group.save()
 
+Remove the avatar image for a group::
+
+    group.avatar = ""
+    group.save()
+
 Remove a group::
 
     gl.groups.delete(group_id)

--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -109,6 +109,11 @@ Set the avatar image for a project::
     project.avatar = open('path/to/file.png', 'rb')
     project.save()
 
+Remove the avatar image for a project::
+
+    project.avatar = ""
+    project.save()
+
 Delete a project::
 
     gl.projects.delete(project_id)

--- a/docs/gl_objects/topics.rst
+++ b/docs/gl_objects/topics.rst
@@ -50,3 +50,16 @@ Delete a topic::
 Merge a source topic into a target topic::
 
     gl.topics.merge(topic_id, target_topic_id)
+
+Set the avatar image for a topic::
+
+    # the avatar image can be passed as data (content of the file) or as a file
+    # object opened in binary mode
+    topic.avatar = open('path/to/file.png', 'rb')
+    topic.save()
+
+Remove the avatar image for a topic::
+
+    topic.avatar = ""
+    topic.save()
+

--- a/gitlab/utils.py
+++ b/gitlab/utils.py
@@ -188,6 +188,12 @@ def _transform_types(
 
         # if the type is FileAttribute we need to pass the data as file
         if isinstance(gitlab_attribute, types.FileAttribute) and transform_files:
+            # The GitLab API accepts mixed types
+            # (e.g. a file for avatar image or empty string for removing the avatar)
+            # So if string is empty, keep it in data dict
+            if isinstance(data[attr_name], str) and data[attr_name] == "":
+                continue
+
             key = gitlab_attribute.get_file_name(attr_name)
             files[attr_name] = (key, data.pop(attr_name))
             continue

--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -138,6 +138,34 @@ def test_group_labels(group):
     label.delete()
 
 
+def test_group_avatar_upload(gl, group, fixture_dir):
+    """Test uploading an avatar to a group."""
+    # Upload avatar
+    with open(fixture_dir / "avatar.png", "rb") as avatar_file:
+        group.avatar = avatar_file
+        group.save()
+
+    # Verify the avatar was set
+    updated_group = gl.groups.get(group.id)
+    assert updated_group.avatar_url is not None
+
+
+def test_group_avatar_remove(gl, group, fixture_dir):
+    """Test removing an avatar from a group."""
+    # First set an avatar
+    with open(fixture_dir / "avatar.png", "rb") as avatar_file:
+        group.avatar = avatar_file
+        group.save()
+
+    # Now remove the avatar
+    group.avatar = ""
+    group.save()
+
+    # Verify the avatar was removed
+    updated_group = gl.groups.get(group.id)
+    assert updated_group.avatar_url is None
+
+
 @pytest.mark.gitlab_premium
 @pytest.mark.xfail(reason="/ldap/groups endpoint not documented")
 def test_ldap_groups(gl):

--- a/tests/functional/api/test_projects.py
+++ b/tests/functional/api/test_projects.py
@@ -48,6 +48,29 @@ def test_project_members(user, project):
     member.delete()
 
 
+def test_project_avatar_upload(gl, project, fixture_dir):
+    """Test uploading an avatar to a project."""
+    with open(fixture_dir / "avatar.png", "rb") as avatar_file:
+        project.avatar = avatar_file
+        project.save()
+
+    updated_project = gl.projects.get(project.id)
+    assert updated_project.avatar_url is not None
+
+
+def test_project_avatar_remove(gl, project, fixture_dir):
+    """Test removing an avatar from a project."""
+    with open(fixture_dir / "avatar.png", "rb") as avatar_file:
+        project.avatar = avatar_file
+        project.save()
+
+    project.avatar = ""
+    project.save()
+
+    updated_project = gl.projects.get(project.id)
+    assert updated_project.avatar_url is None
+
+
 def test_project_badges(project):
     badge_image = "http://example.com"
     badge_link = "http://example/img.svg"

--- a/tests/functional/api/test_topics.py
+++ b/tests/functional/api/test_topics.py
@@ -31,3 +31,48 @@ def test_topics(gl, gitlab_version):
     assert merged_topic["id"] == topic2.id
 
     topic2.delete()
+
+
+def test_topic_avatar_upload(gl, fixture_dir):
+    """Test uploading an avatar to a topic."""
+
+    topic = gl.topics.create(
+        {
+            "name": "avatar-topic",
+            "description": "Topic with avatar",
+            "title": "Avatar Topic",
+        }
+    )
+
+    with open(fixture_dir / "avatar.png", "rb") as avatar_file:
+        topic.avatar = avatar_file
+        topic.save()
+
+    updated_topic = gl.topics.get(topic.id)
+    assert updated_topic.avatar_url is not None
+
+    topic.delete()
+
+
+def test_topic_avatar_remove(gl, fixture_dir):
+    """Test removing an avatar from a topic."""
+
+    topic = gl.topics.create(
+        {
+            "name": "avatar-topic-remove",
+            "description": "Remove avatar",
+            "title": "Remove Avatar",
+        }
+    )
+
+    with open(fixture_dir / "avatar.png", "rb") as avatar_file:
+        topic.avatar = avatar_file
+        topic.save()
+
+    topic.avatar = ""
+    topic.save()
+
+    updated_topic = gl.topics.get(topic.id)
+    assert updated_topic.avatar_url is None
+
+    topic.delete()


### PR DESCRIPTION
## Changes

When attempting to remove for example a [groups](https://docs.gitlab.com/api/groups/#remove-a-group-avatar), [projects](https://docs.gitlab.com/api/projects/#remove-a-project-avatar) or [topics](https://docs.gitlab.com/api/topics/#remove-a-topic-avatar) avatar by setting it to an empty string, the current implementation raises a validation error about unsupported file formats.

The solution is to add a special condition that checks if the value of a `FileAttribute` is an empty string. If so, it should remain in the `data` dictionary instead of being moved to the `files` dictionary.

Fixes #2933 

### Documentation and testing

- [X] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [X] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)