### PR TITLE
ci(release): use the correct token for publish to GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,4 @@ jobs:
       uses: python-semantic-release/publish-action@v10.4.1
       if: steps.release.outputs.released == 'true'
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.RELEASE_GITHUB_TOKEN }}


### PR DESCRIPTION
For the: "Publish package distributions to GitHub Releases" use the correct `secrets.RELEASE_GITHUB_TOKEN`. Before it was using `secrets.GITHUB_TOKEN`

The other steps are already using `secrets.RELEASE_GITHUB_TOKEN`

Closes: https://github.com/python-gitlab/python-gitlab/issues/3288