### PR TITLE
feat!: drop Python 3.9 support and add Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python:
-          - version: "3.9"
-            toxenv: py39,smoke
           - version: "3.10"
             toxenv: py310,smoke
           - version: "3.11"
@@ -36,17 +34,17 @@ jobs:
             toxenv: py312,smoke
           - version: "3.13"
             toxenv: py313,smoke
-          - version: "3.14.0-alpha - 3.14" # SemVer's version range syntax
+          - version: "3.14"
             toxenv: py314,smoke
         include:
           - os: macos-latest
             python:
-              version: "3.13"
-              toxenv: py313,smoke
+              version: "3.14"
+              toxenv: py314,smoke
           - os: windows-latest
             python:
-              version: "3.13"
-              toxenv: py313,smoke
+              version: "3.14"
+              toxenv: py314,smoke
     steps:
       - uses: actions/checkout@v5.0.0
       - name: Set up Python ${{ matrix.python.version }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.13"
 
 sphinx:
   configuration: docs/conf.py

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Features
 Installation
 ------------
 
-As of 5.0.0, ``python-gitlab`` is compatible with Python 3.9+.
+As of 7.0.0, ``python-gitlab`` is compatible with Python 3.10+.
 
 Use ``pip`` to install the latest stable version of ``python-gitlab``:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ maintainers = [
     {name = "Nejc Habjan", email="nejc.habjan@siemens.com"},
     {name = "Roger Meier", email="r.meier@siemens.com"}
 ]
-requires-python = ">=3.9.0"
+requires-python = ">=3.10.0"
 dependencies = [
     "requests>=2.32.0",
     "requests-toolbelt>=1.0.0",
@@ -30,11 +30,11 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 keywords = ["api", "client", "gitlab", "python", "python-gitlab", "wrapper"]
 license = {text = "LGPL-3.0-or-later"}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,8 +1,7 @@
 -r requirements.txt
 anyio==4.11.0
 build==1.3.0
-coverage==7.10.7 ; python_version <= '3.9'
-coverage==7.11.0 ; python_version > '3.9'
+coverage==7.11.0
 pytest-console-scripts==1.4.1
 pytest-cov==7.0.0
 pytest-github-actions-annotate-failures==0.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,14 @@
 minversion = 4.0
 skipsdist = True
 skip_missing_interpreters = True
-envlist = py313,py312,py311,py310,py39,black,isort,flake8,mypy,twine-check,cz,pylint
+envlist = py314,py313,py312,py311,py310,black,isort,flake8,mypy,twine-check,cz,pylint
 
 # NOTE(jlvillal): To use a label use the `-m` flag.
 # For example to run the `func` label group of environments do:
 #   tox -m func
 labels =
     lint = black,isort,flake8,mypy,pylint,cz
-    unit = py313,py312,py311,py310,py39,py38
+    unit = py314,py313,py312,py311,py310
 # func is the functional tests. This is very time consuming.
     func = cli_func_v4,api_func_v4
 


### PR DESCRIPTION
Python 3.9 is End-of-Life (EOL) as of 2025-10 as stated in https://devguide.python.org/versions/ and
https://peps.python.org/pep-0596/#lifespan

By dropping support for Python 3.9 and requiring Python 3.10 or higher it allows python-gitlab to take advantage of new features in Python 3.10, which are documented at:
https://docs.python.org/3/whatsnew/3.10.html

Also mark Python 3.14 as officially supported as it has been released.

Closes: https://github.com/python-gitlab/python-gitlab/issues/3285

BREAKING CHANGE: As of python-gitlab 7.0.0, Python 3.9 is no longer supported. Python 3.10 or higher is required.