### PR TITLE
fix(api): allow individual project merge request discussion notes to be resolved

### DIFF
--- a/docs/gl_objects/discussions.rst
+++ b/docs/gl_objects/discussions.rst
@@ -75,6 +75,12 @@ You can get and update a single note using the ``*DiscussionNote`` resources::
     last_note.body = 'Updated comment'
     last_note.save()
 
+Resolve / unresolve a note::
+
+    last_note = discussion.notes.get(note_id)
+    last_note.resolved = True  # True to resolve, False to unresolve
+    last_note.save()
+
 Create a new discussion::
 
     discussion = resource.discussions.create({'body': 'First comment of discussion'})

--- a/gitlab/v4/objects/notes.py
+++ b/gitlab/v4/objects/notes.py
@@ -172,7 +172,7 @@ class ProjectMergeRequestDiscussionNoteManager(
         "discussion_id": "id",
     }
     _create_attrs = RequiredOptional(required=("body",), optional=("created_at",))
-    _update_attrs = RequiredOptional(required=("body",))
+    _update_attrs = RequiredOptional(exclusive=("body", "resolved"))
 
 
 class ProjectSnippetNote(SaveMixin, ObjectDeleteMixin, RESTObject):

--- a/tests/functional/api/test_merge_requests.py
+++ b/tests/functional/api/test_merge_requests.py
@@ -69,6 +69,13 @@ def test_merge_request_discussion(project):
     discussion = mr.discussions.get(discussion.id)
     assert discussion.attributes["notes"][-1]["body"] == "updated body"
 
+    note_from_get = discussion.notes.get(note.id)
+    note_from_get.resolved = True
+    note_from_get.save()
+
+    discussion = mr.discussions.get(discussion.id)
+    assert discussion.attributes["notes"][-1]["resolved"] is True
+
     note_from_get.delete()
 
 


### PR DESCRIPTION
## Changes

Currently, the `body` attribute is marked as `required` for updates in the `ProjectMergeRequestDiscussionNoteManager`, which causes it to be sent with every PUT request on `.save()`. However, [the GitLab API will return a 400 error](https://docs.gitlab.com/api/discussions/#modify-an-existing-merge-request-thread-note:~:text=note%20or%20reply.-,Exactly%20one%20of%20body%20or%20resolved%20must%20be%20set.,-resolved) if both `body` and `resolved` are sent in a PUT request. This makes it effectively impossible to set `resolved` to `True` for an individual merge request discussion note, since `body` will always be sent alongside `resolved`, leading to this 400 error.

This change adds `resolved` to `_update_attrs` and makes it `exclusive` with `body`, so that only one may be sent in the PUT request.

### Documentation and testing

This change updates the `test_merge_request_discussion` functional test to also test that `resolved` can be set to `True` for a project merge request discussion note. I ran the test against the existing code to verify that it failed as expected, and ran it again after implementing the fix to verify that it now passes.

I have also added an example to `docs/gl_objects/discussions.rst` that demonstrates resolving a single merge request discussion note (as opposed to the existing example, which only demonstrates resolving an entire merge request discussion thread, not a single note).