### PR TITLE
feat(graphql): update to gql 4.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: pylint
         additional_dependencies:
           - argcomplete==2.0.0
-          - gql==3.5.0
+          - gql==4.0.0
           - httpx==0.27.2
           - pytest==7.4.2
           - requests==2.28.1
@@ -37,7 +37,7 @@ repos:
       - id: mypy
         args: []
         additional_dependencies:
-          - gql==3.5.0
+          - gql==4.0.0
           - httpx==0.27.2
           - jinja2==3.1.2
           - pytest==7.4.2

--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -18,7 +18,6 @@ from gitlab import _backends, utils
 try:
     import gql
     import gql.transport.exceptions
-    import graphql
     import httpx
 
     from ._backends.graphql import GitlabAsyncTransport, GitlabTransport
@@ -1350,7 +1349,7 @@ class GraphQL(_BaseGraphQL):
     def __exit__(self, *args: Any) -> None:
         self._http_client.close()
 
-    def execute(self, request: str | graphql.Source, *args: Any, **kwargs: Any) -> Any:
+    def execute(self, request: str, *args: Any, **kwargs: Any) -> Any:
         parsed_document = self._gql(request)
         retry = utils.Retry(
             max_retries=self._max_retries,
@@ -1420,9 +1419,7 @@ class AsyncGraphQL(_BaseGraphQL):
     async def __aexit__(self, *args: Any) -> None:
         await self._http_client.aclose()
 
-    async def execute(
-        self, request: str | graphql.Source, *args: Any, **kwargs: Any
-    ) -> Any:
+    async def execute(self, request: str, *args: Any, **kwargs: Any) -> Any:
         parsed_document = self._gql(request)
         retry = utils.Retry(
             max_retries=self._max_retries,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 autocompletion = ["argcomplete>=1.10.0,<3"]
 yaml = ["PyYaml>=6.0.1"]
-graphql = ["gql[httpx]>=3.5.0,<4"]
+graphql = ["gql[httpx]>=3.5.0,<5"]
 
 [project.scripts]
 gitlab = "gitlab.cli:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gql==3.5.3
+gql==4.0.0
 httpx==0.28.1
 requests==2.32.4
 requests-toolbelt==1.0.0


### PR DESCRIPTION
BREAKING CHANGE: GraphQL.execute() no longer accepts graphql.Source
