### PR TITLE
feat(users): implement support for 'admins' in administrators 'list'

### DIFF
--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -410,6 +410,7 @@ class UserManager(CRUDMixin[User]):
         "custom_attributes",
         "status",
         "two_factor",
+        "admins",
     )
     _create_attrs = RequiredOptional(
         optional=(


### PR DESCRIPTION
## Changes

Implement support `admins` in `list` : https://docs.gitlab.com/api/users/#as-an-administrator

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

```bash
gitlab user list --admins true
gitlab user list --admins false
```

* Documentation automatically generated and new key matches `admins` sources
* No test added as most other settings are not implemented in tests/functional/cli/test_cli_v4.py
