### PR TITLE
feat(api): pipeline inputs support (#3194)

### DIFF
--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -429,6 +429,7 @@ class Project(
         ref: str,
         token: str,
         variables: dict[str, Any] | None = None,
+        inputs: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> ProjectPipeline:
         """Trigger a CI build.
@@ -439,6 +440,7 @@ class Project(
             ref: Commit to build; can be a branch name or a tag
             token: The trigger token
             variables: Variables passed to the build script
+            inputs: Inputs passed to the build script
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -447,7 +449,12 @@ class Project(
         """
         variables = variables or {}
         path = f"/projects/{self.encoded_id}/trigger/pipeline"
-        post_data = {"ref": ref, "token": token, "variables": variables}
+        post_data = {
+            "ref": ref,
+            "token": token,
+            "variables": variables,
+            "inputs": inputs,
+        }
         attrs = self.manager.gitlab.http_post(path, post_data=post_data, **kwargs)
         if TYPE_CHECKING:
             assert isinstance(attrs, dict)


### PR DESCRIPTION


## Changes

Add support to trigger a pipeline with inputs. Inputs have recently been officially supported by gitlab

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
