### PR TITLE
feat(hooks): support custom webhook template on project hooks

### DIFF
--- a/gitlab/v4/objects/hooks.py
+++ b/gitlab/v4/objects/hooks.py
@@ -60,6 +60,7 @@ class ProjectHookManager(CRUDMixin[ProjectHook]):
             "wiki_page_events",
             "enable_ssl_verification",
             "token",
+            "custom_webhook_template",
         ),
     )
     _update_attrs = RequiredOptional(
@@ -76,6 +77,7 @@ class ProjectHookManager(CRUDMixin[ProjectHook]):
             "wiki_events",
             "enable_ssl_verification",
             "token",
+            "custom_webhook_template",
         ),
     )
 


### PR DESCRIPTION
## Changes

Adds a optional parameter `custom_webhook_template` to project hooks

### Documentation and testing

Tested this in a local docker container running Gitlab EE 
