### PR TITLE
fix: add retry_transient_errors to merge_config

### DIFF
--- a/gitlab/client.py
+++ b/gitlab/client.py
@@ -352,6 +352,8 @@ class Gitlab:
             pagination=options.get("pagination") or config.pagination,
             order_by=options.get("order_by") or config.order_by,
             user_agent=options.get("user_agent") or config.user_agent,
+            retry_transient_errors=options.get("retry_transient_errors")
+            or config.retry_transient_errors,
         )
 
     @staticmethod


### PR DESCRIPTION
`merge_config()` supports other options that the constructor and `from_config()` factory method do, and was just missing this one.
