### PR TITLE
docs: update CONTRIBUTING.rst with policy on issue management

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,16 +20,56 @@ jobs:
           stale-issue-label: "stale"
           stale-pr-label: "stale"
 
-          any-of-labels: 'need info,Waiting for response,stale'
+          # If an issue/PR has an assignee it won't be marked as stale
+          exempt-all-assignees: true
           stale-issue-message: >
-            This issue was marked stale because it has been open 60 days with no
-            activity. Please remove the stale label or comment on this issue. Otherwise,
-            it will be closed in 15 days.
+            This issue was marked stale because it has been open 60 days with
+            no activity. Please remove the stale label or comment on this
+            issue. Otherwise, it will be closed in 15 days.
+
+            As an open-source project, we rely on community contributions to
+            address many of the reported issues. Without a proposed fix or
+            active work towards a solution it is our policy to close inactive
+            issues. This is documented in CONTRIBUTING.rst
+
+            **How to keep this issue open:**
+            * If you are still experiencing this issue and are willing to
+            investigate a fix, please comment and let us know.
+            * If you (or someone else) can propose a pull request with a
+            solution, that would be fantastic.
+            * Any significant update or active discussion indicating progress
+            will also prevent closure.
+
+            We value your input. If you can help provide a fix, we'd be happy
+            to keep this issue open and support your efforts.
+
           days-before-issue-stale: 60
           days-before-issue-close: 15
           close-issue-message: >
-            This issue was closed because it has been marked stale for 15 days with no
-            activity. If this issue is still valid, please re-open.
+            This issue was closed because it has been marked stale for 15 days
+            with no activity.
+
+            This open-source project relies on community contributions, and
+            while we value all feedback, we have a limited capacity to address
+            every issue without a clear path forward.
+
+            Currently, this issue hasn't received a proposed fix, and there
+            hasn't been recent active discussion indicating someone is planning
+            to work on it. To maintain a manageable backlog and focus our
+            efforts, we will be closing this issue for now.
+
+            **This doesn't mean the issue isn't valid or important.** If you or
+            anyone else in the community is willing to investigate and propose
+            a solution (e.g., by submitting a pull request), please do.
+
+            We believe that those who feel a bug is important enough to fix
+            should ideally be part of the solution. Your contributions are
+            highly welcome.
+
+            Thank you for your understanding and potential future
+            contributions.
+
+            This is documented in CONTRIBUTING.rst
 
           stale-pr-message: >
             This Pull Request (PR) was marked stale because it has been open 90 days
@@ -40,4 +80,3 @@ jobs:
           close-pr-message: >
             This PR was closed because it has been marked stale for 15 days with no
             activity. If this PR is still valid, please re-open.
-

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -9,6 +9,42 @@ You can contribute to the project in multiple ways:
 * Add unit and functional tests
 * Everything else you can think of
 
+Issue Management and Our Approach to Contributions
+--------------------------------------------------
+
+We value every contribution and bug report. However, as an open-source project
+with limited maintainer resources, we rely heavily on the community to help us
+move forward.
+
+**Our Policy on Inactive Issues:**
+
+To keep our issue tracker manageable and focused on actionable items, we have
+the following approach:
+
+* **We encourage reporters to propose solutions:** If you report an issue, we
+  strongly encourage you to also think about how it might be fixed and try to
+  implement that fix.
+* **Community interest is key:** Issues that garner interest from the community
+  (e.g., multiple users confirming, discussions on solutions, offers to help)
+  are more likely to be addressed.
+* **Closing inactive issues:** If an issue report doesn't receive a proposed
+  fix from the original reporter or anyone else in the community, and there's
+  no active discussion or indication that someone is willing to work on it
+  after a reasonable period, it may be closed.
+
+  * When closing such an issue, we will typically leave a comment explaining
+    that it's being closed due to inactivity and a lack of a proposed fix.
+
+* **Reopening issues:** This doesn't mean the issue isn't valid. If you (or
+  someone else) are interested in working on a fix for a closed issue, please
+  comment on the issue. We are more than happy to reopen it and discuss your
+  proposed pull request or solution. We greatly appreciate it when community
+  members take ownership of fixing issues they care about.
+
+We believe this approach helps us focus our efforts effectively and empowers
+the community to contribute directly to the areas they are most passionate
+about.
+
 Development workflow
 --------------------
 


### PR DESCRIPTION
Also update the `stale` job to close issues with no activity, unless they are assigned to someone.