### PR TITLE
feat(api): add listing user contributed projects

### DIFF
--- a/docs/gl_objects/users.rst
+++ b/docs/gl_objects/users.rst
@@ -107,6 +107,10 @@ Get the followings of a user::
 
     user.following_users.list(get_all=True)
 
+List a user's contributed projects::
+
+    user.contributed_projects.list(get_all=True)
+
 List a user's starred projects::
 
     user.starred_projects.list(get_all=True)

--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -68,6 +68,8 @@ __all__ = [
     "UserMembershipManager",
     "UserProject",
     "UserProjectManager",
+    "UserContributedProject",
+    "UserContributedProjectManager",
 ]
 
 
@@ -182,6 +184,7 @@ class User(SaveMixin, ObjectDeleteMixin, RESTObject):
     memberships: UserMembershipManager
     personal_access_tokens: UserPersonalAccessTokenManager
     projects: UserProjectManager
+    contributed_projects: UserContributedProjectManager
     starred_projects: StarredProjectManager
     status: UserStatusManager
 
@@ -663,6 +666,17 @@ class UserProjectManager(ListMixin[UserProject], CreateMixin[UserProject]):
         else:
             path = f"/users/{self._from_parent_attrs['user_id']}/projects"
         return super().list(path=path, iterator=iterator, **kwargs)
+
+
+class UserContributedProject(RESTObject):
+    _id_attr = "id"
+    _repr_attr = "path_with_namespace"
+
+
+class UserContributedProjectManager(ListMixin[UserContributedProject]):
+    _path = "/users/{user_id}/contributed_projects"
+    _obj_cls = UserContributedProject
+    _from_parent_attrs = {"user_id": "id"}
 
 
 class StarredProject(RESTObject):

--- a/tests/unit/objects/test_users.py
+++ b/tests/unit/objects/test_users.py
@@ -7,7 +7,13 @@ https://docs.gitlab.com/ee/api/projects.html#list-projects-starred-by-a-user
 import pytest
 import responses
 
-from gitlab.v4.objects import StarredProject, User, UserMembership, UserStatus
+from gitlab.v4.objects import (
+    StarredProject,
+    User,
+    UserContributedProject,
+    UserMembership,
+    UserStatus,
+)
 
 from .test_projects import project_content
 
@@ -243,6 +249,19 @@ def resp_starred_projects():
 
 
 @pytest.fixture
+def resp_contributed_projects():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            method=responses.GET,
+            url="http://localhost/api/v4/users/1/contributed_projects",
+            json=[project_content],
+            content_type="application/json",
+            status=200,
+        )
+        yield rsps
+
+
+@pytest.fixture
 def resp_runner_create():
     with responses.RequestsMock() as rsps:
         rsps.add(
@@ -312,6 +331,12 @@ def test_list_followers(user, resp_followers_following):
     assert followers[0].id == 2
     assert isinstance(followings[0], User)
     assert followings[1].id == 4
+
+
+def test_list_contributed_projects(user, resp_contributed_projects):
+    projects = user.contributed_projects.list()
+    assert isinstance(projects[0], UserContributedProject)
+    assert projects[0].id == project_content["id"]
 
 
 def test_list_starred_projects(user, resp_starred_projects):


### PR DESCRIPTION
## Changes

This PR implements an endpoint for listing a user's contributed projects (related issue #3119):
```http
GET /users/:user_id/contributed_projects
```
GitLab docs: https://docs.gitlab.com/api/projects/#list-projects-a-user-has-contributed-to

**API usage**
```python
projects = user.contributed_projects.list()
```

**CLI usage**
```bash
gitlab -g something user-contributed-project list --user-id username
```

**Modified files:**
* "docs/gl_objects/users.rst" - explain the added method.
* "gitlab/v4/objects/users.py" - the API implementation.
* "tests/unit/objects/test_users.py" - add a unit test

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)
