### PR TITLE
ci: run the pre-commit rst checks in the CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,3 +41,5 @@ jobs:
         run: tox -e isort -- --check
       - name: Run pylint Python code static checker (https://github.com/PyCQA/pylint)
         run: tox -e pylint
+      - name: Run pre-commit rst checks (https://pre-commit.com/)
+        run: tox -e pre-commit-rst

--- a/docs/api-usage-advanced.rst
+++ b/docs/api-usage-advanced.rst
@@ -147,7 +147,7 @@ python-gitlab can automatically retry in such case, when
 ``retry_transient_errors`` argument is set to ``True``.  When enabled,
 HTTP error codes 500 (Internal Server Error), 502 (502 Bad Gateway),
 503 (Service Unavailable), 504 (Gateway Timeout), and Cloudflare
-errors (520-530) are retried. `requests.exceptions.Timeout` are also
+errors (520-530) are retried. ``requests.exceptions.Timeout`` are also
 handled.
 
 Additionally, HTTP error code 409 (Conflict) is retried if the reason

--- a/tox.ini
+++ b/tox.ini
@@ -146,8 +146,16 @@ commands = pytest tests/smoke {posargs}
 
 [testenv:pre-commit]
 skip_install = true
-deps = -r requirements-precommit.txt
+deps = -r {toxinidir}/requirements-precommit.txt
 commands = pre-commit run --all-files --show-diff-on-failure
+
+[testenv:pre-commit-rst]
+skip_install = true
+deps = -r {toxinidir}/requirements-precommit.txt
+commands =
+  pre-commit run rst-backticks --all-files --show-diff-on-failure
+  pre-commit run rst-directive-colons --all-files --show-diff-on-failure
+  pre-commit run rst-inline-touching-normal --all-files --show-diff-on-failure
 
 [testenv:install]
 skip_install = true


### PR DESCRIPTION
These were only being run when a modification happened to pre-commit

Also correct an issue with missing backticks in the docs.