### PR TITLE
fix: actually define project repr_attr

### DIFF
--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -178,6 +178,8 @@ class Project(
     _repr_attr = "path_with_namespace"
     _upload_path = "/projects/{id}/uploads"
 
+    path_with_namespace: str
+
     access_tokens: ProjectAccessTokenManager
     accessrequests: ProjectAccessRequestManager
     additionalstatistics: ProjectAdditionalStatisticsManager


### PR DESCRIPTION
While `_repr_attr=` is given to specify the attribute to use to repr the object, that object attribute itself is not actually defined, so tools like PyRight/MyPy complain that:

```
Type of "path_with_namespace" is unknown
```
