### PR TITLE
feat(api): add support for sort filter in runner jobs

### DIFF
--- a/gitlab/v4/objects/runners.py
+++ b/gitlab/v4/objects/runners.py
@@ -38,7 +38,7 @@ class RunnerJobManager(ListMixin[RunnerJob]):
     _path = "/runners/{runner_id}/jobs"
     _obj_cls = RunnerJob
     _from_parent_attrs = {"runner_id": "id"}
-    _list_filters = ("status",)
+    _list_filters = ("status", "sort")
 
 
 class Runner(SaveMixin, ObjectDeleteMixin, RESTObject):


### PR DESCRIPTION
This commits allows users to configure the 'sort' filter as defined in [1], so that one can fetch the most recent jobs first.

[1]: https://docs.gitlab.com/api/runners/#list-all-jobs-processed-by-a-runner

<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

Added support for `sort` filter when fetching runner jobs.

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
