### PR TITLE
feat(users): implement 'skip_confirmation' in users 'emails' creation

### DIFF
--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -502,7 +502,9 @@ class UserEmailManager(
     _path = "/users/{user_id}/emails"
     _obj_cls = UserEmail
     _from_parent_attrs = {"user_id": "id"}
-    _create_attrs = RequiredOptional(required=("email",))
+    _create_attrs = RequiredOptional(
+        required=("email",), optional=("skip_confirmation",)
+    )
 
 
 class UserActivities(RESTObject):


### PR DESCRIPTION
## Changes

- Implement missing argument in user-email creation : https://docs.gitlab.com/api/user_email_addresses/#add-an-email-address-for-a-user

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

>

- Documentation automatically generated and new key matches admins sources
- No test added as most other settings are not implemented in tests/functional/cli/test_cli_v4.py