### PR TITLE
docs(pull_mirror): fix incorrect start() method usage example

### DIFF
--- a/docs/gl_objects/pull_mirror.rst
+++ b/docs/gl_objects/pull_mirror.rst
@@ -33,6 +33,6 @@ Update an existing remote mirror's attributes::
     mirror.only_protected_branches = True
     mirror.save()
 
-Start an sync of the pull mirror::
+Start a sync of the pull mirror::
 
-  mirror.start()
+  project.pull_mirror.start()


### PR DESCRIPTION
The documentation incorrectly showed calling start() on the ProjectPullMirror object (mirror.start()), but the method only exists on the ProjectPullMirrorManager. Updated the example to show the correct usage: project.pull_mirror.start().

Fixes #3269