### PR TITLE
ci(gitlab-ci): create 'codestyle' job for GitLab CI/CD and local usage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,24 @@
 image: python:3.14
 
 stages:
+  - prepare
   - build
   - deploy
   - promote
+
+lint:
+  stage: prepare
+  script:
+    # Configurations
+    - set +x
+    # Run lint workflows
+    - |
+      grep 'run: ' ./.github/workflows/lint.yml | sed 's/.* run: //g' | while read -r command; do
+        echo ' '
+        echo "- ${command}"
+        echo ' '
+        sh -c "${command}" || exit 1
+      done
 
 build-images:
   stage: build
@@ -27,7 +42,7 @@ build-images:
 
 deploy-images:
   stage: deploy
-  image: 
+  image:
     name: mplatform/manifest-tool:alpine-v2.0.4@sha256:38b399ff66f9df247af59facceb7b60e2cd01c2d649aae318da7587efb4bbf87
     entrypoint: [""]
   script:


### PR DESCRIPTION
## Changes

- Create 'codestyle' job for GitLab CI/CD and local usage

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

---

* Thought about it due to #3265,
  where I ran the codestyle documented functions from an Alpine container,  
  but took a different approach here to match 100% the GitHub workflow (for seamless maintenance reasons),  
  meant for GitLab CI/CD forks / rehostes, and if interested for local usage ([gcil](https://radiandevcore.gitlab.io/tools/gcil/))

* PR denial is OK, will probably keep it on my fork anyways for future patch PR checks