### PR TITLE
Update and fix variable _create_attrs and _update_attrs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ docs/_build
 .tox
 .venv/
 venv/
+.mypy_cache/
 
 # Include tracked hidden files and directories in search and diff tools
 !.dockerignore

--- a/gitlab/v4/objects/variables.py
+++ b/gitlab/v4/objects/variables.py
@@ -27,10 +27,11 @@ class VariableManager(CRUDMixin[Variable]):
     _path = "/admin/ci/variables"
     _obj_cls = Variable
     _create_attrs = RequiredOptional(
-        required=("key", "value"), optional=("protected", "variable_type", "masked")
+        required=("key", "value"),
+        optional=("protected", "variable_type", "masked", "masked_and_hidden"),
     )
     _update_attrs = RequiredOptional(
-        required=("key", "value"), optional=("protected", "variable_type", "masked")
+        required=("key",), optional=("value", "protected", "variable_type", "masked")
     )
 
 
@@ -43,10 +44,11 @@ class GroupVariableManager(CRUDMixin[GroupVariable]):
     _obj_cls = GroupVariable
     _from_parent_attrs = {"group_id": "id"}
     _create_attrs = RequiredOptional(
-        required=("key", "value"), optional=("protected", "variable_type", "masked")
+        required=("key", "value"),
+        optional=("protected", "variable_type", "masked", "masked_and_hidden"),
     )
     _update_attrs = RequiredOptional(
-        required=("key", "value"), optional=("protected", "variable_type", "masked")
+        required=("key",), optional=("value", "protected", "variable_type", "masked")
     )
 
 
@@ -60,9 +62,15 @@ class ProjectVariableManager(CRUDMixin[ProjectVariable]):
     _from_parent_attrs = {"project_id": "id"}
     _create_attrs = RequiredOptional(
         required=("key", "value"),
-        optional=("protected", "variable_type", "masked", "environment_scope"),
+        optional=(
+            "protected",
+            "variable_type",
+            "masked",
+            "environment_scope",
+            "masked_and_hidden",
+        ),
     )
     _update_attrs = RequiredOptional(
-        required=("key", "value"),
-        optional=("protected", "variable_type", "masked", "environment_scope"),
+        required=("key",),
+        optional=("value", "protected", "variable_type", "masked", "environment_scope"),
     )

