### PR TITLE
ci(stale): fix permission for stale action and allow manual run

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,10 +3,12 @@ name: 'Close stale issues and PRs'
 on:
   schedule:
     - cron: '30 1 * * *'
+  workflow_dispatch: # For manual runs
 
 permissions:
   issues: write
   pull-requests: write
+  actions: write
 
 concurrency:
   group: lock


### PR DESCRIPTION
As documented at: https://github.com/actions/stale it requires the
"actions: write" permission.

Also allow manually running the stale action.

