### PR TITLE
chore(deps): upgrade coverage to 7.11.0 for Python > 3.9

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,8 @@
 -r requirements.txt
 anyio==4.11.0
 build==1.3.0
-coverage==7.10.7
+coverage==7.10.7 ; python_version <= '3.9'
+coverage==7.11.0 ; python_version > '3.9'
 pytest-console-scripts==1.4.1
 pytest-cov==7.0.0
 pytest-github-actions-annotate-failures==0.3.0


### PR DESCRIPTION
For Python versions newer than 3.9 use 'coverage==7.11.0'

For 3.9 and older continue to use 'coverage==7.10.7'
