### PR TITLE
fix(types): add explicit submodule import for pyright compatibility

### DIFF
--- a/gitlab/v4/objects/repositories.py
+++ b/gitlab/v4/objects/repositories.py
@@ -17,6 +17,8 @@ from gitlab import types, utils
 
 if TYPE_CHECKING:
     # When running mypy we use these as the base classes
+    import gitlab.base
+
     _RestObjectBase = gitlab.base.RESTObject
 else:
     _RestObjectBase = object


### PR DESCRIPTION
## Summary

- Add `import gitlab.base` inside the `TYPE_CHECKING` block in `repositories.py` so that pyright can resolve `gitlab.base.RESTObject`

Without the explicit import, pyright cannot resolve the submodule access via the parent package — implicit submodule access is a runtime loader side effect that type checkers don't model ([pyright docs](https://docs.basedpyright.com/latest/usage/import-statements/#loader-side-effects)). This causes `_RestObjectBase` to be `Unknown`, which propagates through `RepositoryMixin` into `Project` and other classes that inherit it, producing `reportUnknownMemberType` / `reportUnknownVariableType` / `reportUnknownArgumentType` warnings.

Note: `gitlab/mixins.py` has the same pattern but already works correctly because it uses `from gitlab import base` and then `base.RESTObject`.

Fixes #3342

## Test plan

- [x] Verified with basedpyright on a real project: previously-required `# pyright: ignore` suppression comments become unnecessary after this fix
- [ ] Existing CI tests pass (no runtime impact — change is inside `TYPE_CHECKING` block only)