### PR TITLE
fix(client): retry fetching server version after an unknown result

### DIFF
--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -404,7 +404,7 @@ class Gitlab:
             The server version and server revision.
                 ('unknown', 'unknown') if the server doesn't perform as expected.
         """
-        if self._server_version is None:
+        if self._server_version in (None, "unknown"):
             try:
                 data = self.http_get("/version")
                 if isinstance(data, dict):


### PR DESCRIPTION
<!-- Please make sure your commit messages follow Conventional Commits
(https://www.conventionalcommits.org) with a commit type (e.g. feat, fix, refactor, chore):

Bad:        Added support for release links
Good:     feat(api): add support for release links

Bad:        Update documentation for projects
Good:     docs(projects): update example for saving project attributes-->

## Changes

Fixes `Gitlab.version()` caching a failed lookup permanently. Previously, once a call to `/version` failed and `_server_version`/`_server_revision` were set to `"unknown"`, every subsequent call to `version()` would short-circuit on the `self._server_version is None` check and keep returning `("unknown","unknown")` forever - even if the GitLab server became reachable again.

`version()` now also retries the `/version` request when the cached value is `"unknown"`, not just when it's `None`.

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

<!--
Note: In some cases, basic functional tests may be easier to add, as they do not require adding mocked GitLab responses.
-->
