### PR TITLE
feat(api): add support for project feature flags and feature flag user lists

### DIFF
--- a/docs/api-objects.rst
+++ b/docs/api-objects.rst
@@ -24,7 +24,7 @@ API examples
    gl_objects/environments
    gl_objects/events
    gl_objects/epics
-   gl_objects/features
+   gl_objects/gitlab_features
    gl_objects/geo_nodes
    gl_objects/groups
    gl_objects/group_access_tokens
@@ -49,6 +49,8 @@ API examples
    gl_objects/pipelines_and_jobs
    gl_objects/projects
    gl_objects/project_access_tokens
+   gl_objects/project_feature_flags
+   gl_objects/project_feature_flag_user_lists
    gl_objects/protected_branches
    gl_objects/protected_container_repositories
    gl_objects/protected_environments

--- a/docs/gl_objects/gitlab_features.rst
+++ b/docs/gl_objects/gitlab_features.rst
@@ -1,6 +1,11 @@
-##############
-Features flags
-##############
+################################
+GitLab Development Feature Flags
+################################
+
+.. note::
+
+   This API is for managing GitLab's internal development feature flags and requires administrator access.
+   For project-level feature flags, see :doc:`project_feature_flags`.
 
 Reference
 ---------

--- a/docs/gl_objects/project_feature_flag_user_lists.rst
+++ b/docs/gl_objects/project_feature_flag_user_lists.rst
@@ -1,0 +1,51 @@
+###############################
+Project Feature Flag User Lists
+###############################
+
+Reference
+---------
+
+* v4 API:
+
+  + :class:`gitlab.v4.objects.ProjectFeatureFlagUserList`
+  + :class:`gitlab.v4.objects.ProjectFeatureFlagUserListManager`
+  + :attr:`gitlab.v4.objects.Project.feature_flags_user_lists`
+
+* GitLab API: https://docs.gitlab.com/api/feature_flag_user_lists
+
+Examples
+--------
+
+List user lists::
+
+    user_lists = project.feature_flags_user_lists.list()
+
+Get a user list::
+
+    user_list = project.feature_flags_user_lists.get(list_iid)
+
+Create a user list::
+
+    user_list = project.feature_flags_user_lists.create({
+        'name': 'my_user_list',
+        'user_xids': 'user1,user2,user3'
+    })
+
+Update a user list::
+
+    user_list.name = 'updated_list_name'
+    user_list.user_xids = 'user1,user2'
+    user_list.save()
+
+Delete a user list::
+
+    user_list.delete()
+
+Search for a user list::
+
+    user_lists = project.feature_flags_user_lists.list(search='my_list')
+
+See also
+--------
+
+* :doc:`project_feature_flags`

--- a/docs/gl_objects/project_feature_flags.rst
+++ b/docs/gl_objects/project_feature_flags.rst
@@ -1,0 +1,63 @@
+#####################
+Project Feature Flags
+#####################
+
+Reference
+---------
+
+* v4 API:
+
+  + :class:`gitlab.v4.objects.ProjectFeatureFlag`
+  + :class:`gitlab.v4.objects.ProjectFeatureFlagManager`
+  + :attr:`gitlab.v4.objects.Project.feature_flags`
+
+* GitLab API: https://docs.gitlab.com/api/feature_flags
+
+Examples
+--------
+
+List feature flags::
+
+    flags = project.feature_flags.list()
+
+Get a feature flag::
+
+    flag = project.feature_flags.get('my_feature_flag')
+
+Create a feature flag::
+
+    flag = project.feature_flags.create({'name': 'my_feature_flag', 'version': 'new_version_flag'})
+
+Create a feature flag with strategies::
+
+    flag = project.feature_flags.create({
+        'name': 'my_complex_flag',
+        'version': 'new_version_flag',
+        'strategies': [{
+            'name': 'userWithId',
+            'parameters': {'userIds': 'user1,user2'}
+        }]
+    })
+
+Update a feature flag::
+
+    flag.description = 'Updated description'
+    flag.save()
+
+Rename a feature flag::
+
+    # You can rename a flag by changing its name attribute and calling save()
+    flag.name = 'new_flag_name'
+    flag.save()
+
+    # Alternatively, you can use the manager's update method
+    project.feature_flags.update('old_flag_name', {'name': 'new_flag_name'})
+
+Delete a feature flag::
+
+    flag.delete()
+
+See also
+--------
+
+* :doc:`project_feature_flag_user_lists`

