### PR TITLE
feat(broadcast_messages): allow using the 'theme' API attribute

### DIFF
--- a/gitlab/v4/objects/broadcast_messages.py
+++ b/gitlab/v4/objects/broadcast_messages.py
@@ -15,7 +15,14 @@ class BroadcastMessageManager(CRUDMixin[BroadcastMessage]):
 
     _create_attrs = RequiredOptional(
         required=("message",),
-        optional=("starts_at", "ends_at", "color", "font", "target_access_levels"),
+        optional=(
+            "starts_at",
+            "ends_at",
+            "color",
+            "font",
+            "theme",
+            "target_access_levels",
+        ),
     )
     _update_attrs = RequiredOptional(
         optional=(
@@ -24,6 +31,7 @@ class BroadcastMessageManager(CRUDMixin[BroadcastMessage]):
             "ends_at",
             "color",
             "font",
+            "theme",
             "target_access_levels",
         )
     )


### PR DESCRIPTION
## Changes

- feat(broadcast_messages): allow using the 'theme' API attribute

### Documentation and testing

- Documentation automatically generated
- No test added as most other settings are not implemented in tests/functional/cli/test_cli_v4.py