### PR TITLE
fix(tests): update pformat/pprint assertions for Py3.15

### DIFF
--- a/tests/unit/base/test_rest_object.py
+++ b/tests/unit/base/test_rest_object.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pickle
+import sys
 
 import pytest
 
@@ -222,11 +223,21 @@ def test_pformat(fake_manager):
     fake_object = helpers.FakeObject(
         fake_manager, {"attr1": "foo" * 10, "ham": "eggs" * 15}
     )
-    assert fake_object.pformat() == (
-        "<class 'tests.unit.helpers.FakeObject'> => "
-        "\n{'attr1': 'foofoofoofoofoofoofoofoofoofoo',\n"
-        " 'ham': 'eggseggseggseggseggseggseggseggseggseggseggseggseggseggseggs'}"
-    )
+    if sys.version_info >= (3, 15):
+        expected = (
+            "<class 'tests.unit.helpers.FakeObject'> => "
+            "\n{\n"
+            "    'attr1': 'foofoofoofoofoofoofoofoofoofoo',\n"
+            "    'ham': 'eggseggseggseggseggseggseggseggseggseggseggseggseggseggseggs',\n"
+            "}"
+        )
+    else:
+        expected = (
+            "<class 'tests.unit.helpers.FakeObject'> => "
+            "\n{'attr1': 'foofoofoofoofoofoofoofoofoofoo',\n"
+            " 'ham': 'eggseggseggseggseggseggseggseggseggseggseggseggseggseggseggs'}"
+        )
+    assert fake_object.pformat() == expected
 
 
 def test_pprint(capfd, fake_manager):
@@ -236,11 +247,21 @@ def test_pprint(capfd, fake_manager):
     result = fake_object.pprint()
     assert result is None
     stdout, stderr = capfd.readouterr()
-    assert stdout == (
-        "<class 'tests.unit.helpers.FakeObject'> => "
-        "\n{'attr1': 'foofoofoofoofoofoofoofoofoofoo',\n"
-        " 'ham': 'eggseggseggseggseggseggseggseggseggseggseggseggseggseggseggs'}\n"
-    )
+    if sys.version_info >= (3, 15):
+        expected = (
+            "<class 'tests.unit.helpers.FakeObject'> => "
+            "\n{\n"
+            "    'attr1': 'foofoofoofoofoofoofoofoofoofoo',\n"
+            "    'ham': 'eggseggseggseggseggseggseggseggseggseggseggseggseggseggseggs',\n"
+            "}\n"
+        )
+    else:
+        expected = (
+            "<class 'tests.unit.helpers.FakeObject'> => "
+            "\n{'attr1': 'foofoofoofoofoofoofoofoofoofoo',\n"
+            " 'ham': 'eggseggseggseggseggseggseggseggseggseggseggseggseggseggseggs'}\n"
+        )
+    assert stdout == expected
     assert stderr == ""
 
 


### PR DESCRIPTION
## Changes

Python 3.15 changed the default behaviour of pprint.PrettyPrinter:
- default indent changed from 1 to 4
- default width changed from 80 to 88
- default compact=False layout now places opening braces/brackets on their own line with contents indented, similar to pretty-printed JSON

See: https://docs.python.org/3.15/library/pprint.html (gh-112632)