### PR TITLE
fix(repositories): narrow return type of repository_merge_base to dict[str, Any]

### DIFF
--- a/gitlab/v4/objects/repositories.py
+++ b/gitlab/v4/objects/repositories.py
@@ -329,9 +329,7 @@ class RepositoryMixin(_RestObjectBase):
 
     @cli.register_custom_action(cls_names="Project", required=("refs",))
     @exc.on_http_error(exc.GitlabGetError)
-    def repository_merge_base(
-        self, refs: list[str], **kwargs: Any
-    ) -> dict[str, Any] | requests.Response:
+    def repository_merge_base(self, refs: list[str], **kwargs: Any) -> dict[str, Any]:
         """Return a diff between two branches/commits.
 
         Args:
@@ -351,7 +349,10 @@ class RepositoryMixin(_RestObjectBase):
             custom_types={"refs": types.ArrayAttribute},
             transform_data=True,
         )
-        return self.manager.gitlab.http_get(path, query_data=query_data, **kwargs)
+        result = self.manager.gitlab.http_get(path, query_data=query_data, **kwargs)
+        if TYPE_CHECKING:
+            assert isinstance(result, dict)
+        return result
 
     @cli.register_custom_action(cls_names="Project")
     @exc.on_http_error(exc.GitlabDeleteError)

--- a/gitlab/v4/objects/repositories.py
+++ b/gitlab/v4/objects/repositories.py
@@ -330,7 +330,7 @@ class RepositoryMixin(_RestObjectBase):
     @cli.register_custom_action(cls_names="Project", required=("refs",))
     @exc.on_http_error(exc.GitlabGetError)
     def repository_merge_base(self, refs: list[str], **kwargs: Any) -> dict[str, Any]:
-        """Return a diff between two branches/commits.
+        """Return the common ancestor commit for the given refs.
 
         Args:
             refs: The refs to find the common ancestor of. Multiple refs can be passed.


### PR DESCRIPTION
Fixes #3390.

The `RepositoryMixin.repository_merge_base` method was annotated to return
`dict[str, Any] | requests.Response`, but the call to `http_get` does not pass
`streamed=True` or `raw=True`, and the GitLab `/repository/merge_base` endpoint
always responds with `application/json`. Per `Gitlab.http_get`'s implementation
(gitlab/client.py), this means the result is always a parsed `dict` at runtime,
and the `requests.Response` branch is unreachable.

This change:
- narrows the return annotation to `dict[str, Any]`
- adds a `TYPE_CHECKING`-guarded `assert isinstance(result, dict)` to inform
  the type-checker, matching the existing pattern used in `repository_raw_blob`
  and `repository_archive`

No runtime behavior changes. Downstream users no longer need to add
`cast()` or `assert isinstance(...)` calls before indexing the result.