### PR TITLE
fix(docker): run container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,8 @@ RUN pip install --no-cache-dir $(find dist -name *.whl) && \
     rm -rf dist/
 
 ENTRYPOINT ["gitlab"]
+
+# Run as a non-root user for container security
+RUN (addgroup -S app 2>/dev/null || groupadd --system app) && (adduser -S -u 1001 -G app app 2>/dev/null || useradd --system --uid 1001 --gid app --create-home app)
+USER 1001
 CMD ["--version"]


### PR DESCRIPTION
## Changes

Add a non-root user (`app`, UID 1001) to the Dockerfile and set `USER 1001`
before the container entrypoint. Running as root in a container is a security
risk — it widens the blast radius if the process is compromised, and many
Kubernetes deployments enforce a non-zero `runAsUser` policy that would
reject a root container at admission.

The `RUN` instruction uses both Alpine-style (`addgroup -S` / `adduser -S`)
and glibc-style (`groupadd --system` / `useradd --system`) forms so the
image continues to build from either `python:3.x-alpine` or
`python:3.x-slim` base images.

### Documentation and testing

- [ ] Documentation in the matching [docs section](https://github.com/python-gitlab/python-gitlab/tree/main/docs)
- [ ] [Unit tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/unit) and/or [functional tests](https://github.com/python-gitlab/python-gitlab/tree/main/tests/functional)

---

> This change was generated by [Autar](https://autar.ai) and reviewed by a
> human before submission.
