### PR TITLE
fix: file save start_branch as a body attribute

### DIFF
--- a/gitlab/v4/objects/files.py
+++ b/gitlab/v4/objects/files.py
@@ -29,6 +29,7 @@ class ProjectFile(SaveMixin, ObjectDeleteMixin, RESTObject):
     file_path: str
     manager: ProjectFileManager
     content: str  # since the `decode()` method uses `self.content`
+    start_branch: str | None = None
 
     def decode(self) -> bytes:
         """Returns the decoded content of the file.
@@ -41,7 +42,11 @@ class ProjectFile(SaveMixin, ObjectDeleteMixin, RESTObject):
     # NOTE(jlvillal): Signature doesn't match SaveMixin.save() so ignore
     # type error
     def save(  # type: ignore[override]
-        self, branch: str, commit_message: str, **kwargs: Any
+        self,
+        branch: str,
+        commit_message: str,
+        start_branch: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """Save the changes made to the file to the server.
 
@@ -50,6 +55,7 @@ class ProjectFile(SaveMixin, ObjectDeleteMixin, RESTObject):
         Args:
             branch: Branch in which the file will be updated
             commit_message: Message to send with the commit
+            start_branch: Name of the branch to start the new branch from
             **kwargs: Extra options to send to the server (e.g. sudo)
 
         Raises:
@@ -58,6 +64,7 @@ class ProjectFile(SaveMixin, ObjectDeleteMixin, RESTObject):
         """
         self.branch = branch
         self.commit_message = commit_message
+        self.start_branch = start_branch
         self.file_path = utils.EncodedId(self.file_path)
         super().save(**kwargs)
 


### PR DESCRIPTION
Passing `start_branch` as kwargs results in it being passed as query argument to the API:

```
send: b'PUT /api/v4/projects/12345678/repository/files/readme.txt?start_branch=main

send: b'{"file_path": "readme.txt", "branch": "new_branch", "content":
"Modified contents", "commit_message": "File was modified for this new
branch"}'
```

which results in error being returned:

```
{"message":"You can only create or edit files when you are on a branch"}
```

It should instead be sent a body attribute, which succeeds in creating the branch during the save.

To be sent as body attribute it must be specified as concrete function argument and class attribute instead of just using kwargs

Closes: #3318

<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

<!-- Remove this comment and describe your changes here. -->

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