--- a/gitlab/v4/objects/variables.py
+++ b/gitlab/v4/objects/variables.py
@@ -27,8 +27,7 @@ class VariableManager(CRUDMixin[Variable]):
     _path = "/admin/ci/variables"
     _obj_cls = Variable
     _create_attrs = RequiredOptional(
-        required=("key", "value"),
-        optional=("protected", "variable_type", "masked", "masked_and_hidden"),
+        required=("key", "value"), optional=("protected", "variable_type", "masked")
     )
     _update_attrs = RequiredOptional(
         required=("key",), optional=("value", "protected", "variable_type", "masked")

--- a/gitlab/v4/objects/variables.py
+++ b/gitlab/v4/objects/variables.py
@@ -27,10 +27,19 @@ class VariableManager(CRUDMixin[Variable]):
     _path = "/admin/ci/variables"
     _obj_cls = Variable
     _create_attrs = RequiredOptional(
-        required=("key", "value"), optional=("protected", "variable_type", "masked")
+        required=("key", "value"),
+        optional=("description", "masked", "protected", "raw", "variable_type"),
     )
     _update_attrs = RequiredOptional(
-        required=("key",), optional=("value", "protected", "variable_type", "masked")
+        required=("key",),
+        optional=(
+            "description",
+            "masked",
+            "protected",
+            "raw",
+            "value",
+            "variable_type",
+        ),
     )
 
 
@@ -44,10 +53,27 @@ class GroupVariableManager(CRUDMixin[GroupVariable]):
     _from_parent_attrs = {"group_id": "id"}
     _create_attrs = RequiredOptional(
         required=("key", "value"),
-        optional=("protected", "variable_type", "masked", "masked_and_hidden"),
+        optional=(
+            "description",
+            "environment_scope",
+            "masked",
+            "masked_and_hidden",
+            "protected",
+            "raw",
+            "variable_type",
+        ),
     )
     _update_attrs = RequiredOptional(
-        required=("key",), optional=("value", "protected", "variable_type", "masked")
+        required=("key",),
+        optional=(
+            "description",
+            "environment_scope",
+            "masked",
+            "protected",
+            "raw",
+            "value",
+            "variable_type",
+        ),
     )
 
 
@@ -62,14 +88,24 @@ class ProjectVariableManager(CRUDMixin[ProjectVariable]):
     _create_attrs = RequiredOptional(
         required=("key", "value"),
         optional=(
-            "protected",
-            "variable_type",
-            "masked",
+            "description",
             "environment_scope",
+            "masked",
             "masked_and_hidden",
+            "protected",
+            "raw",
+            "variable_type",
         ),
     )
     _update_attrs = RequiredOptional(
         required=("key",),
-        optional=("value", "protected", "variable_type", "masked", "environment_scope"),
+        optional=(
+            "description",
+            "environment_scope",
+            "masked",
+            "protected",
+            "raw",
+            "value",
+            "variable_type",
+        ),
     )

--- a/tests/functional/api/test_variables.py
+++ b/tests/functional/api/test_variables.py
@@ -43,3 +43,51 @@ def test_project_variables(project):
     assert variable.value == "new_value1"
 
     variable.delete()
+
+
+def test_hidden_instance_variables(gl):
+    variable = gl.variables.create(
+        {"key": "key1", "value": "secret_value", "masked_and_hidden": True}
+    )
+    assert variable.value == "secret_value"
+    assert variable.description is None
+    assert variable in gl.variables.list()
+
+    variable.description = "new_description"
+    variable.save()
+    variable = gl.variables.get(variable.key)
+    assert variable.description == "new_description"
+
+    variable.delete()
+
+
+def test_hidden_group_variables(group):
+    variable = group.variables.create(
+        {"key": "key1", "value": "secret_value", "masked_and_hidden": True}
+    )
+    assert variable.value is None
+    assert variable.description is None
+    assert variable in group.variables.list()
+
+    variable.description = "new_description"
+    variable.save()
+    variable = group.variables.get(variable.key)
+    assert variable.description == "new_description"
+
+    variable.delete()
+
+
+def test_hidden_project_variables(project):
+    variable = project.variables.create(
+        {"key": "key1", "value": "secret_value", "masked_and_hidden": True}
+    )
+    assert variable.value is None
+    assert variable.description is None
+    assert variable in project.variables.list()
+
+    variable.description = "new_description"
+    variable.save()
+    variable = project.variables.get(variable.key)
+    assert variable.description == "new_description"
+
+    variable.delete()

--- a/tests/functional/api/test_variables.py
+++ b/tests/functional/api/test_variables.py
@@ -45,26 +45,12 @@ def test_project_variables(project):
     variable.delete()
 
 
-def test_hidden_instance_variables(gl):
-    variable = gl.variables.create(
-        {"key": "key1", "value": "secret_value", "masked_and_hidden": True}
-    )
-    assert variable.value == "secret_value"
-    assert variable.description is None
-    assert variable in gl.variables.list()
-
-    variable.description = "new_description"
-    variable.save()
-    variable = gl.variables.get(variable.key)
-    assert variable.description == "new_description"
-
-    variable.delete()
-
-
 def test_hidden_group_variables(group):
     variable = group.variables.create(
         {"key": "key1", "value": "secret_value", "masked_and_hidden": True}
     )
+
+    variable = group.variables.get(variable.key)
     assert variable.value is None
     assert variable.description is None
     assert variable in group.variables.list()
@@ -81,6 +67,8 @@ def test_hidden_project_variables(project):
     variable = project.variables.create(
         {"key": "key1", "value": "secret_value", "masked_and_hidden": True}
     )
+
+    variable = project.variables.get(variable.key)
     assert variable.value is None
     assert variable.description is None
     assert variable in project.variables.list()


### PR DESCRIPTION
## Changes

1. make `value` an optional attribute for variable updates

    When updating a CI/CD variable that has been marked "Masked and hidden", you likely do not have the value when updating. In this case, the value is `None` which the api rejects (`400: {'value': ['is invalid']}`).

2. add `masked_and_hidden` the the list of optional attributes for creating variables

    When creating variables which you want to be hidden, you have to use the `masked_and_hidden` property.

    I don't think this was causing problems but for the sake completion and documentation I think it makes sense to include.

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [x] ~~Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)~~
- [x] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
