### PR TITLE
fix: add cancel API for BulkImport (#3292)

### DIFF
--- a/gitlab/v4/objects/bulk_imports.py
+++ b/gitlab/v4/objects/bulk_imports.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+from typing import Any
+
+import requests
+
+from gitlab import cli
+from gitlab import exceptions as exc
 from gitlab.base import RESTObject
 from gitlab.mixins import CreateMixin, ListMixin, RefreshMixin, RetrieveMixin
 from gitlab.types import RequiredOptional
@@ -16,6 +22,21 @@ __all__ = [
 
 class BulkImport(RefreshMixin, RESTObject):
     entities: BulkImportEntityManager
+
+    @cli.register_custom_action(cls_names="BulkImport")
+    @exc.on_http_error(exc.GitlabCancelError)
+    def cancel(self, **kwargs: Any) -> dict[str, Any] | requests.Response:
+        """Cancel a bulk import.
+
+        Args:
+            **kwargs: Extra options to send to the server (e.g. sudo)
+
+        Raises:
+            GitlabAuthenticationError: If authentication is not correct
+            GitlabCancelError: If the request failed
+        """
+        path = f"{self.manager.path}/{self.encoded_id}/cancel"
+        return self.manager.gitlab.http_post(path, **kwargs)
 
 
 class BulkImportManager(CreateMixin[BulkImport], RetrieveMixin[BulkImport]):


### PR DESCRIPTION
Fixes #3292.

### Problem
API `POST /bulk_imports/:id/cancel` documented at https://docs.gitlab.com/api/bulk_imports/#cancel-a-migration was missing in `BulkImport` model (`gitlab/v4/objects/bulk_imports.py:17`). No way to cancel a migration via python-gitlab.

### Solution
- `gitlab/v4/objects/bulk_imports.py:1-39` — add imports `typing.Any`, `requests`, `gitlab.cli`, `gitlab.exceptions`, and new method:

```python
@cli.register_custom_action(cls_names="BulkImport")
@exc.on_http_error(exc.GitlabCancelError)
def cancel(self, **kwargs: Any) -> dict[str, Any] | requests.Response:
    path = f"{self.manager.path}/{self.encoded_id}/cancel"
    return self.manager.gitlab.http_post(path, **kwargs)
```

Mirrors `ProjectPipeline.cancel` (`gitlab/v4/objects/pipelines.py:67-80`), single file, 15 lines, no cross-folder changes. Uses existing `GitlabCancelError` (no new exception).

### Verification (folder-local only, no global installs)
- Cloned to `C:\Users\Azelf\AppData\Local\Temp\opencode\python-gitlab-fix`, `python -m venv .venv`, `pip install -e .` (folder-local), `pip install responses pytest`
- Existing tests still pass: `pytest tests/unit/objects/test_bulk_imports.py -v` → **6 passed**
- New behavior:
```python
import responses; from gitlab import Gitlab
gl = Gitlab('http://localhost', private_token='test')
with responses.RequestsMock() as rsps:
    rsps.add(GET, "http://localhost/api/v4/bulk_imports/1", json={"id":1}, status=200)
    rsps.add(POST, "http://localhost/api/v4/bulk_imports/1/cancel", json={"id":1,"status":"finished"}, status=200)
    m = gl.bulk_imports.get(1); assert m.cancel()["status"]=="finished"
```
- `BulkImport.cancel` exists, CLI `bulk-import cancel` registered.

Stars: **2472★** (not zero), updated 2026, no duplicate PR (checked `closed_by_pull_requests`).

Closes #3292
