### PR TITLE
chore(precommit): update dependency black to v26

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 25.12.0
+    rev: 26.1.0
     hooks:
       - id: black
   - repo: https://github.com/commitizen-tools/commitizen


### PR DESCRIPTION
Prior commit 39975d5cdae48e2f38cffa58057a4469c855e90e updated black to v26 but did not update `.pre-commit-config.yaml`. This resolves that.