### PR TITLE
chore(deps): update dependency argparse to v3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ license = {text = "LGPL-3.0-or-later"}
 dynamic = ["version"]
 
 [project.optional-dependencies]
-autocompletion = ["argcomplete>=1.10.0,<3"]
+autocompletion = ["argcomplete>=1.10.0,<4"]
 yaml = ["PyYaml>=6.0.1"]
 graphql = ["gql[httpx]>=3.5.0,<5"]
 


### PR DESCRIPTION
## Changes

Allow argcomplete v3 to be used.

### Documentation and testing

I checked with latest `argcomplete == 3.7.0` and certainly the completion in bash is working with a quick check.
