### PR TITLE
feat(users): allow updating only a user's email, username or name

### DIFF
--- a/gitlab/v4/objects/users.py
+++ b/gitlab/v4/objects/users.py
@@ -453,8 +453,10 @@ class UserManager(CRUDMixin[User]):
         )
     )
     _update_attrs = RequiredOptional(
-        required=("email", "username", "name"),
         optional=(
+            "email",
+            "username",
+            "name",
             "password",
             "skype",
             "linkedin",
@@ -475,7 +477,7 @@ class UserManager(CRUDMixin[User]):
             "private_profile",
             "color_scheme_id",
             "theme_id",
-        ),
+        )
     )
     _types = {"confirm": types.LowercaseStringAttribute, "avatar": types.ImageAttribute}
 


### PR DESCRIPTION
## Changes

From  #3368

- Allow updating only a user's email, username or name : 

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

- Documentation automatically generated
- No test added as most other settings are not implemented in tests/functional/cli/test_cli_v4.py