--- a/docs/gl_objects/projects.rst
+++ b/docs/gl_objects/projects.rst
@@ -409,6 +409,44 @@ Search projects by custom attribute::
     project.customattributes.set('type', 'internal')
     gl.projects.list(custom_attributes={'type': 'internal'}, get_all=True)
 
+Project feature flags
+=====================
+
+Reference
+---------
+
+* v4 API:
+
+  + :class:`gitlab.v4.objects.ProjectFeatureFlag`
+  + :class:`gitlab.v4.objects.ProjectFeatureFlagManager`
+  + :attr:`gitlab.v4.objects.Project.feature_flags`
+
+* GitLab API: https://docs.gitlab.com/api/feature_flags
+
+Examples
+--------
+
+See :doc:`project_feature_flags`.
+
+Project feature flag user lists
+===============================
+
+Reference
+---------
+
+* v4 API:
+
+  + :class:`gitlab.v4.objects.ProjectFeatureFlagUserList`
+  + :class:`gitlab.v4.objects.ProjectFeatureFlagUserListManager`
+  + :attr:`gitlab.v4.objects.Project.feature_flags_user_lists`
+
+* GitLab API: https://docs.gitlab.com/api/feature_flag_user_lists
+
+Examples
+--------
+
+See :doc:`project_feature_flag_user_lists`.
+
 Project files
 =============
 

--- a/gitlab/types.py
+++ b/gitlab/types.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 from typing import Any, TYPE_CHECKING
+
+from gitlab import exceptions
 
 
 @dataclasses.dataclass(frozen=True)
@@ -36,6 +39,13 @@ class RequiredOptional:
 
 
 class GitlabAttribute:
+    # Used in utils._transform_types() to decide if we should call get_for_api()
+    # on the attribute when transform_data is False (e.g. for POST/PUT/PATCH).
+    #
+    # This allows us to force transformation of data even when sending JSON bodies,
+    # which is useful for types like CommaSeparatedStringAttribute.
+    transform_in_body = False
+
     def __init__(self, value: Any = None) -> None:
         self._value = value
 
@@ -47,6 +57,16 @@ class GitlabAttribute:
 
     def get_for_api(self, *, key: str) -> tuple[str, Any]:
         return (key, self._value)
+
+
+class JsonAttribute(GitlabAttribute):
+    def set_from_cli(self, cli_value: str) -> None:
+        try:
+            self._value = json.loads(cli_value)
+        except (ValueError, TypeError) as e:
+            raise exceptions.GitlabParsingError(
+                f"Could not parse JSON data: {e}"
+            ) from e
 
 
 class _ListArrayAttribute(GitlabAttribute):
@@ -82,9 +102,23 @@ class ArrayAttribute(_ListArrayAttribute):
 
 
 class CommaSeparatedListAttribute(_ListArrayAttribute):
-    """For values which are sent to the server as a Comma Separated Values
-    (CSV) string.  We allow them to be specified as a list and we convert it
-    into a CSV"""
+    """
+    For values which are sent to the server as a Comma Separated Values (CSV) string
+    in query parameters (GET), but as a list/array in JSON bodies (POST/PUT).
+    """
+
+
+class CommaSeparatedStringAttribute(_ListArrayAttribute):
+    """
+    For values which are sent to the server as a Comma Separated Values (CSV) string.
+    Unlike CommaSeparatedListAttribute, this type ensures the value is converted
+    to a string even in JSON bodies (POST/PUT requests).
+    """
+
+    # Used in utils._transform_types() to ensure the value is converted to a string
+    # via get_for_api() even when transform_data is False (e.g. for POST/PUT/PATCH).
+    # This is needed because some APIs require a CSV string instead of a JSON array.
+    transform_in_body = True
 
 
 class LowercaseStringAttribute(GitlabAttribute):

