### PR TITLE
feat(api): add support for order_by filter in runner jobs

### DIFF
--- a/gitlab/v4/objects/runners.py
+++ b/gitlab/v4/objects/runners.py
@@ -38,7 +38,7 @@ class RunnerJobManager(ListMixin[RunnerJob]):
     _path = "/runners/{runner_id}/jobs"
     _obj_cls = RunnerJob
     _from_parent_attrs = {"runner_id": "id"}
-    _list_filters = ("status", "sort")
+    _list_filters = ("status", "order_by", "sort")
 
 
 class Runner(SaveMixin, ObjectDeleteMixin, RESTObject):


### PR DESCRIPTION
This commits adds to the work done in [1]. After reading the docs [2] again, you must define `order_by` when using `sort`, so this commits adds this as an additional filter.

[1]: https://github.com/python-gitlab/python-gitlab/pull/3336
[2]: https://docs.gitlab.com/api/runners/#list-all-jobs-processed-by-a-runner

## Changes

Added support for `order_by` filter when fetching runner jobs.

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