--- a/gitlab/utils.py
+++ b/gitlab/utils.py
@@ -198,7 +198,15 @@ def _transform_types(
             files[attr_name] = (key, data.pop(attr_name))
             continue
 
-        if not transform_data:
+        # If transform_data is False, it means we are preparing data for a JSON body
+        # (POST/PUT/PATCH). In this case, we normally skip transformation because
+        # most types (like ArrayAttribute) only need transformation for query
+        # parameters (GET).
+        #
+        # However, some types (like CommaSeparatedStringAttribute) need to be
+        # transformed even in JSON bodies (e.g. converting a list to a CSV string).
+        # The 'transform_in_body' flag on the attribute class controls this behavior.
+        if not transform_data and not gitlab_attribute.transform_in_body:
             continue
 
         if isinstance(gitlab_attribute, types.GitlabAttribute):

--- a/gitlab/v4/objects/__init__.py
+++ b/gitlab/v4/objects/__init__.py
@@ -24,6 +24,8 @@ from .environments import *
 from .epics import *
 from .events import *
 from .export_import import *
+from .feature_flag_user_lists import *
+from .feature_flags import *
 from .features import *
 from .files import *
 from .geo_nodes import *

--- a/gitlab/v4/objects/feature_flag_user_lists.py
+++ b/gitlab/v4/objects/feature_flag_user_lists.py
@@ -1,0 +1,27 @@
+"""
+GitLab API:
+https://docs.gitlab.com/api/feature_flag_user_lists
+"""
+
+from __future__ import annotations
+
+from gitlab import types
+from gitlab.base import RESTObject
+from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
+from gitlab.types import RequiredOptional
+
+__all__ = ["ProjectFeatureFlagUserList", "ProjectFeatureFlagUserListManager"]
+
+
+class ProjectFeatureFlagUserList(SaveMixin, ObjectDeleteMixin, RESTObject):
+    _id_attr = "iid"
+
+
+class ProjectFeatureFlagUserListManager(CRUDMixin[ProjectFeatureFlagUserList]):
+    _path = "/projects/{project_id}/feature_flags_user_lists"
+    _obj_cls = ProjectFeatureFlagUserList
+    _from_parent_attrs = {"project_id": "id"}
+    _create_attrs = RequiredOptional(required=("name", "user_xids"))
+    _update_attrs = RequiredOptional(optional=("name", "user_xids"))
+    _list_filters = ("search",)
+    _types = {"user_xids": types.CommaSeparatedStringAttribute}

--- a/gitlab/v4/objects/feature_flags.py
+++ b/gitlab/v4/objects/feature_flags.py
@@ -1,0 +1,106 @@
+"""
+GitLab API:
+https://docs.gitlab.com/api/feature_flags
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gitlab import types, utils
+from gitlab.base import RESTObject
+from gitlab.mixins import CRUDMixin, ObjectDeleteMixin, SaveMixin
+from gitlab.types import RequiredOptional
+
+__all__ = ["ProjectFeatureFlag", "ProjectFeatureFlagManager"]
+
+
+class ProjectFeatureFlag(SaveMixin, ObjectDeleteMixin, RESTObject):
+    _id_attr = "name"
+    manager: ProjectFeatureFlagManager
+
+    def _get_save_url_id(self) -> str | int | None:
+        """Get the ID used to construct the API URL for the save operation.
+
+        For renames, this must be the *original* name of the flag. For other
+        updates, it is the current name.
+        """
+        if self._id_attr in self._updated_attrs:
+            # If the name is being changed, use the original name for the URL.
+            obj_id = self._attrs.get(self._id_attr)
+            if isinstance(obj_id, str):
+                return utils.EncodedId(obj_id)
+            return obj_id
+        return self.encoded_id
+
+    def save(self, **kwargs: Any) -> dict[str, Any] | None:
+        """Save the changes made to the object to the server.
+
+        This is the standard method to use when updating a feature flag object
+        that you have already retrieved.
+
+        It is overridden here to correctly handle renaming. When `name` is
+        changed, the API requires the *original* name in the URL, and this
+        method provides it.
+
+        Args:
+            **kwargs: Extra options to send to the server (e.g. sudo)
+
+        Returns:
+            The new object data (*not* a RESTObject)
+
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabUpdateError: If the server cannot perform the request
+        """
+        updated_data = self._get_updated_data()
+        if not updated_data:
+            return None
+
+        obj_id = self._get_save_url_id()
+        server_data = self.manager.update(obj_id, updated_data, **kwargs)
+        self._update_attrs(server_data)
+        return server_data
+
+
+class ProjectFeatureFlagManager(CRUDMixin[ProjectFeatureFlag]):
+    _path = "/projects/{project_id}/feature_flags"
+    _obj_cls = ProjectFeatureFlag
+    _from_parent_attrs = {"project_id": "id"}
+    _create_attrs = RequiredOptional(
+        required=("name",), optional=("version", "description", "active", "strategies")
+    )
+    _update_attrs = RequiredOptional(
+        # new_name is used for renaming via CLI and mapped to 'name' in update()
+        optional=("name", "new_name", "description", "active", "strategies")
+    )
+    _list_filters = ("scope",)
+    _types = {"strategies": types.JsonAttribute}
+
+    def update(
+        self,
+        id: str | int | None = None,
+        new_data: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Update a Project Feature Flag.
+
+        This is a lower-level method called by `ProjectFeatureFlag.save()` and
+        is also used directly by the CLI.
+
+        The `new_name` parameter is a special case to support renaming via the
+        CLI (`--new-name`). It is converted to the `name` parameter that the
+        GitLab API expects in the request body.
+
+        Args:
+            id: The current name of the feature flag.
+            new_data: The dictionary of attributes to update.
+            **kwargs: Extra options to send to the server (e.g. sudo)
+        """
+        # Avoid mutating the caller-provided new_data dict by working on a copy.
+        data = dict(new_data or {})
+        # When used via CLI, we have 'new_name' to distinguish from the ID 'name'.
+        # When used via .save(), the object passes 'name' directly in new_data.
+        if "new_name" in data:
+            data["name"] = data.pop("new_name")
+        return super().update(id, data, **kwargs)

--- a/gitlab/v4/objects/projects.py
+++ b/gitlab/v4/objects/projects.py
@@ -49,6 +49,8 @@ from .environments import (  # noqa: F401
 )
 from .events import ProjectEventManager  # noqa: F401
 from .export_import import ProjectExportManager, ProjectImportManager  # noqa: F401
+from .feature_flag_user_lists import ProjectFeatureFlagUserListManager  # noqa: F401
+from .feature_flags import ProjectFeatureFlagManager  # noqa: F401
 from .files import ProjectFileManager  # noqa: F401
 from .hooks import ProjectHookManager  # noqa: F401
 from .integrations import ProjectIntegrationManager, ProjectServiceManager  # noqa: F401
@@ -201,6 +203,8 @@ class Project(
     environments: ProjectEnvironmentManager
     events: ProjectEventManager
     exports: ProjectExportManager
+    feature_flags: ProjectFeatureFlagManager
+    feature_flags_user_lists: ProjectFeatureFlagUserListManager
     files: ProjectFileManager
     forks: ProjectForkManager
     generic_packages: GenericPackageManager

--- a/tests/functional/api/test_project_feature_flag_user_lists.py
+++ b/tests/functional/api/test_project_feature_flag_user_lists.py
@@ -1,0 +1,56 @@
+import pytest
+
+from gitlab import exceptions
+
+
+@pytest.fixture
+def user_list(project, user):
+    user_list = project.feature_flags_user_lists.create(
+        {"name": "test_user_list", "user_xids": str(user.id)}
+    )
+    yield user_list
+    try:
+        user_list.delete()
+    except exceptions.GitlabDeleteError:
+        pass
+
+
+def test_create_user_list(project, user):
+    user_list = project.feature_flags_user_lists.create(
+        {"name": "created_user_list", "user_xids": str(user.id)}
+    )
+    assert user_list.name == "created_user_list"
+    assert str(user.id) in user_list.user_xids
+    user_list.delete()
+
+
+def test_list_user_lists(project, user_list):
+    ff_user_lists = project.feature_flags_user_lists.list()
+    assert len(ff_user_lists) >= 1
+    assert user_list.iid in [ff_user.iid for ff_user in ff_user_lists]
+
+
+def test_get_user_list(project, user_list, user):
+    retrieved_list = project.feature_flags_user_lists.get(user_list.iid)
+    assert retrieved_list.name == user_list.name
+    assert str(user.id) in retrieved_list.user_xids
+
+
+def test_update_user_list(project, user_list):
+    user_list.name = "updated_user_list"
+    user_list.save()
+
+    updated_list = project.feature_flags_user_lists.get(user_list.iid)
+    assert updated_list.name == "updated_user_list"
+
+
+def test_delete_user_list(project, user_list):
+    user_list.delete()
+    with pytest.raises(exceptions.GitlabGetError):
+        project.feature_flags_user_lists.get(user_list.iid)
+
+
+def test_search_user_list(project, user_list):
+    ff_user_lists = project.feature_flags_user_lists.list(search=user_list.name)
+    assert len(ff_user_lists) >= 1
+    assert user_list.iid in [ff_user.iid for ff_user in ff_user_lists]

--- a/tests/functional/api/test_project_feature_flags.py
+++ b/tests/functional/api/test_project_feature_flags.py
@@ -1,0 +1,127 @@
+import pytest
+
+from gitlab import exceptions
+
+
+@pytest.fixture
+def feature_flag(project):
+    flag_name = "test_flag_fixture"
+    flag = project.feature_flags.create(
+        {"name": flag_name, "version": "new_version_flag"}
+    )
+    yield flag
+    try:
+        flag.delete()
+    except exceptions.GitlabDeleteError:
+        pass
+
+
+def test_create_feature_flag(project):
+    flag_name = "test_flag_create"
+    flag = project.feature_flags.create(
+        {"name": flag_name, "version": "new_version_flag"}
+    )
+    assert flag.name == flag_name
+    assert flag.active is True
+    flag.delete()
+
+
+def test_create_feature_flag_with_strategies(project):
+    flag_name = "test_flag_strategies"
+    strategies = [{"name": "userWithId", "parameters": {"userIds": "user1"}}]
+    flag = project.feature_flags.create(
+        {"name": flag_name, "version": "new_version_flag", "strategies": strategies}
+    )
+    assert len(flag.strategies) == 1
+    assert flag.strategies[0]["name"] == "userWithId"
+    assert flag.strategies[0]["parameters"]["userIds"] == "user1"
+    flag.delete()
+
+
+def test_list_feature_flags(project, feature_flag):
+    flags = project.feature_flags.list()
+    assert len(flags) >= 1
+    assert feature_flag.name in [f.name for f in flags]
+
+
+def test_update_feature_flag(project, feature_flag):
+    feature_flag.active = False
+    feature_flag.save()
+
+    updated_flag = project.feature_flags.get(feature_flag.name)
+    assert updated_flag.active is False
+
+
+def test_rename_feature_flag(project, feature_flag):
+    # Rename via save()
+    new_name = "renamed_flag"
+    feature_flag.name = new_name
+    feature_flag.save()
+
+    updated_flag = project.feature_flags.get(new_name)
+    assert updated_flag.name == new_name
+
+    # Rename via update()
+    newer_name = "renamed_flag_2"
+    project.feature_flags.update(new_name, {"name": newer_name})
+
+    updated_flag_2 = project.feature_flags.get(newer_name)
+    assert updated_flag_2.name == newer_name
+
+    # Update the fixture object so teardown can delete the correct flag
+    feature_flag.name = newer_name
+
+
+def test_delete_feature_flag(project, feature_flag):
+    feature_flag.delete()
+    with pytest.raises(exceptions.GitlabGetError):
+        project.feature_flags.get(feature_flag.name)
+
+
+def test_delete_feature_flag_strategy(project, feature_flag):
+    strategies = [
+        {"name": "default", "parameters": {}},
+        {"name": "userWithId", "parameters": {"userIds": "user1"}},
+    ]
+    feature_flag.strategies = strategies
+    feature_flag.save()
+
+    updated_feature_flag = project.feature_flags.get(feature_flag.name)
+    assert len(updated_feature_flag.strategies) == 2
+
+    # Remove strategy using _destroy
+    updated_strategies = updated_feature_flag.strategies
+    for strategy in updated_strategies:
+        if strategy["name"] == "userWithId":
+            strategy["_destroy"] = True
+    updated_feature_flag.save()
+
+    updated_feature_flag = project.feature_flags.get(feature_flag.name)
+    assert len(updated_feature_flag.strategies) == 1
+    assert updated_feature_flag.strategies[0]["name"] == "default"
+
+
+def test_delete_feature_flag_scope(project, feature_flag):
+    strategies = [
+        {
+            "name": "default",
+            "parameters": {},
+            "scopes": [{"environment_scope": "*"}, {"environment_scope": "production"}],
+        }
+    ]
+    feature_flag.strategies = strategies
+    feature_flag.save()
+
+    updated_feature_flag = project.feature_flags.get(feature_flag.name)
+    assert len(updated_feature_flag.strategies[0]["scopes"]) == 2
+
+    # Remove scope using _destroy
+    updated_strategies = updated_feature_flag.strategies
+    for scope in updated_strategies[0]["scopes"]:
+        if scope["environment_scope"] == "production":
+            scope["_destroy"] = True
+    updated_feature_flag.save()
+
+    updated_feature_flag = project.feature_flags.get(feature_flag.name)
+    assert len(updated_feature_flag.strategies[0]["scopes"]) == 1
+    assert updated_feature_flag.strategies[0]["scopes"][0]["environment_scope"] == "*"

--- a/tests/functional/cli/test_cli_project_feature_flag_user_lists.py
+++ b/tests/functional/cli/test_cli_project_feature_flag_user_lists.py
@@ -1,0 +1,120 @@
+import json
+
+import pytest
+
+
+@pytest.fixture
+def user_list_cli(gitlab_cli, project, user):
+    list_name = "cli_test_list_fixture"
+    cmd = [
+        "-o",
+        "json",
+        "project-feature-flag-user-list",
+        "create",
+        "--project-id",
+        str(project.id),
+        "--name",
+        list_name,
+        "--user-xids",
+        str(user.id),
+    ]
+    ret = gitlab_cli(cmd)
+    data = json.loads(ret.stdout)
+    iid = str(data["iid"])
+
+    yield iid
+
+    try:
+        cmd = [
+            "project-feature-flag-user-list",
+            "delete",
+            "--project-id",
+            str(project.id),
+            "--iid",
+            iid,
+        ]
+        gitlab_cli(cmd)
+    except Exception:
+        pass
+
+
+def test_project_feature_flag_user_list_cli_create_delete(gitlab_cli, project, user):
+    list_name = "cli_test_list_create"
+
+    cmd = [
+        "-o",
+        "json",
+        "project-feature-flag-user-list",
+        "create",
+        "--project-id",
+        str(project.id),
+        "--name",
+        list_name,
+        "--user-xids",
+        str(user.id),
+    ]
+    ret = gitlab_cli(cmd)
+    assert ret.success
+    data = json.loads(ret.stdout)
+    assert data["name"] == list_name
+    assert str(user.id) in data["user_xids"]
+    iid = str(data["iid"])
+
+    cmd = [
+        "project-feature-flag-user-list",
+        "delete",
+        "--project-id",
+        str(project.id),
+        "--iid",
+        iid,
+    ]
+    ret = gitlab_cli(cmd)
+    assert ret.success
+
+
+def test_project_feature_flag_user_list_cli_list(gitlab_cli, project, user_list_cli):
+    cmd = [
+        "-o",
+        "json",
+        "project-feature-flag-user-list",
+        "list",
+        "--project-id",
+        str(project.id),
+    ]
+    ret = gitlab_cli(cmd)
+    assert ret.success
+    data = json.loads(ret.stdout)
+    assert any(item["name"] == "cli_test_list_fixture" for item in data)
+
+
+def test_project_feature_flag_user_list_cli_get(gitlab_cli, project, user_list_cli):
+    cmd = [
+        "-o",
+        "json",
+        "project-feature-flag-user-list",
+        "get",
+        "--project-id",
+        str(project.id),
+        "--iid",
+        user_list_cli,
+    ]
+    ret = gitlab_cli(cmd)
+    assert ret.success
+    data = json.loads(ret.stdout)
+    assert data["name"] == "cli_test_list_fixture"
+
+
+def test_project_feature_flag_user_list_cli_update(gitlab_cli, project, user_list_cli):
+    new_name = "cli_updated_list"
+    cmd = [
+        "project-feature-flag-user-list",
+        "update",
+        "--project-id",
+        str(project.id),
+        "--iid",
+        user_list_cli,
+        "--name",
+        new_name,
+    ]
+    ret = gitlab_cli(cmd)
+    assert ret.success

--- a/tests/functional/cli/test_cli_project_feature_flags.py
+++ b/tests/functional/cli/test_cli_project_feature_flags.py
@@ -1,0 +1,203 @@
+import json
+
+import pytest
+
+
+@pytest.fixture
+def feature_flag_cli(gitlab_cli, project):
+    flag_name = "test_flag_cli_fixture"
+    cmd = [
+        "project-feature-flag",
+        "create",
+        "--project-id",
+        str(project.id),
+        "--name",
+        flag_name,
+    ]
+    gitlab_cli(cmd)
+    yield flag_name
+    try:
+        cmd = [
+            "project-feature-flag",
+            "delete",
+            "--project-id",
+            str(project.id),
+            "--name",
+            flag_name,
+        ]
+        gitlab_cli(cmd)
+    except Exception:
+        pass
+
+
+def test_project_feature_flag_cli_create_delete(gitlab_cli, project):
+    flag_name = "test_flag_cli_create"
+    cmd = [
+        "project-feature-flag",
+        "create",
+        "--project-id",
+        str(project.id),
+        "--name",
+        flag_name,
+    ]
+    ret = gitlab_cli(cmd)
+    assert ret.success
+    assert flag_name in ret.stdout
+
+    cmd = [
+        "project-feature-flag",
+        "delete",
+        "--project-id",
+        str(project.id),
+        "--name",
+        flag_name,
+    ]
+    ret = gitlab_cli(cmd)
+    assert ret.success
+
+
+def test_project_feature_flag_cli_create_with_strategies(gitlab_cli, project):
+    flag_name = "test_flag_cli_strategies"
+    strategies_json = (
+        '[{"name": "userWithId", "parameters": {"userIds": "user1,user2"}}]'
+    )
+
+    cmd = [
+        "project-feature-flag",
+        "create",
+        "--project-id",
+        str(project.id),
+        "--name",
+        flag_name,
+        "--strategies",
+        strategies_json,
+    ]
+    ret = gitlab_cli(cmd)
+    assert ret.success
+
+    cmd = [
+        "-o",
+        "json",
+        "project-feature-flag",
+        "get",
+        "--project-id",
+        str(project.id),
+        "--name",
+        flag_name,
+    ]
+    ret = gitlab_cli(cmd)
+    assert ret.success
+    data = json.loads(ret.stdout)
+    assert len(data["strategies"]) == 1
+    assert data["strategies"][0]["name"] == "userWithId"
+
+
+def test_project_feature_flag_cli_list(gitlab_cli, project, feature_flag_cli):
+    cmd = ["project-feature-flag", "list", "--project-id", str(project.id)]
+    ret = gitlab_cli(cmd)
+    assert ret.success
+    assert feature_flag_cli in ret.stdout
+
+
+def test_project_feature_flag_cli_get(gitlab_cli, project, feature_flag_cli):
+    cmd = [
+        "project-feature-flag",
+        "get",
+        "--project-id",
+        str(project.id),
+        "--name",
+        feature_flag_cli,
+    ]
+    ret = gitlab_cli(cmd)
+    assert ret.success
+    assert feature_flag_cli in ret.stdout
+
+
+def test_project_feature_flag_cli_update(gitlab_cli, project, feature_flag_cli):
+    cmd = [
+        "project-feature-flag",
+        "update",
+        "--project-id",
+        str(project.id),
+        "--name",
+        feature_flag_cli,
+        "--active",
+        "false",
+    ]
+    ret = gitlab_cli(cmd)
+    assert ret.success
+
+    cmd = [
+        "-o",
+        "json",
+        "project-feature-flag",
+        "get",
+        "--project-id",
+        str(project.id),
+        "--name",
+        feature_flag_cli,
+    ]
+    ret = gitlab_cli(cmd)
+    assert ret.success
+    data = json.loads(ret.stdout)
+    assert data["active"] is False
+
+
+def test_project_feature_flag_cli_create_with_malformed_strategies(gitlab_cli, project):
+    flag_name = "test_flag_cli_malformed_strategies"
+    strategies_json = '[{"name": "userWithId"'  # Malformed JSON
+
+    cmd = [
+        "project-feature-flag",
+        "create",
+        "--project-id",
+        str(project.id),
+        "--name",
+        flag_name,
+        "--strategies",
+        strategies_json,
+    ]
+    ret = gitlab_cli(cmd)
+    assert not ret.success
+    assert "Could not parse JSON data" in ret.stderr
+
+
+def test_project_feature_flag_cli_rename(gitlab_cli, project, feature_flag_cli):
+    new_name = "cli_renamed_flag"
+    cmd = [
+        "project-feature-flag",
+        "update",
+        "--project-id",
+        str(project.id),
+        "--name",
+        feature_flag_cli,
+        "--new-name",
+        new_name,
+    ]
+    ret = gitlab_cli(cmd)
+    assert ret.success
+
+    cmd = [
+        "-o",
+        "json",
+        "project-feature-flag",
+        "get",
+        "--project-id",
+        str(project.id),
+        "--name",
+        new_name,
+    ]
+    ret = gitlab_cli(cmd)
+    assert ret.success
+    data = json.loads(ret.stdout)
+    assert data["name"] == new_name
+    # Cleanup renamed flag
+    cmd = [
+        "project-feature-flag",
+        "delete",
+        "--project-id",
+        str(project.id),
+        "--name",
+        new_name,
+    ]
+    gitlab_cli(cmd)

--- a/tests/unit/objects/test_project_feature_flag_user_lists.py
+++ b/tests/unit/objects/test_project_feature_flag_user_lists.py
@@ -1,0 +1,30 @@
+"""
+Unit tests for Project Feature Flag User Lists.
+"""
+
+import responses
+
+
+def test_create_user_list_with_list_conversion(project):
+    """
+    Verify that passing a list of integers for user_xids is converted
+    to a comma-separated string in the API payload.
+    """
+    with responses.RequestsMock() as rs:
+        rs.add(
+            responses.POST,
+            "http://localhost/api/v4/projects/1/feature_flags_user_lists",
+            json={"iid": 1, "name": "list", "user_xids": "1,2,3"},
+            status=201,
+            match=[
+                responses.matchers.json_params_matcher(
+                    {"name": "list", "user_xids": "1,2,3"}
+                )
+            ],
+        )
+
+        project.feature_flags_user_lists.create(
+            {"name": "list", "user_xids": [1, 2, 3]}
+        )
+
+        assert len(rs.calls) == 1

--- a/tests/unit/objects/test_project_feature_flags.py
+++ b/tests/unit/objects/test_project_feature_flags.py
@@ -1,0 +1,35 @@
+"""
+Unit tests for Project Feature Flags.
+"""
+
+import responses
+
+from gitlab.v4.objects import ProjectFeatureFlag
+
+
+def test_feature_flag_rename(project):
+    """
+    Verify that renaming a feature flag uses the old name in the URL
+    and the new name in the payload.
+    """
+    flag_content = {"name": "old_name", "version": "new_version_flag", "active": True}
+    flag = ProjectFeatureFlag(project.feature_flags, flag_content)
+
+    # Rename locally
+    flag.name = "new_name"
+
+    with responses.RequestsMock() as rs:
+        rs.add(
+            responses.PUT,
+            "http://localhost/api/v4/projects/1/feature_flags/old_name",
+            json={"name": "new_name", "version": "new_version_flag", "active": True},
+            status=200,
+            match=[responses.matchers.json_params_matcher({"name": "new_name"})],
+        )
+
+        flag.save()
+
+        assert len(rs.calls) == 1
+        # URL should use the old name (ID)
+        assert rs.calls[0].request.url.endswith("/feature_flags/old_name")
+        assert flag.name == "new_name"

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1,6 +1,6 @@
 import pytest
 
-from gitlab import types
+from gitlab import exceptions, types
 
 
 class TestRequiredOptional:
@@ -122,3 +122,40 @@ def test_csv_string_attribute_get_for_api_from_int_list():
 def test_lowercase_string_attribute_get_for_api():
     o = types.LowercaseStringAttribute("FOO")
     assert o.get_for_api(key="spam") == ("spam", "foo")
+
+
+# JsonAttribute tests
+def test_json_attribute() -> None:
+    attr = types.JsonAttribute()
+
+    attr.set_from_cli('{"key": "value"}')
+    assert attr.get() == {"key": "value"}
+
+    with pytest.raises(exceptions.GitlabParsingError):
+        attr.set_from_cli("  ")
+
+
+# CommaSeparatedStringAttribute tests
+def test_comma_separated_string_attribute() -> None:
+    # Test with list of integers
+    attr = types.CommaSeparatedStringAttribute([1, 2, 3])
+    assert attr.get_for_api(key="ids") == ("ids", "1,2,3")
+
+    # Test with list of strings
+    attr = types.CommaSeparatedStringAttribute(["a", "b"])
+    assert attr.get_for_api(key="names") == ("names", "a,b")
+
+    # Test with string value (should be preserved)
+    attr = types.CommaSeparatedStringAttribute("1,2,3")
+    assert attr.get_for_api(key="ids") == ("ids", "1,2,3")
+
+    # Test CLI setting
+    attr = types.CommaSeparatedStringAttribute()
+    attr.set_from_cli("1, 2, 3")
+    assert attr.get() == ["1", "2", "3"]
+
+    attr.set_from_cli("")
+    assert attr.get() == []
+
+    # Verify transform_in_body is True
+    assert types.CommaSeparatedStringAttribute.transform_in_body is True


### PR DESCRIPTION
<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

This change introduces support for managing Project Feature Flags and Feature Flag User Lists via the API and CLI.

It adds the `ProjectFeatureFlag` and `ProjectFeatureFlagUserList` objects and their corresponding managers, which are exposed on the `Project` object as `project.feature_flags` and `project.feature_flags_user_lists`.

To support the specific data formats required by these GitLab APIs, this change also introduces:

- `JsonAttribute`: A new attribute type to handle the strategies field, which is sent as a JSON object.
- `CommaSeparatedStringAttribute`: A new attribute type to handle the user_xids field, which is sent as a comma-separated string.

Additionally, a custom `save()` method has been implemented for `ProjectFeatureFlag` to correctly handle renaming, as the flag's name is also its unique identifier.

The implementation includes:

- API object and manager definitions.
- Functional API tests.
- Functional CLI tests.
- Unit tests for the new attribute types and the custom renaming logic.

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->

**Documentation updates**:

- Added new documentation pages for Project Feature Flags and Feature Flag User Lists.
- Renamed the existing `features.rst` to `gitlab_features.rst` and updated its content to clearly distinguish that this API/feature is for admin-only GitLab Development Feature Flags - not for project-level feature flags.

## References:

Support for following API is being included in this PR
- GitLab Project Feature Flag API: https://docs.gitlab.com/api/feature_flags/
- GitLab Project Feature Flag User List API: https://docs.gitlab.com/api/feature_flag_user_lists/

Documentation changed/clarified related to following existing feature in python-gitlab
- API on Feature flag for GitLab Development: https://docs.gitlab.com/api/features/

closes #3350 